### PR TITLE
feat(desktop): use process-wrap for child process cleanup

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -286,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +307,7 @@ dependencies = [
 name = "cli-commentator-desktop"
 version = "0.0.1"
 dependencies = [
+ "process-wrap",
  "serde",
  "serde_json",
  "tauri",
@@ -1760,6 +1767,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2373,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5fd83ab7fa55fd06f5e665e3fc52b8bca451c0486b8ea60ad649cd1c10a5da"
+dependencies = [
+ "indexmap 2.13.0",
+ "nix",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -3603,7 +3634,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,3 +14,4 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+process-wrap = { version = "9", features = ["std", "process-group", "job-object"] }

--- a/apps/desktop/src-tauri/src/server.rs
+++ b/apps/desktop/src-tauri/src/server.rs
@@ -1,10 +1,17 @@
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::Stdio;
 use std::sync::Mutex;
 use tauri::State;
+use process_wrap::std::*;
+
+#[cfg(unix)]
+use process_wrap::std::ProcessGroup;
+
+#[cfg(windows)]
+use process_wrap::std::JobObject;
 
 pub struct ServerState {
-    process: Mutex<Option<Child>>,
+    process: Mutex<Option<Box<dyn ChildWrapper>>>,
 }
 
 impl ServerState {
@@ -34,11 +41,21 @@ pub fn start_server(state: State<'_, ServerState>) -> Result<bool, String> {
 
     let project_root = get_project_root()?;
 
-    let child = Command::new("pnpm")
-        .args(["-C", "apps/server", "dev"])
-        .current_dir(&project_root)
-        .stdout(Stdio::inherit()) // Inherit logs to avoid buffer issues
-        .stderr(Stdio::inherit())
+    let mut command = CommandWrap::with_new("pnpm", |cmd| {
+        cmd.args(["-C", "apps/server", "dev"])
+            .current_dir(&project_root)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+    });
+
+    // Platform-specific wrapper for proper child process cleanup
+    #[cfg(unix)]
+    command.wrap(ProcessGroup::leader());
+
+    #[cfg(windows)]
+    command.wrap(JobObject);
+
+    let child = command
         .spawn()
         .map_err(|e| format!("Failed to start server: {}", e))?;
 
@@ -51,21 +68,8 @@ pub fn stop_server(state: State<'_, ServerState>) -> Result<(), String> {
     let mut proc = state.process.lock().map_err(|e| e.to_string())?;
 
     if let Some(mut child) = proc.take() {
-        let pid = child.id();
-
-        // Kill the process group to also terminate child processes (node, etc.)
-        #[cfg(unix)]
-        {
-            use std::process::Command as StdCommand;
-            // Use pkill to kill all child processes of the pnpm process
-            let _ = StdCommand::new("pkill")
-                .args(["-P", &pid.to_string()])
-                .status();
-        }
-
-        // Then kill the main process
+        // kill() terminates the entire process group (Unix) or job object (Windows)
         let _ = child.kill();
-        let _ = child.wait(); // Reap the zombie process
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add process-wrap dependency for cross-platform process group management
- Unix: Use ProcessGroup to kill entire process tree
- Windows: Use JobObject for proper child process cleanup
- Remove manual pkill command, simplify stop_server implementation

Closes #26, #27

## Test plan (macOS)
- [ ] `cd apps/desktop/src-tauri && cargo check` - Build passes
- [ ] `pnpm dev:desktop:managed` - App starts
- [ ] Start → Stop → `lsof -nP -iTCP:8787 -sTCP:LISTEN || echo "STOPPED"` - Should print STOPPED
- [ ] Start → Close window → `lsof -nP -iTCP:8787 -sTCP:LISTEN || echo "STOPPED"` - Should print STOPPED

## Test plan (Windows CI)
- [ ] Windows CI build should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)