### PR TITLE
feat(desktop): add server_status_detailed with crash/orphan detection

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod server;
 
-use server::{server_status, start_server, stop_server, ServerState};
+use server::{server_status, server_status_detailed, start_server, stop_server, ServerState};
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -10,7 +10,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             start_server,
             stop_server,
-            server_status
+            server_status,
+            server_status_detailed
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/apps/desktop/src-tauri/src/server.rs
+++ b/apps/desktop/src-tauri/src/server.rs
@@ -1,6 +1,8 @@
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::State;
 use process_wrap::std::*;
 
@@ -10,16 +12,68 @@ use process_wrap::std::ProcessGroup;
 #[cfg(windows)]
 use process_wrap::std::JobObject;
 
+const SERVER_PORT: u16 = 8787;
+
+#[derive(Clone, serde::Serialize)]
+pub struct ServerStatus {
+    pub desired: DesiredState,
+    pub actual: ActualState,
+    pub pid: Option<u32>,
+    pub started_at: Option<u64>,
+    pub exit_code: Option<i32>,
+    pub crash_suspected: bool,
+    pub orphan_suspected: bool,
+    pub diagnostics: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DesiredState {
+    Running,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActualState {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+struct ServerRuntime {
+    process: Option<Box<dyn ChildWrapper>>,
+    desired: DesiredState,
+    pid: Option<u32>,
+    started_at: Option<u64>,
+    last_exit: Option<i32>,
+}
+
 pub struct ServerState {
-    process: Mutex<Option<Box<dyn ChildWrapper>>>,
+    runtime: Mutex<ServerRuntime>,
 }
 
 impl ServerState {
     pub fn new() -> Self {
         Self {
-            process: Mutex::new(None),
+            runtime: Mutex::new(ServerRuntime {
+                process: None,
+                desired: DesiredState::Stopped,
+                pid: None,
+                started_at: None,
+                last_exit: None,
+            }),
         }
     }
+}
+
+/// Check if the server port is in use
+fn check_port_in_use() -> bool {
+    TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], SERVER_PORT)),
+        Duration::from_millis(200),
+    )
+    .is_ok()
 }
 
 /// Get project root from CARGO_MANIFEST_DIR
@@ -32,11 +86,85 @@ fn get_project_root() -> Result<PathBuf, String> {
 }
 
 #[tauri::command]
-pub fn start_server(state: State<'_, ServerState>) -> Result<bool, String> {
-    let mut proc = state.process.lock().map_err(|e| e.to_string())?;
+pub fn server_status_detailed(state: State<'_, ServerState>) -> ServerStatus {
+    let mut rt = state.runtime.lock().unwrap();
 
-    if proc.is_some() {
-        return Ok(false); // Already running
+    // 1. Check process liveness + cleanup if dead
+    let (actual, exit_code) = match rt.process.as_mut() {
+        Some(child) => match child.try_wait() {
+            Ok(Some(status)) => {
+                // Process exited → cleanup
+                rt.last_exit = status.code();
+                rt.process = None; // Release handle
+                (ActualState::Dead, rt.last_exit)
+            }
+            Ok(None) => (ActualState::Alive, None),
+            Err(_) => (ActualState::Unknown, None),
+        },
+        None => (ActualState::Dead, rt.last_exit),
+    };
+
+    // 2. Crash detection (desired=running but actual=dead)
+    let crash_suspected = rt.desired == DesiredState::Running && actual == ActualState::Dead;
+
+    // 3. Orphan detection (port in use but no tracked process)
+    let orphan_suspected = rt.process.is_none() && check_port_in_use();
+
+    // 4. Log warnings
+    if crash_suspected {
+        eprintln!(
+            "[WARN] Crash suspected: desired={:?}, actual={:?}, pid={:?}",
+            rt.desired, actual, rt.pid
+        );
+    }
+    if orphan_suspected {
+        eprintln!(
+            "[WARN] Orphan suspected: port {} in use but no tracked process",
+            SERVER_PORT
+        );
+    }
+
+    // 5. Generate diagnostics
+    let diagnostics = match (crash_suspected, orphan_suspected) {
+        (true, true) => Some("crash_and_orphan".to_string()),
+        (true, false) => Some("crash_suspected".to_string()),
+        (false, true) => Some("orphan_port_in_use".to_string()),
+        (false, false) => None,
+    };
+
+    ServerStatus {
+        desired: rt.desired,
+        actual,
+        pid: rt.pid,
+        started_at: rt.started_at,
+        exit_code,
+        crash_suspected,
+        orphan_suspected,
+        diagnostics,
+    }
+}
+
+#[tauri::command]
+pub fn server_status(state: State<'_, ServerState>) -> bool {
+    let status = server_status_detailed(state);
+    status.actual == ActualState::Alive
+}
+
+#[tauri::command]
+pub fn start_server(state: State<'_, ServerState>) -> Result<bool, String> {
+    let mut rt = state.runtime.lock().map_err(|e| e.to_string())?;
+
+    // Cleanup dead handle if exists
+    if let Some(ref mut child) = rt.process {
+        if let Ok(Some(status)) = child.try_wait() {
+            rt.last_exit = status.code();
+            rt.process = None;
+        }
+    }
+
+    // Already alive → return false
+    if rt.process.is_some() {
+        return Ok(false);
     }
 
     let project_root = get_project_root()?;
@@ -59,27 +187,43 @@ pub fn start_server(state: State<'_, ServerState>) -> Result<bool, String> {
         .spawn()
         .map_err(|e| format!("Failed to start server: {}", e))?;
 
-    *proc = Some(child);
+    let pid = child.id();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    rt.process = Some(child);
+    rt.desired = DesiredState::Running;
+    rt.pid = Some(pid);
+    rt.started_at = Some(now);
+
     Ok(true)
 }
 
 #[tauri::command]
 pub fn stop_server(state: State<'_, ServerState>) -> Result<(), String> {
-    let mut proc = state.process.lock().map_err(|e| e.to_string())?;
+    let mut rt = state.runtime.lock().map_err(|e| e.to_string())?;
 
-    if let Some(mut child) = proc.take() {
-        // kill() terminates the entire process group (Unix) or job object (Windows)
-        let _ = child.kill();
+    rt.desired = DesiredState::Stopped;
+
+    if let Some(mut child) = rt.process.take() {
+        // Try to get exit code before kill
+        if let Ok(Some(status)) = child.try_wait() {
+            rt.last_exit = status.code();
+        } else {
+            // kill() terminates the entire process group (Unix) or job object (Windows)
+            let _ = child.kill();
+            // Get exit code after kill
+            if let Ok(status) = child.wait() {
+                rt.last_exit = status.code();
+            }
+        }
     }
 
-    Ok(())
-}
+    // Clear stale tracking info on intentional stop
+    rt.pid = None;
+    rt.started_at = None;
 
-#[tauri::command]
-pub fn server_status(state: State<'_, ServerState>) -> bool {
-    state
-        .process
-        .lock()
-        .map(|p| p.is_some())
-        .unwrap_or(false)
+    Ok(())
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -20,10 +20,21 @@ type LegacyHello = { type: "hello"; style: Style };
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "reconnecting";
 
+type ServerStatusDetail = {
+  desired: "running" | "stopped";
+  actual: "alive" | "dead" | "unknown";
+  pid: number | null;
+  started_at: number | null;
+  exit_code: number | null;
+  crash_suspected: boolean;
+  orphan_suspected: boolean;
+  diagnostics: string | null;
+};
+
 // Tauri debug panel for Gate B testing
 function TauriDebugPanel() {
   const [isTauri, setIsTauri] = useState(false);
-  const [serverStatus, setServerStatus] = useState<string>("unknown");
+  const [status, setStatus] = useState<ServerStatusDetail | null>(null);
 
   useEffect(() => {
     const tauri = (window as { __TAURI__?: { core?: { invoke: (cmd: string) => Promise<unknown> } } }).__TAURI__;
@@ -32,34 +43,42 @@ function TauriDebugPanel() {
     }
   }, []);
 
+  // Polling (3 second interval)
+  useEffect(() => {
+    if (!isTauri) return;
+    const tauri = (window as { __TAURI__?: { core?: { invoke: (cmd: string) => Promise<unknown> } } }).__TAURI__;
+
+    const poll = async () => {
+      try {
+        const result = await tauri?.core?.invoke("server_status_detailed");
+        setStatus(result as ServerStatusDetail);
+      } catch {
+        // Ignore polling errors
+      }
+    };
+
+    poll(); // Initial immediate call
+    const interval = setInterval(poll, 3000);
+    return () => clearInterval(interval);
+  }, [isTauri]);
+
   if (!import.meta.env.DEV || !isTauri) return null;
 
   const tauri = (window as { __TAURI__?: { core?: { invoke: (cmd: string) => Promise<unknown> } } }).__TAURI__;
 
   const handleStart = async () => {
     try {
-      const result = await tauri?.core?.invoke("start_server");
-      setServerStatus(result ? "started" : "already running");
-    } catch (e) {
-      setServerStatus(`error: ${e}`);
+      await tauri?.core?.invoke("start_server");
+    } catch {
+      // Ignore errors
     }
   };
 
   const handleStop = async () => {
     try {
       await tauri?.core?.invoke("stop_server");
-      setServerStatus("stopped");
-    } catch (e) {
-      setServerStatus(`error: ${e}`);
-    }
-  };
-
-  const handleStatus = async () => {
-    try {
-      const result = await tauri?.core?.invoke("server_status");
-      setServerStatus(result ? "running" : "not running");
-    } catch (e) {
-      setServerStatus(`error: ${e}`);
+    } catch {
+      // Ignore errors
     }
   };
 
@@ -74,13 +93,40 @@ function TauriDebugPanel() {
       borderRadius: 8,
       fontSize: 12,
       zIndex: 9999,
+      minWidth: 180,
     }}>
       <div style={{ fontWeight: "bold", marginBottom: 8 }}>Tauri Debug</div>
-      <div style={{ marginBottom: 8 }}>Server: {serverStatus}</div>
+
+      {status && (
+        <div style={{ marginBottom: 8, lineHeight: 1.6 }}>
+          <div>Desired: {status.desired}</div>
+          <div>Actual: <span style={{
+            color: status.actual === "alive" ? "#22c55e" :
+                   status.actual === "dead" ? "#ef4444" : "#f59e0b"
+          }}>{status.actual}</span></div>
+          <div>PID: {status.pid ?? "-"}</div>
+          {status.started_at && (
+            <div style={{ fontSize: 10, opacity: 0.7 }}>
+              Started: {new Date(status.started_at).toLocaleTimeString()}
+            </div>
+          )}
+          {status.crash_suspected && (
+            <div style={{ color: "#ef4444", marginTop: 4 }}>Crash suspected</div>
+          )}
+          {status.orphan_suspected && (
+            <div style={{ color: "#f59e0b", marginTop: 4 }}>Orphan: port in use</div>
+          )}
+          {status.diagnostics && (
+            <div style={{ fontSize: 10, opacity: 0.6, marginTop: 4 }}>
+              [{status.diagnostics}]
+            </div>
+          )}
+        </div>
+      )}
+
       <div style={{ display: "flex", gap: 4 }}>
         <button onClick={handleStart} style={{ padding: "4px 8px" }}>Start</button>
         <button onClick={handleStop} style={{ padding: "4px 8px" }}>Stop</button>
-        <button onClick={handleStatus} style={{ padding: "4px 8px" }}>Status</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Sprint 16: Server health monitoring and orphan process visualization

- Add `ServerStatus` struct with desired/actual state tracking
- Add `DesiredState` and `ActualState` enums with `Debug` derive
- Implement orphan detection via TCP port check
- Implement crash detection (desired=running but process dead)
- Clean up dead handles in `start_server` for reliable restarts
- Clear PID/started_at on intentional stop for UI clarity
- Update TauriDebugPanel with 3-second polling and detailed status
- Show crash/orphan warnings and diagnostics in UI

## Related Issues

Closes #31

## Type of Change

- [x] New feature

## Checklist

### General
- [x] Tests pass locally (`pnpm -C apps/server test`)
- [x] No new TypeScript errors
- [x] Code follows existing patterns in the codebase

## Test Plan

1. Start → 3秒以内に `actual=alive`, PID表示
2. Stop → `actual=dead`, crash/orphan 両方 false
3. Crash（別ターミナルでPID kill）→ `crash_suspected=true`
4. Orphan（8787を別プロセスで掴む）→ `orphan_suspected=true`

---
Generated with [Claude Code](https://claude.com/claude-code)