### PR TITLE
fix(web): hide Tauri Debug panel in production builds

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,7 +32,7 @@ function TauriDebugPanel() {
     }
   }, []);
 
-  if (!isTauri) return null;
+  if (!import.meta.env.DEV || !isTauri) return null;
 
   const tauri = (window as { __TAURI__?: { core?: { invoke: (cmd: string) => Promise<unknown> } } }).__TAURI__;
 


### PR DESCRIPTION
## Summary
- Add DEV mode check to TauriDebugPanel to only show in development builds
- Production builds will no longer display the debug panel

Closes #28

## Test plan
- [ ] `pnpm dev:desktop:managed` - Debug panel should appear
- [ ] `pnpm -C apps/web build && pnpm -C apps/web preview` - Debug panel should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)