### PR TITLE
feat(server): add INPUT_MODE validation and startup config logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ cli-commentator/
 |----|------|
 | 未設定 / `pty` | PTYモード：CLIを起動して出力をキャプチャ（デフォルト） |
 | `file` | ファイル監視モード：`tail -f` でログファイルを監視（`INPUT_FILE` 必須） |
+| その他 | 警告を出力してPTYモードにフォールバック |
 
 **ファイル監視モードの使用例:**
 ```bash
@@ -95,6 +96,10 @@ INPUT_MODE=file INPUT_FILE=/var/log/app.log pnpm dev:server
 # CIログを監視
 INPUT_MODE=file INPUT_FILE=./ci-output.log pnpm dev:server
 ```
+
+**バリデーション:**
+- `INPUT_MODE=file` で `INPUT_FILE` が未設定 → エラー終了 (exit 1)
+- `INPUT_MODE=file` で `INPUT_FILE` のファイルが存在しない → エラー終了 (exit 1)
 
 ### LLM_PROVIDER の動作
 
@@ -205,3 +210,34 @@ pnpm smoke:llm --all
 - `comment()` 関数で LLM_PROVIDER に応じて分岐（Sprint 6 で統合済み）
 - タイムアウト保護: `comment()` は `COMMENT_TIMEOUT_MS` 後に自動でルールベースにフォールバック（Sprint 8）
 - AbortController 対応: LLM リクエストに signal を渡して abort 可能（Sprint 8）
+
+## Typical Use Cases
+
+### 1. PTYモード（デフォルト）
+```bash
+# Claude Codeの実況
+TARGET_CMD="claude" TARGET_ARGS="code ." pnpm dev
+
+# カスタムコマンドの実況
+TARGET_CMD="npm" TARGET_ARGS="run build" pnpm dev
+```
+
+### 2. ファイル監視モード
+```bash
+# 外部プロセスのログを監視（プロセスは別で起動済み）
+INPUT_MODE=file INPUT_FILE=/var/log/myapp.log pnpm dev:server
+
+# 別ターミナルでWeb UIを起動
+pnpm dev:web
+```
+
+### 3. Tauriデスクトップアプリ
+```bash
+# 開発モード（サーバー自動起動）
+pnpm dev:desktop:managed
+
+# DebugPanelでサーバー状態を確認
+# - Desired/Actual state
+# - PID
+# - Crash/Orphan detection
+```

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import fs from "node:fs";
 import http from "node:http";
 import { WebSocketServer } from "ws";
 
@@ -17,7 +18,18 @@ const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? 
 
 // Input mode configuration
 type InputMode = "pty" | "file";
-const INPUT_MODE: InputMode = (process.env.INPUT_MODE?.toLowerCase() === "file") ? "file" : "pty";
+const INPUT_MODE_RAW = process.env.INPUT_MODE; // For debugging
+
+function parseInputMode(value?: string): InputMode {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (normalized === "" || normalized === "pty") return "pty";
+  if (normalized === "file") return "file";
+  // Unknown value: warn and fallback to pty
+  console.warn(`[WARN] Unknown INPUT_MODE="${value}", falling back to "pty". Valid values: pty, file`);
+  return "pty";
+}
+
+const INPUT_MODE: InputMode = parseInputMode(INPUT_MODE_RAW);
 const INPUT_FILE = process.env.INPUT_FILE ?? "";
 
 function isStyle(value: unknown): value is Style {
@@ -457,11 +469,47 @@ if (INPUT_MODE === "pty") {
   const initialConfig = configFromEnv();
   setupPTY(initialConfig, null);
 } else {
-  // File mode: setup file tail
+  // File mode: early validation before setupFileTail
+  if (!INPUT_FILE) {
+    console.error("[ERROR] INPUT_FILE is required when INPUT_MODE=file");
+    process.exit(1);
+  }
+  if (!fs.existsSync(INPUT_FILE)) {
+    console.error(`[ERROR] INPUT_FILE not found: ${INPUT_FILE}`);
+    process.exit(1);
+  }
   setupFileTail(INPUT_FILE);
 }
 
+/**
+ * Log startup configuration (no secrets).
+ * Called after currentStyle/currentSourceMode are resolved.
+ */
+function logStartupConfig(): void {
+  const config: Record<string, unknown> = {
+    mode: INPUT_MODE,
+    input_mode_raw: INPUT_MODE_RAW ?? "(unset)",
+    port: PORT,
+  };
+
+  if (INPUT_MODE === "pty") {
+    config.target_cmd = process.env.TARGET_CMD ?? (process.platform === "win32" ? "powershell.exe" : "bash");
+    config.target_args = process.env.TARGET_ARGS_JSON ?? process.env.TARGET_ARGS ?? "";
+    config.target_cwd = process.env.TARGET_CWD ?? process.cwd();
+  } else {
+    config.input_file = INPUT_FILE;
+  }
+
+  // Safe values only (no API keys)
+  config.log_source = currentSourceMode ?? "unknown";
+  config.llm_provider = process.env.LLM_PROVIDER ?? "disabled";
+  config.style = currentStyle ?? "unknown";
+
+  console.log(`[startup] ${JSON.stringify(config)}`);
+}
+
 server.listen(PORT, () => {
+  logStartupConfig();
   console.log(`server listening on http://localhost:${PORT} (mode: ${INPUT_MODE})`);
 });
 


### PR DESCRIPTION
## Summary
- Add `parseInputMode()` with warning for unknown INPUT_MODE values (e.g., `INPUT_MODE=invalid` now logs a warning and falls back to PTY mode)
- Add early validation for `INPUT_FILE` in file mode:
  - Required check: `[ERROR] INPUT_FILE is required when INPUT_MODE=file`
  - Exists check: `[ERROR] INPUT_FILE not found: <path>`
- Add `logStartupConfig()` with JSON format at startup (no secrets leaked):
  ```
  [startup] {"mode":"pty","input_mode_raw":"(unset)","port":8787,"target_cmd":"bash",...}
  ```
- Document INPUT_MODE behavior and typical use cases in CLAUDE.md

## Related Issues
Part of Sprint 18: External monitoring mode hardening

## Test plan
- [x] Run `pnpm -C apps/server test` - 269 tests pass
- [x] Run `cargo check` in desktop - compiles successfully
- [ ] CI passes (Linux + Windows)
- [ ] Manual validation tests:
  - `INPUT_MODE=invalid pnpm dev:server` → warning logged, PTY mode starts
  - `INPUT_MODE=file pnpm dev:server` → error, exit 1
  - `INPUT_MODE=file INPUT_FILE=/nonexistent pnpm dev:server` → error, exit 1
- [ ] Startup log shows JSON with mode, port, target_cmd (PTY) or input_file (file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)