### PR TITLE
feat(web): TTS settings (voice/rate/pitch/volume)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
 import { ProfileSelector } from "./components/ProfileSelector";
 import { ProfileEditor } from "./components/ProfileEditor";
-import { isTTSSupported, speak, stopSpeech, getTTSEnabled, setTTSEnabled } from "./lib/tts";
+import {
+  isTTSSupported,
+  speak,
+  stopSpeech,
+  getTTSEnabled,
+  setTTSEnabled,
+  getTTSSettings,
+  setTTSSettings,
+  waitForVoices,
+  DEFAULT_TTS_SETTINGS,
+  type TTSSettings,
+} from "./lib/tts";
 import type { Style, SourceState, Profile, ProfileSummary, CreateProfileInput } from "./types";
 
 type Msg =
@@ -164,8 +175,13 @@ export default function App() {
 
   // TTS state
   const [ttsEnabled, setTtsEnabledState] = useState(() => getTTSEnabled());
+  const [ttsSettings, setTtsSettingsState] = useState<TTSSettings>(() => getTTSSettings());
+  const [ttsSettingsOpen, setTtsSettingsOpen] = useState(false);
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [voicesLoaded, setVoicesLoaded] = useState(false);
   const ttsSupported = isTTSSupported();
   const ttsEnabledRef = useRef(ttsEnabled);
+  const ttsSettingsRef = useRef(ttsSettings);
 
   const wsUrl = useMemo(() => {
     const port = import.meta.env.VITE_WS_PORT ?? "8787";
@@ -177,6 +193,19 @@ export default function App() {
     ttsEnabledRef.current = ttsEnabled;
   }, [ttsEnabled]);
 
+  useEffect(() => {
+    ttsSettingsRef.current = ttsSettings;
+  }, [ttsSettings]);
+
+  // Load available voices
+  useEffect(() => {
+    if (!ttsSupported) return;
+    waitForVoices().then((v) => {
+      setVoices(v);
+      setVoicesLoaded(true);
+    });
+  }, [ttsSupported]);
+
   // TTS cleanup on unmount (prevent orphan speech on reload/navigation)
   useEffect(() => () => stopSpeech(), []);
 
@@ -185,10 +214,20 @@ export default function App() {
     setTTSEnabled(enabled);
     if (enabled) {
       // Safari対策: ユーザー操作をトリガーに一言喋らせる
-      speak("読み上げを開始します");
+      speak("読み上げを開始します", ttsSettings);
     } else {
       stopSpeech();
+      setTtsSettingsOpen(false);
     }
+  };
+
+  const handleTTSSettingsChange = (newSettings: TTSSettings) => {
+    setTtsSettingsState(newSettings);
+    setTTSSettings(newSettings);
+  };
+
+  const handleTestSpeak = () => {
+    speak("これはテスト読み上げです。設定を確認してください。", ttsSettings);
   };
 
   useEffect(() => {
@@ -244,7 +283,7 @@ export default function App() {
                 setItems((prev) => [...prev, { ts: msg.ts, text: msg.text }].slice(-200));
                 // TTS: 有効なら読み上げ
                 if (ttsEnabledRef.current) {
-                  speak(msg.text);
+                  speak(msg.text, ttsSettingsRef.current);
                 }
               }
               break;
@@ -482,12 +521,178 @@ export default function App() {
           />
           読み上げ（TTS）
         </label>
+        {ttsSupported && ttsEnabled && (
+          <button
+            onClick={() => setTtsSettingsOpen((prev) => !prev)}
+            style={{
+              fontSize: 12,
+              padding: "2px 8px",
+              cursor: "pointer",
+              backgroundColor: ttsSettingsOpen ? "#e5e7eb" : "transparent",
+              border: "1px solid #d1d5db",
+              borderRadius: 4,
+            }}
+          >
+            {ttsSettingsOpen ? "▼ 設定" : "▶ 設定"}
+          </button>
+        )}
         {!ttsSupported && (
           <span style={{ fontSize: 12, color: "#ef4444" }}>
             ※ このブラウザはTTS非対応です
           </span>
         )}
       </div>
+
+      {/* TTS Settings Panel */}
+      {ttsSupported && ttsEnabled && ttsSettingsOpen && (
+        <div
+          style={{
+            margin: "0 0 12px 0",
+            padding: 12,
+            backgroundColor: "#f9fafb",
+            border: "1px solid #e5e7eb",
+            borderRadius: 8,
+            fontSize: 13,
+          }}
+        >
+          {/* Voice Select */}
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+              音声:
+            </label>
+            {voices.length > 0 ? (
+              <select
+                value={ttsSettings.voiceURI ?? ""}
+                onChange={(e) =>
+                  handleTTSSettingsChange({
+                    ...ttsSettings,
+                    voiceURI: e.target.value || null,
+                  })
+                }
+                style={{ width: "100%", padding: 4 }}
+              >
+                <option value="">デフォルト</option>
+                {voices.map((v) => (
+                  <option key={v.voiceURI} value={v.voiceURI}>
+                    {v.name} ({v.lang})
+                  </option>
+                ))}
+              </select>
+            ) : voicesLoaded ? (
+              <span style={{ color: "#6b7280" }}>音声一覧は取得できません（デフォルト音声のみ）</span>
+            ) : (
+              <span style={{ color: "#6b7280" }}>音声リストを読み込み中...</span>
+            )}
+          </div>
+
+          {/* Rate Slider */}
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+              速度: {ttsSettings.rate.toFixed(1)}
+            </label>
+            <input
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.1"
+              value={ttsSettings.rate}
+              onChange={(e) =>
+                handleTTSSettingsChange({
+                  ...ttsSettings,
+                  rate: parseFloat(e.target.value),
+                })
+              }
+              style={{ width: "100%" }}
+            />
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+              <span>遅い (0.5)</span>
+              <span>速い (2.0)</span>
+            </div>
+          </div>
+
+          {/* Pitch Slider */}
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+              音程: {ttsSettings.pitch.toFixed(1)}
+            </label>
+            <input
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.1"
+              value={ttsSettings.pitch}
+              onChange={(e) =>
+                handleTTSSettingsChange({
+                  ...ttsSettings,
+                  pitch: parseFloat(e.target.value),
+                })
+              }
+              style={{ width: "100%" }}
+            />
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+              <span>低い (0.5)</span>
+              <span>高い (2.0)</span>
+            </div>
+          </div>
+
+          {/* Volume Slider */}
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+              音量: {Math.round(ttsSettings.volume * 100)}%
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.1"
+              value={ttsSettings.volume}
+              onChange={(e) =>
+                handleTTSSettingsChange({
+                  ...ttsSettings,
+                  volume: parseFloat(e.target.value),
+                })
+              }
+              style={{ width: "100%" }}
+            />
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+              <span>0%</span>
+              <span>100%</span>
+            </div>
+          </div>
+
+          {/* Test & Reset Buttons */}
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              onClick={handleTestSpeak}
+              style={{
+                padding: "6px 12px",
+                backgroundColor: "#3b82f6",
+                color: "white",
+                border: "none",
+                borderRadius: 4,
+                cursor: "pointer",
+                fontSize: 12,
+              }}
+            >
+              テスト読み上げ
+            </button>
+            <button
+              onClick={() => handleTTSSettingsChange(DEFAULT_TTS_SETTINGS)}
+              style={{
+                padding: "6px 12px",
+                backgroundColor: "#6b7280",
+                color: "white",
+                border: "none",
+                borderRadius: 4,
+                cursor: "pointer",
+                fontSize: 12,
+              }}
+            >
+              リセット
+            </button>
+          </div>
+        </div>
+      )}
 
       <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 8 }}>
         Ruleset: {sourceLabel}

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -1,11 +1,86 @@
 /**
  * TTS (Text-to-Speech) utilities using Web Speech API
  * Sprint 24: cancel方式（最新のみ読み上げ）
+ * Sprint 25: TTS設定（voice/rate/pitch/volume）
  */
+
+/** TTS 設定 */
+export interface TTSSettings {
+  voiceURI: string | null; // null = default voice
+  rate: number;   // 0.1 - 10 (default: 1.0)
+  pitch: number;  // 0 - 2 (default: 1.0)
+  volume: number; // 0 - 1 (default: 1.0)
+}
+
+/** デフォルト設定 */
+export const DEFAULT_TTS_SETTINGS: TTSSettings = {
+  voiceURI: null,
+  rate: 1.0,
+  pitch: 1.0,
+  volume: 1.0,
+};
 
 /** TTS サポート判定 */
 export function isTTSSupported(): boolean {
   return typeof window !== "undefined" && "speechSynthesis" in window;
+}
+
+/**
+ * 利用可能な音声リストを取得
+ * 注意: 音声リストは非同期でロードされる場合がある（特にChrome）
+ */
+export function getVoices(): SpeechSynthesisVoice[] {
+  if (!isTTSSupported()) return [];
+  return speechSynthesis.getVoices();
+}
+
+/**
+ * 音声リストの読み込みを待機
+ * Chrome等では初回呼び出し時に空配列が返るため、onvoiceschanged を待つ
+ */
+export function waitForVoices(timeoutMs = 3000): Promise<SpeechSynthesisVoice[]> {
+  return new Promise((resolve) => {
+    if (!isTTSSupported()) {
+      resolve([]);
+      return;
+    }
+
+    const voices = speechSynthesis.getVoices();
+    if (voices.length > 0) {
+      resolve(voices);
+      return;
+    }
+
+    // 音声がまだロードされていない場合、イベントを待つ
+    // 既存ハンドラを退避してチェーン
+    const prevHandler = speechSynthesis.onvoiceschanged;
+    let resolved = false;
+
+    const cleanup = () => {
+      speechSynthesis.onvoiceschanged = prevHandler;
+    };
+
+    const timeoutId = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        resolve(speechSynthesis.getVoices());
+      }
+    }, timeoutMs);
+
+    speechSynthesis.onvoiceschanged = (ev) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeoutId);
+        cleanup();
+        resolve(speechSynthesis.getVoices());
+      }
+      // 元のハンドラも呼ぶ
+      if (prevHandler) {
+        prevHandler.call(speechSynthesis, ev);
+      }
+    };
+  });
 }
 
 /**
@@ -31,8 +106,15 @@ export function stopSpeech(): void {
 
 /**
  * 読み上げ実行（cancel方式：前の発話をキャンセルして最新のみ）
+ * @param text 読み上げるテキスト
+ * @param options TTS設定（省略時はデフォルト）
+ * @param lang 言語コード（デフォルト: ja-JP）
  */
-export function speak(text: string, lang = "ja-JP"): void {
+export function speak(
+  text: string,
+  options: Partial<TTSSettings> = {},
+  lang = "ja-JP"
+): void {
   if (!isTTSSupported()) return;
 
   speechSynthesis.cancel(); // 前の発話をキャンセル
@@ -40,15 +122,29 @@ export function speak(text: string, lang = "ja-JP"): void {
   const normalized = normalizeForSpeech(text);
   if (!normalized) return;
 
+  const settings = { ...DEFAULT_TTS_SETTINGS, ...options };
+
   const utterance = new SpeechSynthesisUtterance(normalized);
   utterance.lang = lang;
-  utterance.rate = 1.0;
+  utterance.rate = settings.rate;
+  utterance.pitch = settings.pitch;
+  utterance.volume = settings.volume;
+
+  // 指定された音声を設定
+  if (settings.voiceURI) {
+    const voices = speechSynthesis.getVoices();
+    const voice = voices.find((v) => v.voiceURI === settings.voiceURI);
+    if (voice) {
+      utterance.voice = voice;
+    }
+  }
 
   speechSynthesis.speak(utterance);
 }
 
 // localStorage キー
 const TTS_ENABLED_KEY = "cli-commentator-tts-enabled";
+const TTS_SETTINGS_KEY = "cli-commentator-tts-settings";
 
 /** localStorage から TTS 有効状態を取得 */
 export function getTTSEnabled(): boolean {
@@ -60,4 +156,38 @@ export function getTTSEnabled(): boolean {
 export function setTTSEnabled(enabled: boolean): void {
   if (typeof localStorage === "undefined") return;
   localStorage.setItem(TTS_ENABLED_KEY, String(enabled));
+}
+
+/** 数値をクランプ */
+function clamp(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+/** localStorage から TTS 設定を取得（サニタイズ付き） */
+export function getTTSSettings(): TTSSettings {
+  if (typeof localStorage === "undefined") return DEFAULT_TTS_SETTINGS;
+  try {
+    const stored = localStorage.getItem(TTS_SETTINGS_KEY);
+    if (!stored) return DEFAULT_TTS_SETTINGS;
+    const parsed = JSON.parse(stored) as Record<string, unknown>;
+    return {
+      voiceURI: typeof parsed.voiceURI === "string" ? parsed.voiceURI : null,
+      rate: clamp(parsed.rate, 0.1, 10, DEFAULT_TTS_SETTINGS.rate),
+      pitch: clamp(parsed.pitch, 0, 2, DEFAULT_TTS_SETTINGS.pitch),
+      volume: clamp(parsed.volume, 0, 1, DEFAULT_TTS_SETTINGS.volume),
+    };
+  } catch {
+    return DEFAULT_TTS_SETTINGS;
+  }
+}
+
+/** localStorage に TTS 設定を保存 */
+export function setTTSSettings(settings: TTSSettings): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(TTS_SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // localStorage full or unavailable - fail silently
+  }
 }


### PR DESCRIPTION
## Summary

- TTS toggleの下に展開可能な設定パネルを追加
- Voice選択（Chrome非同期ロード対応）、Rate/Pitch/Volumeスライダー
- テスト読み上げボタン、リセットボタン
- localStorageに設定を永続化（サニタイズ付き）

## Changes

| File | Description |
|------|-------------|
| `apps/web/src/lib/tts.ts` | `TTSSettings` type, `speak()` options対応, `waitForVoices()`, localStorage persistence with clamp |
| `apps/web/src/App.tsx` | 展開可能な設定UI, voice/rate/pitch/volume controls |

## Safety measures

- **voicesLoaded state**: 音声リスト取得失敗時に「音声一覧は取得できません（デフォルト音声のみ）」表示
- **onvoiceschanged handler chaining**: 既存ハンドラを退避→復元、元ハンドラもチェーン呼び出し
- **localStorage sanitization**: `clamp()` + 型チェックで壊れた値でもfallback

## Behavior preserved

- Cancel方式（新commentary→前の発話をキャンセル）
- Safari/iOS: toggle ON時に「読み上げを開始します」（user gesture対策）
- Unmount/toggle OFF時にspeech停止＋設定パネル閉じる

## Test plan

- [ ] Toggle ON → 設定ボタン表示確認
- [ ] Voice選択 → テスト読み上げで反映確認
- [ ] Rate/Pitch/Volume調整 → テスト読み上げで反映確認
- [ ] リロード後も設定が維持される
- [ ] Safari/iOSで音声リスト取得不可時のメッセージ確認

## Notes

- `apps/web lint` の5エラーは既存（本PRで増加なし）
- インラインstyle使用は最小導線のため許容、次のUX整備でCSS側へ寄せる予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)