### PR TITLE
test(llm): provider contract tests + empty-response standardization (Sprint 12-B)

### DIFF
--- a/apps/server/src/llm/providers/anthropic.ts
+++ b/apps/server/src/llm/providers/anthropic.ts
@@ -132,6 +132,10 @@ export function createAnthropicAdapter(
         .map((block) => block.text ?? "")
         .join("");
 
+      if (!text) {
+        throw new CommentError("comment_llm_error", "Empty response from LLM");
+      }
+
       return {
         text,
         usage: data.usage

--- a/apps/server/src/llm/providers/gemini.ts
+++ b/apps/server/src/llm/providers/gemini.ts
@@ -121,7 +121,10 @@ export function createGeminiAdapter(
       }
 
       // Extract text from response
-      const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!text) {
+        throw new CommentError("comment_llm_error", "Empty response from LLM");
+      }
 
       return {
         text,

--- a/apps/server/src/llm/providers/openai_compat.ts
+++ b/apps/server/src/llm/providers/openai_compat.ts
@@ -116,7 +116,10 @@ export function createOpenAICompatAdapter(config: OpenAICompatConfig): LLMAdapte
         throw new CommentError("comment_llm_error", "Invalid JSON response");
       }
 
-      const text = data.choices?.[0]?.message?.content ?? "";
+      const text = data.choices?.[0]?.message?.content;
+      if (!text) {
+        throw new CommentError("comment_llm_error", "Empty response from LLM");
+      }
 
       return {
         text,

--- a/apps/server/src/tests/gemini.provider.test.ts
+++ b/apps/server/src/tests/gemini.provider.test.ts
@@ -220,7 +220,7 @@ describe("createGeminiAdapter", () => {
     });
   });
 
-  it("handles empty response gracefully", async () => {
+  it("throws comment_llm_error for empty response", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
@@ -230,11 +230,14 @@ describe("createGeminiAdapter", () => {
     });
 
     const adapter = createGeminiAdapter({ GOOGLE_API_KEY: "test-key" });
-    const result = await adapter.generateText({
-      messages: [{ role: "user", content: "Hi" }],
+    await expect(
+      adapter.generateText({
+        messages: [{ role: "user", content: "Hi" }],
+      })
+    ).rejects.toMatchObject({
+      name: "CommentError",
+      code: "comment_llm_error",
     });
-
-    expect(result.text).toBe("");
   });
 
   it("passes signal to fetch", async () => {

--- a/apps/server/src/tests/llm.contract.test.ts
+++ b/apps/server/src/tests/llm.contract.test.ts
@@ -1,0 +1,229 @@
+/**
+ * LLM Provider Contract Tests
+ *
+ * Verifies that all LLM providers implement the same contract:
+ * 1. Returns { text: string } on success
+ * 2. Throws CommentError("comment_llm_error") for empty response
+ * 3. Throws CommentError("comment_aborted") when signal is pre-aborted
+ * 4. Throws CommentError("comment_aborted") when aborted during fetch
+ * 5. Throws CommentError("comment_llm_error") on network failure
+ * 6. Throws CommentError("comment_llm_error") on HTTP 4xx/5xx
+ * 7. Throws CommentError("comment_llm_error") on invalid JSON
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLLMAdapter } from "../llm/factory.js";
+import { CommentError } from "../errors.js";
+import type { LLMAdapter } from "../llm/adapter.js";
+
+// Provider configurations for testing
+const PROVIDERS = [
+  {
+    name: "openai",
+    env: { LLM_PROVIDER: "openai", OPENAI_API_KEY: "test-key" },
+  },
+  {
+    name: "groq",
+    env: { LLM_PROVIDER: "groq", GROQ_API_KEY: "test-key" },
+  },
+  {
+    name: "local",
+    env: { LLM_PROVIDER: "local" },
+  },
+  {
+    name: "gemini",
+    env: { LLM_PROVIDER: "gemini", GOOGLE_API_KEY: "test-key" },
+  },
+  {
+    name: "anthropic",
+    env: { LLM_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "test-key" },
+  },
+] as const;
+
+// Mock responses for each provider type
+function getMockSuccessResponse(providerName: string): unknown {
+  switch (providerName) {
+    case "openai":
+    case "groq":
+    case "local":
+      return {
+        choices: [{ message: { content: "test response" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      };
+    case "gemini":
+      return {
+        candidates: [{ content: { parts: [{ text: "test response" }] } }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      };
+    case "anthropic":
+      return {
+        content: [{ type: "text", text: "test response" }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+    default:
+      throw new Error(`Unknown provider: ${providerName}`);
+  }
+}
+
+function getMockEmptyResponse(providerName: string): unknown {
+  switch (providerName) {
+    case "openai":
+    case "groq":
+    case "local":
+      return { choices: [] };
+    case "gemini":
+      return { candidates: [] };
+    case "anthropic":
+      return { content: [] };
+    default:
+      throw new Error(`Unknown provider: ${providerName}`);
+  }
+}
+
+function getMockHttpErrorResponse(providerName: string): unknown {
+  switch (providerName) {
+    case "openai":
+    case "groq":
+    case "local":
+      return { error: { message: "Unauthorized" } };
+    case "gemini":
+      return { error: { message: "Unauthorized", code: 401 } };
+    case "anthropic":
+      return { error: { message: "Unauthorized", type: "authentication_error" } };
+    default:
+      throw new Error(`Unknown provider: ${providerName}`);
+  }
+}
+
+// Test request
+const TEST_REQUEST = {
+  messages: [{ role: "user" as const, content: "Hello" }],
+};
+
+describe.each(PROVIDERS)("LLM Contract: $name", ({ name, env }) => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let adapter: LLMAdapter;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    adapter = createLLMAdapter(env);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  // Contract 1: Returns text string on success
+  it("returns text string on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => getMockSuccessResponse(name),
+    });
+
+    const result = await adapter.generateText(TEST_REQUEST);
+
+    expect(typeof result.text).toBe("string");
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.text).toBe("test response");
+  });
+
+  // Contract 2: Throws comment_llm_error for empty response
+  it("throws comment_llm_error for empty response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => getMockEmptyResponse(name),
+    });
+
+    try {
+      await adapter.generateText(TEST_REQUEST);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_llm_error");
+    }
+  });
+
+  // Contract 3: Throws comment_aborted when signal is already aborted
+  it("throws comment_aborted when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await adapter.generateText({
+        ...TEST_REQUEST,
+        signal: controller.signal,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_aborted");
+    }
+
+    // fetch should not be called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // Contract 4: Throws comment_aborted when aborted during fetch
+  it("throws comment_aborted when aborted during fetch", async () => {
+    const abortError = new Error("Aborted");
+    abortError.name = "AbortError";
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    try {
+      await adapter.generateText(TEST_REQUEST);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_aborted");
+    }
+  });
+
+  // Contract 5: Throws comment_llm_error on network failure
+  it("throws comment_llm_error on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    try {
+      await adapter.generateText(TEST_REQUEST);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_llm_error");
+    }
+  });
+
+  // Contract 6: Throws comment_llm_error on HTTP 4xx/5xx
+  it("throws comment_llm_error on HTTP 4xx/5xx", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => getMockHttpErrorResponse(name),
+    });
+
+    try {
+      await adapter.generateText(TEST_REQUEST);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_llm_error");
+    }
+  });
+
+  // Contract 7: Throws comment_llm_error on invalid JSON
+  it("throws comment_llm_error on invalid JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    });
+
+    try {
+      await adapter.generateText(TEST_REQUEST);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CommentError);
+      expect((err as CommentError).code).toBe("comment_llm_error");
+    }
+  });
+});

--- a/apps/server/src/tests/openai_compat.test.ts
+++ b/apps/server/src/tests/openai_compat.test.ts
@@ -160,7 +160,7 @@ describe("createOpenAICompatAdapter", () => {
     });
   });
 
-  it("handles empty content in response", async () => {
+  it("throws comment_llm_error for empty content in response", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
@@ -170,11 +170,14 @@ describe("createOpenAICompatAdapter", () => {
     });
 
     const adapter = createOpenAICompatAdapter(baseConfig);
-    const result = await adapter.generateText({
-      messages: [{ role: "user", content: "Hi" }],
+    await expect(
+      adapter.generateText({
+        messages: [{ role: "user", content: "Hi" }],
+      })
+    ).rejects.toMatchObject({
+      name: "CommentError",
+      code: "comment_llm_error",
     });
-
-    expect(result.text).toBe("");
   });
 
   it("uses custom defaultMaxTokens and defaultTemperature", async () => {


### PR DESCRIPTION
## Summary
- Add provider contract test suite (5 providers × 7 contracts = 35 cases)
- Standardize empty LLM responses to throw `CommentError("comment_llm_error")`
  - openai_compat (openai/groq/local)
  - gemini
  - anthropic
- Update existing provider unit tests to match new contract

## Why
- Prevent provider drift and regressions (consistent behavior across providers)
- Make fallback behavior deterministic (empty response is treated as LLM failure)

## Test plan
- [x] `pnpm -C apps/server test src/tests/llm.contract.test.ts`
- [x] `pnpm -C apps/server test` (155 passed)
- [x] `pnpm smoke:llm mock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)