### PR TITLE
test(detect): lock boundary fixture + minimal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Server tests
+        run: pnpm -C apps/server test
+
+      - name: Web build
+        run: pnpm -C apps/web build

--- a/apps/server/src/__tests__/detect.test.ts
+++ b/apps/server/src/__tests__/detect.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { MAX_DETECT_LINES, detectSourceFromText } from "../rulesets/detect.js";
+import { MAX_DETECT_LINES, createAutoDetector, detectSourceFromText } from "../rulesets/detect.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -14,6 +14,7 @@ const cases = [
   { name: "codex.approval.log", expected: "codex" },
   { name: "codex.lifecycle-error.log", expected: "generic" },
   { name: "generic.shell.log", expected: "generic" },
+  { name: "lock-does-not-flip-after-initial-detect.log", expected: "claude" },
   { name: "mixed-claude-codex-strong.log", expected: "generic" },
   { name: "ignore-strong-signal-after-50-lines.log", expected: "generic" }
 ] as const;
@@ -26,6 +27,32 @@ describe("ruleset auto detect", () => {
       expect(detectSourceFromText(content)).toBe(testCase.expected);
     });
   }
+
+  it("keeps the initial decision even if opposite signals appear later", async () => {
+    const filePath = path.join(fixturesDir, "lock-does-not-flip-after-initial-detect.log");
+    const content = await fs.readFile(filePath, "utf8");
+    const lines = content.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const detector = createAutoDetector();
+
+    let firstDecisionLine = -1;
+    let firstDecisionValue: string | null = null;
+
+    for (const [index, line] of lines.entries()) {
+      const decided = detector.update(line);
+      if (decided && firstDecisionValue === null) {
+        firstDecisionValue = decided;
+        firstDecisionLine = index;
+      }
+    }
+
+    if (firstDecisionValue === null) {
+      throw new Error("Expected an initial decision before reaching the end of the fixture.");
+    }
+
+    expect(firstDecisionLine).toBeLessThan(lines.length - 1);
+    expect(firstDecisionValue).toBe("claude");
+    expect(detector.get()).toBe("claude");
+  });
 
   it("exports MAX_DETECT_LINES", () => {
     expect(MAX_DETECT_LINES).toBe(50);

--- a/apps/server/test/fixtures/lock-does-not-flip-after-initial-detect.log
+++ b/apps/server/test/fixtures/lock-does-not-flip-after-initial-detect.log
@@ -1,0 +1,9 @@
+phase1: initial claude signal
+⏺ Read(file.txt)
+phase2: opposite codex signals
+would you like to run the following command?
+you approved the action to run
+apply_patch
+would you like to run the following command?
+you approved the action to run
+apply patch


### PR DESCRIPTION
- Add lock-boundary fixture/test to ensure the initial decision does not flip.\n- CI: Node 20 + pnpm 9 runs server tests and web build on PRs/main.\n- How to verify: pnpm -C apps/server test (optionally pnpm -C apps/web build)