### PR TITLE
docs: add Related Issues auto-close syntax to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,18 @@
 
 <!-- Brief description of changes -->
 
+## Related Issues
+
+<!--
+Use separate lines for auto-close:
+Closes #123
+Closes #456
+
+NOT: Closes #123, #456 (comma won't work)
+
+Note: Closing keywords only work for PRs targeting the default branch (main).
+-->
+
 ## Type of Change
 
 - [ ] Bug fix


### PR DESCRIPTION
## Summary

Add "Related Issues" section to PR template with guidance on using Closes # syntax.

- Add Related Issues section with `Closes #` syntax guidance
- Document that comma-separated syntax doesn't work
- Note that closing keywords only work for default branch PRs

## Type of Change

- [x] Documentation

## Test Plan

Review the PR template preview.

---
Generated with [Claude Code](https://claude.com/claude-code)