### PR TITLE
chore(deps): tune dependabot limits and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       day: "monday"
       time: "02:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "deps:npm"
@@ -69,7 +69,7 @@ updates:
       day: "monday"
       time: "02:30"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "deps:cargo"
@@ -101,9 +101,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "03:00"
+      time: "04:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "deps:actions"


### PR DESCRIPTION
## Summary
- Reduce `open-pull-requests-limit`: 5 → 3 (all ecosystems)
- Stagger GitHub Actions schedule: 03:00 → 04:00 JST

## Rationale
Reduces simultaneous PR volume and conflict likelihood when multiple Dependabot PRs are created.

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Observe next Dependabot run for reduced PR count

🤖 Generated with [Claude Code](https://claude.com/claude-code)