### PR TITLE
test(server): stabilize file-tail timing on Windows

### DIFF
--- a/apps/server/src/tests/file-tail.test.ts
+++ b/apps/server/src/tests/file-tail.test.ts
@@ -9,13 +9,21 @@ import os from "node:os";
 import { FileTail, createFileTail } from "../input/file-tail.js";
 
 /**
+ * Platform-aware defaults for eventually() helper.
+ * Windows fs.watch is slower to detect changes, so we use longer timeouts.
+ */
+const isWindows = process.platform === "win32";
+const DEFAULT_TIMEOUT = isWindows ? 8000 : 3000;
+const DEFAULT_INTERVAL = isWindows ? 100 : 50;
+
+/**
  * Wait for a condition to become true with polling.
  * Useful for async tests where timing varies (especially on Windows).
  */
 async function eventually(
   fn: () => boolean,
-  timeout = 3000,
-  interval = 50
+  timeout = DEFAULT_TIMEOUT,
+  interval = DEFAULT_INTERVAL
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {


### PR DESCRIPTION
## Summary
- Adjust eventually() helper defaults on Windows to reduce flaky fs.watch timing issues
- Windows: timeout 8s, interval 100ms
- Others: keep existing 3s / 50ms behavior

## Rationale
Windows runners can deliver fs.watch events later; extending the polling window improves CI stability without changing production behavior.

**Production code is not affected. Only test helper timing is changed.**

## Test plan
- [x] `pnpm -C apps/server test -- --run file-tail` (local)
- [ ] CI: test + test_windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)