### PR TITLE
feat(web): add TTS toggle for commentary

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
 import { ProfileSelector } from "./components/ProfileSelector";
 import { ProfileEditor } from "./components/ProfileEditor";
+import { isTTSSupported, speak, stopSpeech, getTTSEnabled, setTTSEnabled } from "./lib/tts";
 import type { Style, SourceState, Profile, ProfileSummary, CreateProfileInput } from "./types";
 
 type Msg =
@@ -161,10 +162,34 @@ export default function App() {
   const [editingProfile, setEditingProfile] = useState<Profile | null | "new">(null);
   const [profileError, setProfileError] = useState<string | null>(null);
 
+  // TTS state
+  const [ttsEnabled, setTtsEnabledState] = useState(() => getTTSEnabled());
+  const ttsSupported = isTTSSupported();
+  const ttsEnabledRef = useRef(ttsEnabled);
+
   const wsUrl = useMemo(() => {
     const port = import.meta.env.VITE_WS_PORT ?? "8787";
     return `ws://localhost:${port}`;
   }, []);
+
+  // TTS ref sync (to avoid stale closure in WebSocket handler)
+  useEffect(() => {
+    ttsEnabledRef.current = ttsEnabled;
+  }, [ttsEnabled]);
+
+  // TTS cleanup on unmount (prevent orphan speech on reload/navigation)
+  useEffect(() => () => stopSpeech(), []);
+
+  const handleTTSToggle = (enabled: boolean) => {
+    setTtsEnabledState(enabled);
+    setTTSEnabled(enabled);
+    if (enabled) {
+      // Safari対策: ユーザー操作をトリガーに一言喋らせる
+      speak("読み上げを開始します");
+    } else {
+      stopSpeech();
+    }
+  };
 
   useEffect(() => {
     // D-1: Prevent ghost reconnection on unmount/hot-reload
@@ -217,6 +242,10 @@ export default function App() {
             case "commentary":
               if ("ts" in msg && "text" in msg) {
                 setItems((prev) => [...prev, { ts: msg.ts, text: msg.text }].slice(-200));
+                // TTS: 有効なら読み上げ
+                if (ttsEnabledRef.current) {
+                  speak(msg.text);
+                }
               }
               break;
             case "profiles":
@@ -439,6 +468,25 @@ export default function App() {
           <option value="zundamon">ずんだもん風（テキスト）</option>
         </select>
         <span style={{ fontSize: 12, opacity: 0.6 }}>（イベント時＋最大2秒に1回）</span>
+      </div>
+
+      {/* TTS Toggle */}
+      <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "12px 0" }}>
+        <label style={{ fontSize: 14, opacity: 0.8, cursor: ttsSupported ? "pointer" : "not-allowed" }}>
+          <input
+            type="checkbox"
+            checked={ttsEnabled}
+            onChange={(e) => handleTTSToggle(e.target.checked)}
+            disabled={!ttsSupported}
+            style={{ marginRight: 8 }}
+          />
+          読み上げ（TTS）
+        </label>
+        {!ttsSupported && (
+          <span style={{ fontSize: 12, color: "#ef4444" }}>
+            ※ このブラウザはTTS非対応です
+          </span>
+        )}
       </div>
 
       <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 8 }}>

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -1,0 +1,63 @@
+/**
+ * TTS (Text-to-Speech) utilities using Web Speech API
+ * Sprint 24: cancel方式（最新のみ読み上げ）
+ */
+
+/** TTS サポート判定 */
+export function isTTSSupported(): boolean {
+  return typeof window !== "undefined" && "speechSynthesis" in window;
+}
+
+/**
+ * テキスト正規化（ログ記号除去、長さ制限）
+ */
+export function normalizeForSpeech(text: string, maxLength = 500): string {
+  const cleaned = text
+    .replace(/\x1b\[[0-9;]*m/g, "") // ANSI escape codes
+    .replace(/[─│┌┐└┘├┤┬┴┼╔╗╚╝╠╣╦╩╬═║]+/g, "") // Box drawing characters
+    .replace(/[⏺⎿✅✓✔✗✘➜➤●○◉◎■□▪▫►▶◀◁★☆❯❮⚡⚠️🔴🟢🟡⬛⬜]+/gu, "") // CLI decorative symbols
+    .replace(/\n{2,}/g, "\n") // 連続改行
+    .trim();
+
+  return cleaned.length > maxLength ? cleaned.slice(0, maxLength) + "..." : cleaned;
+}
+
+/** 読み上げ停止 */
+export function stopSpeech(): void {
+  if (isTTSSupported()) {
+    speechSynthesis.cancel();
+  }
+}
+
+/**
+ * 読み上げ実行（cancel方式：前の発話をキャンセルして最新のみ）
+ */
+export function speak(text: string, lang = "ja-JP"): void {
+  if (!isTTSSupported()) return;
+
+  speechSynthesis.cancel(); // 前の発話をキャンセル
+
+  const normalized = normalizeForSpeech(text);
+  if (!normalized) return;
+
+  const utterance = new SpeechSynthesisUtterance(normalized);
+  utterance.lang = lang;
+  utterance.rate = 1.0;
+
+  speechSynthesis.speak(utterance);
+}
+
+// localStorage キー
+const TTS_ENABLED_KEY = "cli-commentator-tts-enabled";
+
+/** localStorage から TTS 有効状態を取得 */
+export function getTTSEnabled(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(TTS_ENABLED_KEY) === "true";
+}
+
+/** localStorage に TTS 有効状態を保存 */
+export function setTTSEnabled(enabled: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(TTS_ENABLED_KEY, String(enabled));
+}


### PR DESCRIPTION
## Summary
- Web Speech API を使用した TTS（読み上げ）機能を追加
- cancel方式：連投時は前の発話をキャンセルして最新のみ読み上げ
- localStorage でトグル状態を永続化

## Changes
- `apps/web/src/lib/tts.ts` - TTS ユーティリティ（新規）
- `apps/web/src/App.tsx` - TTS統合とUIトグル追加

## Features
- TTS ON/OFF トグル（デフォルトOFF）
- TTS非対応環境ではトグル無効＋メッセージ表示
- テキスト正規化（ANSI codes, 罫線文字, CLI記号を除去、500文字制限）
- Safari対策：トグルON時に「読み上げを開始します」と発話
- アンマウント時に読み上げ停止（リロード/遷移時の残留防止）

## Test plan
- [ ] `pnpm dev` でサーバー＋Web UI起動
- [ ] localhost:5173 で「読み上げ（TTS）」トグルが表示される
- [ ] トグルON → 「読み上げを開始します」と発話される
- [ ] commentary が届くと読み上げられる
- [ ] 連投時、前の発話がキャンセルされて最新のみ読み上げられる
- [ ] ページリロード後もトグル状態が維持される
- [ ] `pnpm -C apps/server test` が全て通る（269件）

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)