### PR TITLE
fix(server): emit start commentary on PTY setup

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -150,10 +150,29 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
   });
 
   // Broadcast start event (ptyRestart is sent separately in restartPTY for correct ordering)
-  broadcast({
-    kind: "event",
-    ev: { ts: Date.now(), type: "start", summary: "開始", detail: `${config.cmd} ${config.args.join(" ")}` },
-  });
+  const startEvent: Event = {
+    ts: Date.now(),
+    type: "start",
+    summary: "開始",
+    detail: `${config.cmd} ${config.args.join(" ")}`,
+  };
+  broadcast({ kind: "event", ev: startEvent });
+
+  // Send commentary for start event
+  void comment(startEvent, currentStyle)
+    .then((text) => {
+      broadcast({ kind: "commentary", ts: Date.now(), text, ev: startEvent });
+    })
+    .catch((err) => {
+      // Fallback: show basic start message if LLM fails
+      broadcast({
+        kind: "commentary",
+        ts: Date.now(),
+        text: `開始: ${startEvent.detail}`,
+        ev: startEvent,
+      });
+      console.error("start commentary failed:", err);
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary
- PTY起動/再起動時に「開始」の実況コメントをWeb UIに送信するように修正
- `commentary.ts` に `Date.now()` を使用（startEvent.tsではなく）し、後続イベントとのts衝突を回避
- LLM呼び出し失敗時のフォールバックメッセージを追加

## Background
Sprint 13のptyRestart実装で、Web UIは `commentary` のみを `items` に積む設計になっていますが、`start` イベントに対する `commentary` が送信されていませんでした。これにより、プロファイル切り替え後にUIが空のままになる問題がありました。

## Changes
- `setupPTY` で `event:start` 送信後に `comment()` を呼び出し、`commentary` も送信
- `commentary.ts` には生成時刻（`Date.now()`）を使用（将来のtsソート対応）
- `.catch()` でフォールバックメッセージを送信し、LLM失敗時もUIに表示を保証

## Test plan
- [x] `pnpm -C apps/server test` - 205 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)