### PR TITLE
feat: unify server port via CLI_COMMENTATOR_PORT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,8 @@ cli-commentator/
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | 8787 | サーバーポート |
+| `CLI_COMMENTATOR_PORT` | 8787 | サーバーポート（Tauri/Server/Web共通） |
+| `PORT` | 8787 | サーバーポート（`CLI_COMMENTATOR_PORT`未設定時のフォールバック） |
 | `TARGET_CMD` | bash (Win: powershell.exe) | 実行するCLIコマンド |
 | `TARGET_ARGS` | (empty) | CLIへの引数（空白区切り） |
 | `TARGET_ARGS_JSON` | (empty) | CLIへの引数（JSON配列、TARGET_ARGSより優先） |

--- a/apps/desktop/src-tauri/src/server.rs
+++ b/apps/desktop/src-tauri/src/server.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -12,7 +13,16 @@ use process_wrap::std::ProcessGroup;
 #[cfg(windows)]
 use process_wrap::std::JobObject;
 
-const SERVER_PORT: u16 = 8787;
+const DEFAULT_PORT: u16 = 8787;
+
+/// Get server port from CLI_COMMENTATOR_PORT or PORT env var, fallback to 8787
+fn get_server_port() -> u16 {
+    env::var("CLI_COMMENTATOR_PORT")
+        .or_else(|_| env::var("PORT"))
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_PORT)
+}
 
 #[derive(Clone, serde::Serialize)]
 pub struct ServerStatus {
@@ -68,9 +78,9 @@ impl ServerState {
 }
 
 /// Check if the server port is in use
-fn check_port_in_use() -> bool {
+fn check_port_in_use(port: u16) -> bool {
     TcpStream::connect_timeout(
-        &std::net::SocketAddr::from(([127, 0, 0, 1], SERVER_PORT)),
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
         Duration::from_millis(200),
     )
     .is_ok()
@@ -88,6 +98,7 @@ fn get_project_root() -> Result<PathBuf, String> {
 #[tauri::command]
 pub fn server_status_detailed(state: State<'_, ServerState>) -> ServerStatus {
     let mut rt = state.runtime.lock().unwrap();
+    let port = get_server_port();
 
     // 1. Check process liveness + cleanup if dead
     let (actual, exit_code) = match rt.process.as_mut() {
@@ -108,7 +119,7 @@ pub fn server_status_detailed(state: State<'_, ServerState>) -> ServerStatus {
     let crash_suspected = rt.desired == DesiredState::Running && actual == ActualState::Dead;
 
     // 3. Orphan detection (port in use but no tracked process)
-    let orphan_suspected = rt.process.is_none() && check_port_in_use();
+    let orphan_suspected = rt.process.is_none() && check_port_in_use(port);
 
     // 4. Log warnings
     if crash_suspected {
@@ -120,7 +131,7 @@ pub fn server_status_detailed(state: State<'_, ServerState>) -> ServerStatus {
     if orphan_suspected {
         eprintln!(
             "[WARN] Orphan suspected: port {} in use but no tracked process",
-            SERVER_PORT
+            port
         );
     }
 
@@ -168,10 +179,12 @@ pub fn start_server(state: State<'_, ServerState>) -> Result<bool, String> {
     }
 
     let project_root = get_project_root()?;
+    let port = get_server_port();
 
     let mut command = CommandWrap::with_new("pnpm", |cmd| {
         cmd.args(["-C", "apps/server", "dev"])
             .current_dir(&project_root)
+            .env("CLI_COMMENTATOR_PORT", port.to_string())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
     });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,7 +11,7 @@ import * as profileManager from "./profile/manager.js";
 import type { ProfileSummary } from "./profile/types.js";
 import { createPTYManager, configFromProfile, configFromEnv, type PTYConfig } from "./pty/index.js";
 
-const PORT = Number(process.env.PORT ?? 8787);
+const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
 
 function isStyle(value: unknown): value is Style {

--- a/apps/web/.env.development
+++ b/apps/web/.env.development
@@ -1,1 +1,2 @@
+# Must match CLI_COMMENTATOR_PORT (or PORT) set for the server
 VITE_WS_PORT=8787

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,2 @@
+# Must match CLI_COMMENTATOR_PORT (or PORT) set for the server
 VITE_WS_PORT=8787


### PR DESCRIPTION
## Summary

Sprint 17-A: Port single source

- Server: Use `CLI_COMMENTATOR_PORT` with `PORT` and `8787` fallbacks
- Tauri: Read port dynamically via `get_server_port()`
- Tauri: Explicitly pass `CLI_COMMENTATOR_PORT` env to spawned server process
- Web: Document `VITE_WS_PORT` must match `CLI_COMMENTATOR_PORT`
- CLAUDE.md: Document `CLI_COMMENTATOR_PORT` as primary env var

This ensures port configuration is consistent across Server, Tauri, and Web UI, preventing orphan detection false positives when port changes.

## Related Issues

<!-- Part of Sprint 17 -->

## Type of Change

- [x] New feature

## Checklist

### General
- [x] Tests pass locally (`pnpm -C apps/server test`)
- [x] No new TypeScript errors
- [x] Code follows existing patterns in the codebase

### Documentation
- [x] CLAUDE.md updated if env vars or config changed

## Test Plan

```bash
# Port変更テスト
CLI_COMMENTATOR_PORT=9999 pnpm dev
# → DebugPanelに "port 9999" が表示される
# → 全コンポーネントが9999で追随
```

---
Generated with [Claude Code](https://claude.com/claude-code)