### PR TITLE
feat: gate comment() by LLM_PROVIDER with safe fallback

### DIFF
--- a/apps/server/src/__tests__/commentary.test.ts
+++ b/apps/server/src/__tests__/commentary.test.ts
@@ -3,7 +3,7 @@ import { comment } from "../styles/index.js";
 import type { Event, Style } from "../types.js";
 
 describe("commentary", () => {
-  it("renders styles consistently", () => {
+  it("renders styles consistently", async () => {
     const ev: Event = {
       ts: 1735689600000,
       type: "search",
@@ -12,7 +12,9 @@ describe("commentary", () => {
     };
 
     const styles: Style[] = ["standard", "kansai", "zundamon"];
-    const output = styles.map((style) => ({ style, text: comment(ev, style) }));
+    const output = await Promise.all(
+      styles.map(async (style) => ({ style, text: await comment(ev, style) }))
+    );
 
     expect(output).toMatchSnapshot();
   });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -122,13 +122,16 @@ term.onData((data) => {
   const detected = getAutoDetectedSource();
   if (detected) broadcastSource(detected);
 
-  // raw は “マスク後” を送る（MVP）
+  // raw は "マスク後" を送る（MVP）
   broadcast({ kind: "raw", data: clean });
 
   for (const ev of evs) {
     broadcast({ kind: "event", ev });
     if (ev.type === "error" || shouldEmitNow()) {
-      broadcast({ kind: "commentary", ts: ev.ts, text: comment(ev, currentStyle), ev });
+      // comment() is async - fire and forget, errors are handled inside
+      void comment(ev, currentStyle).then((text) => {
+        broadcast({ kind: "commentary", ts: ev.ts, text, ev });
+      });
     }
   }
 });
@@ -136,8 +139,11 @@ term.onData((data) => {
 term.onExit(({ exitCode }) => {
   const ev: Event = { ts: Date.now(), type: "done", summary: `終了 code=${exitCode}` };
   broadcast({ kind: "event", ev });
-  broadcast({ kind: "commentary", ts: ev.ts, text: comment(ev, currentStyle), ev });
-  setTimeout(() => cleanup(exitCode ?? 0), 100);
+  // comment() is async - wait for it before cleanup
+  void comment(ev, currentStyle).then((text) => {
+    broadcast({ kind: "commentary", ts: ev.ts, text, ev });
+    setTimeout(() => cleanup(exitCode ?? 0), 100);
+  });
 });
 
 server.listen(PORT, () => {

--- a/apps/server/src/styles/index.ts
+++ b/apps/server/src/styles/index.ts
@@ -2,6 +2,20 @@ import type { Event, Style } from "../types.js";
 import { commentStandard } from "./standard.js";
 import { commentKansai } from "./kansai.js";
 import { commentZundamon } from "./zundamon.js";
+import { createLLMAdapter } from "../llm/factory.js";
+import type { LLMAdapter } from "../llm/adapter.js";
+
+const LLM_PROVIDER = (process.env.LLM_PROVIDER ?? "").trim().toLowerCase();
+
+// 起動時に1回だけ作る（未実装providerでも落とさない）
+const llm: LLMAdapter | null = (() => {
+  if (!LLM_PROVIDER) return null;
+  try {
+    return createLLMAdapter();
+  } catch {
+    return null;
+  }
+})();
 
 const GLOSSARY: Array<{ re: RegExp; note: string }> = [
   { re: /\brg\b/, note: "rg= ripgrep（高速grep）" },
@@ -23,7 +37,7 @@ function annotate(detail?: string): string {
   return hits.length ? `（${Array.from(new Set(hits)).join(" / ")}）` : "";
 }
 
-export function comment(ev: Event, style: Style): string {
+function commentByRules(ev: Event, style: Style): string {
   const beginner = "初心者向け1行解説つき。";
   const note = annotate(ev.detail);
 
@@ -33,4 +47,43 @@ export function comment(ev: Event, style: Style): string {
     commentStandard(ev);
 
   return `${core} ${beginner}${note ? " " + note : ""}`;
+}
+
+function buildLLMPrompt(ev: Event, style: Style): string {
+  const styleDesc =
+    style === "kansai" ? "関西弁で" :
+    style === "zundamon" ? "ずんだもん風（〜なのだ）で" :
+    "標準的な日本語で";
+
+  return `あなたはCLI操作の実況者です。${styleDesc}、以下のイベントを1文で実況してください。
+イベント種別: ${ev.type}
+要約: ${ev.summary}${ev.detail ? `\n詳細: ${ev.detail}` : ""}
+
+回答は実況コメント1文のみ（説明不要）:`;
+}
+
+export async function comment(ev: Event, style: Style): Promise<string> {
+  // 1) provider未指定 → 従来ルール実況
+  if (!LLM_PROVIDER) {
+    return commentByRules(ev, style);
+  }
+
+  // 2) provider指定あり → まずLLMを試す（失敗したら従来へ）
+  try {
+    if (!llm) {
+      return commentByRules(ev, style);
+    }
+
+    const prompt = buildLLMPrompt(ev, style);
+    const res = await llm.generateText({
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    if (res.text && res.text.trim()) {
+      return res.text.trim();
+    }
+    return commentByRules(ev, style);
+  } catch {
+    return commentByRules(ev, style);
+  }
 }

--- a/apps/server/src/tests/llm.comment.test.ts
+++ b/apps/server/src/tests/llm.comment.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Event } from "../types.js";
+
+describe("comment() with LLM_PROVIDER=mock", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("includes [mock- prefix when LLM_PROVIDER=mock", async () => {
+    process.env.LLM_PROVIDER = "mock";
+
+    const { comment } = await import("../styles/index.js");
+
+    const ev: Event = {
+      ts: Date.now(),
+      type: "search",
+      summary: "ファイルを検索中",
+      detail: "rg -n pattern"
+    };
+
+    const out = await comment(ev, "standard");
+    expect(out).toContain("[mock-");
+  });
+
+  it("uses rule-based commentary when LLM_PROVIDER is not set", async () => {
+    delete process.env.LLM_PROVIDER;
+
+    const { comment } = await import("../styles/index.js");
+
+    const ev: Event = {
+      ts: Date.now(),
+      type: "search",
+      summary: "ファイルを検索中",
+      detail: "rg -n pattern"
+    };
+
+    const out = await comment(ev, "standard");
+    // ルール実況は [mock- を含まない
+    expect(out).not.toContain("[mock-");
+    // ルール実況の特徴的なフレーズを含む
+    expect(out).toContain("初心者向け");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract existing comment logic to `commentByRules()`
- Add LLM adapter integration at module load (once, not per-call)
- `LLM_PROVIDER` unset → rule-based commentary (no change)
- `LLM_PROVIDER=mock` → mock LLM response with `[mock-xxx]` prefix
- LLM failure → safe fallback to rule-based commentary

## Changes

- `styles/index.ts`: Add LLM integration with safe fallback
- `index.ts`: Update callers to handle async `comment()`
- `tests/llm.comment.test.ts`: Test LLM_PROVIDER=mock integration

## Test plan

- [x] `pnpm -C apps/server test` - 27/27 pass
- [x] `pnpm -C apps/web build` - success
- [x] `pnpm dev:server` - starts, health check OK
- [ ] Manual test with `LLM_PROVIDER=mock pnpm dev` to see `[mock-xxx]` in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)