### PR TITLE
feat(web): implement CSS design tokens and skin switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,64 @@ pnpm smoke:llm --all
 - タイムアウト保護: `comment()` は `COMMENT_TIMEOUT_MS` 後に自動でルールベースにフォールバック（Sprint 8）
 - AbortController 対応: LLM リクエストに signal を渡して abort 可能（Sprint 8）
 
+## Design Tokens & Skins
+
+Web UIはCSSカスタムプロパティ（デザイントークン）でスタイリングされており、スキン切替に対応している。
+
+### 利用可能なスキン
+
+| スキン | 説明 |
+|--------|------|
+| `standard` | デフォルト。ダーク/ライトモードに対応 |
+| `brutalism` | ブルータリズムスタイル。角丸なし、ハードシャドウ |
+| `paper` | 紙風の温かみのあるスタイル。セリフフォント |
+
+スキンはWeb UIのセレクターから切り替え可能。選択はlocalStorageに保存される。
+
+### トークン構造
+
+```
+apps/web/src/
+├── index.css    # トークン定義 + スキン上書き
+└── App.css      # コンポーネントクラス定義
+```
+
+### 主要トークン
+
+| カテゴリ | トークン例 |
+|----------|-----------|
+| 背景色 | `--color-bg-primary`, `--color-bg-secondary`, `--panel-bg` |
+| 文字色 | `--color-fg-primary`, `--color-fg-secondary`, `--color-fg-muted` |
+| アクセント | `--color-accent`, `--color-accent-hover` |
+| セマンティック | `--color-success`, `--color-warning`, `--color-danger` |
+| ボーダー | `--color-border`, `--color-border-strong` |
+| シャドウ | `--shadow-sm`, `--shadow-md`, `--shadow-lg` |
+| 角丸 | `--radius-sm`, `--radius-md`, `--radius-lg` |
+| スペーシング | `--space-1` ~ `--space-8` |
+| タイポグラフィ | `--text-sm`, `--text-base`, `--text-lg` |
+
+### 新規UIを追加する際のガイドライン
+
+1. **必ずトークン参照を使用** - 直書きの色コード禁止
+2. **App.cssにクラス定義** - インラインスタイルはトークン参照のみ許可
+3. **スキン切替テスト** - Standard/Brutalism/Paperで動作確認
+
+```css
+/* Good */
+.my-component {
+  background-color: var(--panel-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+/* Bad */
+.my-component {
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+```
+
 ## Typical Use Cases
 
 ### 1. PTYモード（デフォルト）

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: var(--space-8);
   text-align: center;
 }
 
@@ -11,9 +11,11 @@
   will-change: filter;
   transition: filter 300ms;
 }
+
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: var(--logo-hover-filter);
 }
+
 .logo.react:hover {
   filter: drop-shadow(0 0 2em #61dafbaa);
 }
@@ -34,9 +36,260 @@
 }
 
 .card {
-  padding: 2em;
+  padding: var(--space-8);
 }
 
 .read-the-docs {
-  color: #888;
+  color: var(--color-fg-muted);
+}
+
+/* ============================================
+   Component Utility Classes
+   ============================================ */
+
+/* Status indicator */
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+}
+
+.status-indicator--connected {
+  background-color: var(--status-connected);
+}
+
+.status-indicator--connecting {
+  background-color: var(--status-connecting);
+}
+
+.status-indicator--disconnected {
+  background-color: var(--status-disconnected);
+}
+
+/* Panel (border is full shorthand token) */
+.panel {
+  background-color: var(--panel-bg);
+  border: var(--panel-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+/* Debug Panel */
+.debug-panel {
+  position: fixed;
+  top: var(--space-2);
+  right: var(--space-2);
+  padding: var(--space-3);
+  background-color: var(--color-bg-secondary);
+  color: var(--color-fg-primary);
+  border: var(--panel-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  z-index: var(--z-debug);
+  min-width: 180px;
+}
+
+.debug-panel__title {
+  font-weight: var(--font-bold);
+  margin-bottom: var(--space-2);
+}
+
+.debug-panel__status {
+  margin-bottom: var(--space-2);
+  line-height: 1.6;
+}
+
+.debug-panel__meta {
+  font-size: var(--text-xs);
+  color: var(--color-fg-tertiary);
+}
+
+.debug-panel__alert {
+  margin-top: var(--space-1);
+}
+
+.debug-panel__alert--crash {
+  color: var(--color-danger);
+}
+
+.debug-panel__alert--warning {
+  color: var(--color-warning);
+}
+
+.debug-panel__actions {
+  display: flex;
+  gap: var(--space-1);
+}
+
+/* Log container */
+.log-container {
+  border: var(--panel-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  height: 60vh;
+  overflow: auto;
+}
+
+/* Log item (border is full shorthand token) */
+.log-item {
+  padding: var(--space-2) 0;
+  border-bottom: var(--list-border);
+}
+
+.log-item:last-child {
+  border-bottom: none;
+}
+
+.log-item__time {
+  font-size: var(--text-sm);
+  color: var(--color-fg-tertiary);
+}
+
+.log-item__text {
+  font-size: var(--text-lg);
+}
+
+/* TTS Settings Panel */
+.tts-settings {
+  margin: 0 0 var(--space-3) 0;
+  padding: var(--space-3);
+  background-color: var(--panel-bg);
+  border: var(--panel-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+}
+
+.tts-settings__field {
+  margin-bottom: var(--space-3);
+}
+
+.tts-settings__label {
+  display: block;
+  margin-bottom: var(--space-1);
+  font-weight: var(--font-medium);
+}
+
+.tts-settings__range-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+}
+
+.tts-settings__helper {
+  color: var(--color-fg-muted);
+}
+
+.tts-settings__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* Settings toggle button */
+.settings-toggle {
+  font-size: var(--text-sm);
+  padding: 2px var(--space-2);
+  cursor: pointer;
+  background-color: transparent;
+  border: var(--btn-border);
+  border-radius: var(--radius-sm);
+}
+
+.settings-toggle--active {
+  background-color: var(--color-bg-tertiary);
+}
+
+/* Modal (border is full shorthand token) */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--modal-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal-backdrop);
+}
+
+.modal {
+  background-color: var(--modal-bg);
+  border-radius: var(--radius-md);
+  border: var(--modal-border);
+  padding: var(--space-6);
+  width: 480px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: var(--shadow-lg);
+}
+
+.modal__title {
+  margin: 0 0 var(--space-4) 0;
+}
+
+/* Form field */
+.form-field {
+  margin-bottom: var(--space-4);
+}
+
+.form-field__label {
+  display: block;
+  margin-bottom: var(--space-1);
+  font-weight: var(--font-medium);
+}
+
+.form-field__required {
+  color: var(--color-danger);
+}
+
+.form-field__helper {
+  font-size: var(--text-sm);
+  color: var(--color-fg-muted);
+  margin-top: var(--space-1);
+}
+
+.form-field__input {
+  width: 100%;
+}
+
+/* Form actions */
+.form-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+/* Control row (e.g., style selector, TTS toggle) */
+.control-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  margin: var(--space-3) 0;
+}
+
+.control-row__label {
+  font-size: var(--text-base);
+  color: var(--color-fg-secondary);
+}
+
+/* Error message */
+.error-message {
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+  margin-top: var(--space-2);
+}
+
+/* Skin selector */
+.skin-selector {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin: var(--space-3) 0;
+}
+
+.skin-selector__label {
+  font-size: var(--text-sm);
+  color: var(--color-fg-secondary);
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,8 @@ import {
 } from "./lib/tts";
 import type { Style, SourceState, Profile, ProfileSummary, CreateProfileInput } from "./types";
 
+export type Skin = "standard" | "brutalism" | "paper";
+
 type Msg =
   | { kind: "hello"; style: Style; source: SourceState }
   | { kind: "style"; style: Style }
@@ -97,60 +99,50 @@ function TauriDebugPanel() {
     }
   };
 
+  const getStatusColor = (actual: string) => {
+    if (actual === "alive") return "var(--color-success)";
+    if (actual === "dead") return "var(--color-danger)";
+    return "var(--color-warning)";
+  };
+
   return (
-    <div style={{
-      position: "fixed",
-      top: 8,
-      right: 8,
-      padding: 12,
-      backgroundColor: "#1e293b",
-      color: "#e2e8f0",
-      borderRadius: 8,
-      fontSize: 12,
-      zIndex: 9999,
-      minWidth: 180,
-    }}>
-      <div style={{ fontWeight: "bold", marginBottom: 8 }}>Tauri Debug</div>
+    <div className="debug-panel">
+      <div className="debug-panel__title">Tauri Debug</div>
 
       {status && (
-        <div style={{ marginBottom: 8, lineHeight: 1.6 }}>
+        <div className="debug-panel__status">
           <div>Desired: {status.desired}</div>
-          <div>Actual: <span style={{
-            color: status.actual === "alive" ? "#22c55e" :
-                   status.actual === "dead" ? "#ef4444" : "#f59e0b"
-          }}>{status.actual}</span></div>
-          <div>Health: <span style={{
-            color: status.health_ok ? "#22c55e" : "#ef4444"
-          }}>{status.health_ok ? "OK" : "NG"}</span></div>
+          <div>Actual: <span style={{ color: getStatusColor(status.actual) }}>{status.actual}</span></div>
+          <div>Health: <span style={{ color: status.health_ok ? "var(--color-success)" : "var(--color-danger)" }}>{status.health_ok ? "OK" : "NG"}</span></div>
           <div>PID: {status.pid ?? "-"} (port {status.port})</div>
           {status.started_at && (
-            <div style={{ fontSize: 10, opacity: 0.7 }}>
+            <div className="debug-panel__meta">
               Started: {new Date(status.started_at).toLocaleTimeString()}
             </div>
           )}
           {status.last_seen_at && (
-            <div style={{ fontSize: 10, opacity: 0.7 }}>
+            <div className="debug-panel__meta">
               Last seen: {new Date(status.last_seen_at).toLocaleTimeString()}
             </div>
           )}
           {status.crash_suspected && (
-            <div style={{ color: "#ef4444", marginTop: 4 }}>Crash suspected</div>
+            <div className="debug-panel__alert debug-panel__alert--crash">Crash suspected</div>
           )}
           {status.orphan_suspected && (
-            <div style={{ color: "#f59e0b", marginTop: 4 }}>Orphan: port in use</div>
+            <div className="debug-panel__alert debug-panel__alert--warning">Orphan: port in use</div>
           )}
           {status.actual === "alive" && !status.health_ok && (
-            <div style={{ color: "#f59e0b", marginTop: 4 }}>Health check failed</div>
+            <div className="debug-panel__alert debug-panel__alert--warning">Health check failed</div>
           )}
           {status.diagnostics && (
-            <div style={{ fontSize: 10, opacity: 0.6, marginTop: 4 }}>
+            <div className="debug-panel__meta">
               [{status.diagnostics}]
             </div>
           )}
         </div>
       )}
 
-      <div style={{ display: "flex", gap: 4 }}>
+      <div className="debug-panel__actions">
         <button onClick={handleStart} style={{ padding: "4px 8px" }}>Start</button>
         <button onClick={handleStop} style={{ padding: "4px 8px" }}>Stop</button>
       </div>
@@ -163,6 +155,10 @@ export default function App() {
   const [style, setStyle] = useState<Style>("kansai");
   const [source, setSource] = useState<SourceState>({ mode: "auto", detected: null });
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("connecting");
+  const [skin, setSkin] = useState<Skin>(() => {
+    const saved = localStorage.getItem("cli-commentator-skin");
+    return (saved as Skin) || "standard";
+  });
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -187,6 +183,12 @@ export default function App() {
     const port = import.meta.env.VITE_WS_PORT ?? "8787";
     return `ws://localhost:${port}`;
   }, []);
+
+  // Apply skin to document
+  useEffect(() => {
+    document.documentElement.setAttribute("data-skin", skin);
+    localStorage.setItem("cli-commentator-skin", skin);
+  }, [skin]);
 
   // TTS ref sync (to avoid stale closure in WebSocket handler)
   useEffect(() => {
@@ -453,27 +455,37 @@ export default function App() {
         : "auto (detecting)"
       : source.mode;
 
+  const getStatusIndicatorClass = () => {
+    switch (connectionStatus) {
+      case "connected":
+        return "status-indicator status-indicator--connected";
+      case "connecting":
+      case "reconnecting":
+        return "status-indicator status-indicator--connecting";
+      default:
+        return "status-indicator status-indicator--disconnected";
+    }
+  };
+
   return (
-    <div style={{ maxWidth: 900, margin: "0 auto", padding: 16 }}>
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "var(--space-4)" }}>
       <TauriDebugPanel />
       <h1>CLI 実況（MVP）</h1>
 
+      {/* Skin selector */}
+      <div className="skin-selector">
+        <span className="skin-selector__label">スキン：</span>
+        <select value={skin} onChange={(e) => setSkin(e.target.value as Skin)}>
+          <option value="standard">Standard</option>
+          <option value="brutalism">Brutalism</option>
+          <option value="paper">Paper</option>
+        </select>
+      </div>
+
       {/* Connection status indicator */}
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12, fontSize: 12 }}>
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor:
-              connectionStatus === "connected"
-                ? "#22c55e"
-                : connectionStatus === "connecting" || connectionStatus === "reconnecting"
-                ? "#f59e0b"
-                : "#ef4444",
-          }}
-        />
-        <span style={{ opacity: 0.7 }}>
+      <div className="control-row" style={{ fontSize: "var(--text-sm)" }}>
+        <span className={getStatusIndicatorClass()} />
+        <span style={{ color: "var(--color-fg-secondary)" }}>
           {connectionStatus === "connected" && "接続中"}
           {connectionStatus === "connecting" && "接続しています..."}
           {connectionStatus === "reconnecting" && "再接続しています..."}
@@ -482,7 +494,7 @@ export default function App() {
       </div>
 
       {/* Profile Selector */}
-      <div style={{ margin: "12px 0", padding: "12px", backgroundColor: "#f5f5f5", borderRadius: 8 }}>
+      <div className="panel" style={{ margin: "var(--space-3) 0" }}>
         <ProfileSelector
           profiles={profiles}
           activeId={activeProfileId}
@@ -493,51 +505,44 @@ export default function App() {
           onDelete={handleDeleteProfile}
         />
         {profileError && (
-          <div style={{ color: "#ef4444", fontSize: 12, marginTop: 8 }}>
+          <div className="error-message">
             エラー: {profileError}
           </div>
         )}
       </div>
 
-      <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "12px 0" }}>
-        <label style={{ fontSize: 14, opacity: 0.8 }}>口調：</label>
+      <div className="control-row">
+        <label className="control-row__label">口調：</label>
         <select value={style} onChange={(e) => sendStyle(e.target.value as Style)}>
           <option value="standard">標準</option>
           <option value="kansai">関西弁</option>
           <option value="zundamon">ずんだもん風（テキスト）</option>
         </select>
-        <span style={{ fontSize: 12, opacity: 0.6 }}>（イベント時＋最大2秒に1回）</span>
+        <span style={{ fontSize: "var(--text-sm)", color: "var(--color-fg-tertiary)" }}>（イベント時＋最大2秒に1回）</span>
       </div>
 
       {/* TTS Toggle */}
-      <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "12px 0" }}>
-        <label style={{ fontSize: 14, opacity: 0.8, cursor: ttsSupported ? "pointer" : "not-allowed" }}>
+      <div className="control-row">
+        <label className="control-row__label" style={{ cursor: ttsSupported ? "pointer" : "not-allowed" }}>
           <input
             type="checkbox"
             checked={ttsEnabled}
             onChange={(e) => handleTTSToggle(e.target.checked)}
             disabled={!ttsSupported}
-            style={{ marginRight: 8 }}
+            style={{ marginRight: "var(--space-2)" }}
           />
           読み上げ（TTS）
         </label>
         {ttsSupported && ttsEnabled && (
           <button
             onClick={() => setTtsSettingsOpen((prev) => !prev)}
-            style={{
-              fontSize: 12,
-              padding: "2px 8px",
-              cursor: "pointer",
-              backgroundColor: ttsSettingsOpen ? "#e5e7eb" : "transparent",
-              border: "1px solid #d1d5db",
-              borderRadius: 4,
-            }}
+            className={`settings-toggle ${ttsSettingsOpen ? "settings-toggle--active" : ""}`}
           >
             {ttsSettingsOpen ? "▼ 設定" : "▶ 設定"}
           </button>
         )}
         {!ttsSupported && (
-          <span style={{ fontSize: 12, color: "#ef4444" }}>
+          <span style={{ fontSize: "var(--text-sm)", color: "var(--color-danger)" }}>
             ※ このブラウザはTTS非対応です
           </span>
         )}
@@ -545,21 +550,10 @@ export default function App() {
 
       {/* TTS Settings Panel */}
       {ttsSupported && ttsEnabled && ttsSettingsOpen && (
-        <div
-          style={{
-            margin: "0 0 12px 0",
-            padding: 12,
-            backgroundColor: "#f9fafb",
-            border: "1px solid #e5e7eb",
-            borderRadius: 8,
-            fontSize: 13,
-          }}
-        >
+        <div className="tts-settings">
           {/* Voice Select */}
-          <div style={{ marginBottom: 12 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
-              音声:
-            </label>
+          <div className="tts-settings__field">
+            <label className="tts-settings__label">音声:</label>
             {voices.length > 0 ? (
               <select
                 value={ttsSettings.voiceURI ?? ""}
@@ -569,7 +563,7 @@ export default function App() {
                     voiceURI: e.target.value || null,
                   })
                 }
-                style={{ width: "100%", padding: 4 }}
+                style={{ width: "100%", padding: "var(--space-1)" }}
               >
                 <option value="">デフォルト</option>
                 {voices.map((v) => (
@@ -579,15 +573,15 @@ export default function App() {
                 ))}
               </select>
             ) : voicesLoaded ? (
-              <span style={{ color: "#6b7280" }}>音声一覧は取得できません（デフォルト音声のみ）</span>
+              <span className="tts-settings__helper">音声一覧は取得できません（デフォルト音声のみ）</span>
             ) : (
-              <span style={{ color: "#6b7280" }}>音声リストを読み込み中...</span>
+              <span className="tts-settings__helper">音声リストを読み込み中...</span>
             )}
           </div>
 
           {/* Rate Slider */}
-          <div style={{ marginBottom: 12 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="tts-settings__field">
+            <label className="tts-settings__label">
               速度: {ttsSettings.rate.toFixed(1)}
             </label>
             <input
@@ -604,15 +598,15 @@ export default function App() {
               }
               style={{ width: "100%" }}
             />
-            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+            <div className="tts-settings__range-labels">
               <span>遅い (0.5)</span>
               <span>速い (2.0)</span>
             </div>
           </div>
 
           {/* Pitch Slider */}
-          <div style={{ marginBottom: 12 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="tts-settings__field">
+            <label className="tts-settings__label">
               音程: {ttsSettings.pitch.toFixed(1)}
             </label>
             <input
@@ -629,15 +623,15 @@ export default function App() {
               }
               style={{ width: "100%" }}
             />
-            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+            <div className="tts-settings__range-labels">
               <span>低い (0.5)</span>
               <span>高い (2.0)</span>
             </div>
           </div>
 
           {/* Volume Slider */}
-          <div style={{ marginBottom: 12 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="tts-settings__field">
+            <label className="tts-settings__label">
               音量: {Math.round(ttsSettings.volume * 100)}%
             </label>
             <input
@@ -654,55 +648,33 @@ export default function App() {
               }
               style={{ width: "100%" }}
             />
-            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "#9ca3af" }}>
+            <div className="tts-settings__range-labels">
               <span>0%</span>
               <span>100%</span>
             </div>
           </div>
 
           {/* Test & Reset Buttons */}
-          <div style={{ display: "flex", gap: 8 }}>
-            <button
-              onClick={handleTestSpeak}
-              style={{
-                padding: "6px 12px",
-                backgroundColor: "#3b82f6",
-                color: "white",
-                border: "none",
-                borderRadius: 4,
-                cursor: "pointer",
-                fontSize: 12,
-              }}
-            >
+          <div className="tts-settings__actions">
+            <button onClick={handleTestSpeak} className="btn-primary">
               テスト読み上げ
             </button>
-            <button
-              onClick={() => handleTTSSettingsChange(DEFAULT_TTS_SETTINGS)}
-              style={{
-                padding: "6px 12px",
-                backgroundColor: "#6b7280",
-                color: "white",
-                border: "none",
-                borderRadius: 4,
-                cursor: "pointer",
-                fontSize: 12,
-              }}
-            >
+            <button onClick={() => handleTTSSettingsChange(DEFAULT_TTS_SETTINGS)} className="btn-secondary">
               リセット
             </button>
           </div>
         </div>
       )}
 
-      <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 8 }}>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--color-fg-secondary)", marginBottom: "var(--space-2)" }}>
         Ruleset: {sourceLabel}
       </div>
 
-      <div style={{ border: "1px solid #ccc", borderRadius: 8, padding: 12, height: "60vh", overflow: "auto" }}>
+      <div className="log-container">
         {items.map((it, idx) => (
-          <div key={idx} style={{ padding: "6px 0", borderBottom: "1px dashed #ddd" }}>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>{new Date(it.ts).toLocaleTimeString()}</div>
-            <div style={{ fontSize: 16 }}>{it.text}</div>
+          <div key={idx} className="log-item">
+            <div className="log-item__time">{new Date(it.ts).toLocaleTimeString()}</div>
+            <div className="log-item__text">{it.text}</div>
           </div>
         ))}
       </div>

--- a/apps/web/src/components/ProfileEditor.tsx
+++ b/apps/web/src/components/ProfileEditor.tsx
@@ -91,66 +91,45 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
 
   return (
     <div
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: "rgba(0, 0, 0, 0.5)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 1000,
-      }}
+      className="modal-backdrop"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div
-        style={{
-          backgroundColor: "#fff",
-          borderRadius: 8,
-          padding: 24,
-          width: 480,
-          maxWidth: "90vw",
-          maxHeight: "90vh",
-          overflow: "auto",
-        }}
-      >
-        <h2 style={{ margin: "0 0 16px 0" }}>
+      <div className="modal">
+        <h2 className="modal__title">
           {isEditing ? "プロファイルを編集" : "新規プロファイル"}
         </h2>
 
         <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
-              名前 <span style={{ color: "#ef4444" }}>*</span>
+          <div className="form-field">
+            <label className="form-field__label">
+              名前 <span className="form-field__required">*</span>
             </label>
             <input
               type="text"
               value={input.name}
               onChange={(e) => setInput({ ...input, name: e.target.value })}
               placeholder="例: Claude Code開発用"
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             />
           </div>
 
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
-              コマンド <span style={{ color: "#ef4444" }}>*</span>
+          <div className="form-field">
+            <label className="form-field__label">
+              コマンド <span className="form-field__required">*</span>
             </label>
             <input
               type="text"
               value={input.cmd}
               onChange={(e) => setInput({ ...input, cmd: e.target.value })}
               placeholder="例: /bin/zsh"
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             />
           </div>
 
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="form-field">
+            <label className="form-field__label">
               引数（スペース区切り）
             </label>
             <input
@@ -158,12 +137,12 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
               value={input.args}
               onChange={(e) => setInput({ ...input, args: e.target.value })}
               placeholder="例: -l -i"
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             />
           </div>
 
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="form-field">
+            <label className="form-field__label">
               作業ディレクトリ
             </label>
             <input
@@ -171,18 +150,18 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
               value={input.cwd}
               onChange={(e) => setInput({ ...input, cwd: e.target.value })}
               placeholder="例: /home/user/project（空欄で現在のディレクトリ）"
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             />
           </div>
 
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="form-field">
+            <label className="form-field__label">
               口調
             </label>
             <select
               value={input.style}
               onChange={(e) => setInput({ ...input, style: e.target.value as Style })}
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             >
               {STYLES.map((s) => (
                 <option key={s.value} value={s.value}>
@@ -192,14 +171,14 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
             </select>
           </div>
 
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="form-field">
+            <label className="form-field__label">
               ルールセット
             </label>
             <select
               value={input.logSource}
               onChange={(e) => setInput({ ...input, logSource: e.target.value as SourceMode })}
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             >
               {LOG_SOURCES.map((s) => (
                 <option key={s.value} value={s.value}>
@@ -209,14 +188,14 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
             </select>
           </div>
 
-          <div style={{ marginBottom: 24 }}>
-            <label style={{ display: "block", marginBottom: 4, fontWeight: 500 }}>
+          <div className="form-field" style={{ marginBottom: "var(--space-6)" }}>
+            <label className="form-field__label">
               LLMプロバイダー
             </label>
             <select
               value={input.llmProvider}
               onChange={(e) => setInput({ ...input, llmProvider: e.target.value as ProviderName | "" })}
-              style={{ width: "100%", padding: 8, borderRadius: 4, border: "1px solid #ccc" }}
+              className="form-field__input"
             >
               {LLM_PROVIDERS.map((p) => (
                 <option key={p.value} value={p.value}>
@@ -224,35 +203,21 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
                 </option>
               ))}
             </select>
-            <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>
+            <div className="form-field__helper">
               ※ APIキーは環境変数で設定してください
             </div>
           </div>
 
-          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <div className="form-actions">
             <button
               type="button"
               onClick={onCancel}
-              style={{
-                padding: "8px 16px",
-                borderRadius: 4,
-                border: "1px solid #ccc",
-                backgroundColor: "#fff",
-                cursor: "pointer",
-              }}
             >
               キャンセル
             </button>
             <button
               type="submit"
-              style={{
-                padding: "8px 16px",
-                borderRadius: 4,
-                border: "none",
-                backgroundColor: "#3b82f6",
-                color: "#fff",
-                cursor: "pointer",
-              }}
+              className="btn-primary"
             >
               {isEditing ? "更新" : "作成"}
             </button>

--- a/apps/web/src/components/ProfileSelector.tsx
+++ b/apps/web/src/components/ProfileSelector.tsx
@@ -26,8 +26,8 @@ export function ProfileSelector({
   };
 
   return (
-    <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-      <label style={{ fontSize: 14, opacity: 0.8 }}>プロファイル：</label>
+    <div className="control-row" style={{ flexWrap: "wrap" }}>
+      <label className="control-row__label">プロファイル：</label>
       <select
         value={activeId ?? ""}
         onChange={(e) => onSelect(e.target.value || null)}
@@ -64,11 +64,8 @@ export function ProfileSelector({
           <button
             onClick={() => handleDelete(activeId)}
             disabled={disabled}
-            style={{
-              padding: "4px 8px",
-              cursor: disabled ? "not-allowed" : "pointer",
-              color: "#ef4444",
-            }}
+            className="btn-danger"
+            style={{ padding: "4px 8px", cursor: disabled ? "not-allowed" : "pointer" }}
             title="削除"
           >
             削除

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,25 +1,366 @@
+/* ============================================
+   Design Tokens
+   ============================================
+
+   Structure:
+   1. Base tokens (raw values)
+   2. Semantic tokens (colors with meaning)
+   3. Component tokens (btn/input/panel)
+   4. Skin overrides (data-skin selectors)
+   ============================================ */
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  /* ==========================================
+     1. Base Tokens
+     ========================================== */
 
+  /* === Typography === */
+  --font-sans: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --font-serif: Georgia, 'Times New Roman', serif;
+  --font-mono: ui-monospace, SFMono-Regular, Consolas, monospace;
+
+  --text-xs: 10px;
+  --text-sm: 12px;
+  --text-base: 14px;
+  --text-lg: 16px;
+  --text-xl: 18px;
+  --text-2xl: 24px;
+  --text-3xl: 32px;
+
+  --font-normal: 400;
+  --font-medium: 500;
+  --font-bold: 700;
+
+  --leading-tight: 1.25;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.75;
+
+  /* === Spacing === */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  /* === Border Radius === */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  /* === Z-Index === */
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-modal-backdrop: 900;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-debug: 9999;
+
+  /* === Transitions === */
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
+  --transition-slow: 350ms ease;
+
+  /* ==========================================
+     2. Semantic Tokens
+     ========================================== */
+
+  /* === Background Colors === */
+  --color-bg-primary: #242424;
+  --color-bg-secondary: #1e293b;
+  --color-bg-tertiary: #1a1a1a;
+  --color-bg-surface: #2d2d2d;
+  --color-bg-elevated: #363636;
+
+  /* === Foreground Colors === */
+  --color-fg-primary: rgba(255, 255, 255, 0.87);
+  --color-fg-secondary: rgba(255, 255, 255, 0.7);
+  --color-fg-tertiary: rgba(255, 255, 255, 0.5);
+  --color-fg-muted: #888;
+
+  /* === Accent Colors === */
+  --color-accent: #646cff;
+  --color-accent-hover: #535bf2;
+  --color-accent-active: #4a4ed6;
+
+  /* === Semantic Colors === */
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #3b82f6;
+
+  /* === Border Colors === */
+  --color-border: rgba(255, 255, 255, 0.15);
+  --color-border-strong: rgba(255, 255, 255, 0.25);
+  --color-border-muted: rgba(255, 255, 255, 0.1);
+
+  /* === Shadow === */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.4);
+
+  /* === Logo hover effect (filter value) === */
+  --logo-hover-filter: drop-shadow(0 0 2em var(--color-accent));
+
+  /* ==========================================
+     3. Component Tokens
+     ========================================== */
+
+  /* Button (border is full shorthand) */
+  --btn-bg: var(--color-bg-tertiary);
+  --btn-bg-hover: var(--color-bg-elevated);
+  --btn-border: 1px solid transparent;
+  --btn-border-hover: 1px solid var(--color-accent);
+  --btn-text: var(--color-fg-primary);
+
+  --btn-primary-bg: var(--color-info);
+  --btn-primary-text: #fff;
+  --btn-primary-hover: #2563eb;
+
+  --btn-secondary-bg: #6b7280;
+  --btn-secondary-text: #fff;
+  --btn-secondary-hover: #4b5563;
+
+  --btn-danger-bg: var(--color-danger);
+  --btn-danger-text: #fff;
+  --btn-danger-hover: #dc2626;
+  --btn-danger-border: 1px solid var(--color-danger);
+
+  /* Input (border is full shorthand) */
+  --input-bg: var(--color-bg-surface);
+  --input-border: 1px solid var(--color-border-strong);
+  --input-border-focus: 1px solid var(--color-accent);
+  --input-text: var(--color-fg-primary);
+  --input-placeholder: var(--color-fg-tertiary);
+
+  /* Panel / Card */
+  --panel-bg: var(--color-bg-secondary);
+  --panel-border: 1px solid var(--color-border);
+
+  /* Modal */
+  --modal-backdrop: rgba(0, 0, 0, 0.5);
+  --modal-bg: var(--color-bg-primary);
+  --modal-border: 1px solid var(--color-border);
+
+  /* List Item */
+  --list-border: 1px dashed var(--color-border-muted);
+  --list-hover-bg: var(--color-bg-surface);
+
+  /* Status Indicator */
+  --status-connected: var(--color-success);
+  --status-connecting: var(--color-warning);
+  --status-disconnected: var(--color-danger);
+
+  /* ==========================================
+     Base settings (applied to :root)
+     ========================================== */
+  font-family: var(--font-sans);
+  line-height: var(--leading-normal);
+  font-weight: var(--font-normal);
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: var(--color-fg-primary);
+  background-color: var(--color-bg-primary);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+/* ============================================
+   Light Mode (OS preference)
+   ============================================ */
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg-primary: #ffffff;
+    --color-bg-secondary: #f9fafb;
+    --color-bg-tertiary: #f3f4f6;
+    --color-bg-surface: #ffffff;
+    --color-bg-elevated: #f9f9f9;
+
+    --color-fg-primary: #213547;
+    --color-fg-secondary: rgba(33, 53, 71, 0.8);
+    --color-fg-tertiary: rgba(33, 53, 71, 0.6);
+    --color-fg-muted: #6b7280;
+
+    --color-accent-hover: #747bff;
+
+    --color-border: rgba(0, 0, 0, 0.1);
+    --color-border-strong: rgba(0, 0, 0, 0.2);
+    --color-border-muted: rgba(0, 0, 0, 0.06);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
+
+    --input-bg: #fff;
+    --input-border: 1px solid #d1d5db;
+
+    --panel-bg: #f5f5f5;
+
+    --modal-bg: #fff;
+  }
 }
+
+/* ============================================
+   4. Skin Overrides
+   ============================================ */
+
+/* Skin: Standard (Default) - uses base tokens */
+html[data-skin="standard"] {
+  /* No overrides needed */
+}
+
+/* Skin: Brutalism */
+html[data-skin="brutalism"] {
+  /* Semantic colors */
+  --color-bg-primary: #f5f5dc;
+  --color-bg-secondary: #fffef0;
+  --color-bg-tertiary: #e8e8cc;
+  --color-bg-surface: #ffffff;
+  --color-bg-elevated: #fffff5;
+
+  --color-fg-primary: #000;
+  --color-fg-secondary: #222;
+  --color-fg-tertiary: #444;
+  --color-fg-muted: #666;
+
+  --color-accent: #ff0000;
+  --color-accent-hover: #cc0000;
+  --color-accent-active: #990000;
+
+  --color-border: #000;
+  --color-border-strong: #000;
+  --color-border-muted: #333;
+
+  /* Shadow - hard offset style */
+  --shadow-sm: 3px 3px 0 #000;
+  --shadow-md: 5px 5px 0 #000;
+  --shadow-lg: 8px 8px 0 #000;
+
+  /* Logo hover - no glow effect */
+  --logo-hover-filter: none;
+
+  /* Border radius - none */
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
+  --radius-full: 0;
+
+  /* Button (full border shorthand) */
+  --btn-bg: #fff;
+  --btn-bg-hover: #f0f0d0;
+  --btn-border: 2px solid #000;
+  --btn-border-hover: 2px solid #000;
+  --btn-danger-hover: #cc0000;
+  --btn-danger-border: 2px solid var(--color-danger);
+
+  --btn-primary-bg: #000;
+  --btn-primary-text: #fff;
+  --btn-primary-hover: #333;
+
+  /* Input (full border shorthand) */
+  --input-bg: #fff;
+  --input-border: 2px solid #000;
+  --input-border-focus: 2px solid var(--color-accent);
+
+  /* Panel */
+  --panel-bg: #fffef0;
+  --panel-border: 2px solid #000;
+
+  /* Modal */
+  --modal-bg: #fff;
+  --modal-border: 2px solid #000;
+
+  /* List */
+  --list-border: 2px dashed #333;
+}
+
+html[data-skin="brutalism"] button {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--font-bold);
+}
+
+/* Skin: Paper */
+html[data-skin="paper"] {
+  /* Use serif font via token */
+  --font-sans: Georgia, 'Times New Roman', serif;
+
+  /* Semantic colors - warm tones */
+  --color-bg-primary: #faf8f5;
+  --color-bg-secondary: #f5f2ed;
+  --color-bg-tertiary: #ebe7e0;
+  --color-bg-surface: #fff;
+  --color-bg-elevated: #fffefb;
+
+  --color-fg-primary: #3d3d3d;
+  --color-fg-secondary: #5a5a5a;
+  --color-fg-tertiary: #808080;
+  --color-fg-muted: #a0a0a0;
+
+  --color-accent: #8b7355;
+  --color-accent-hover: #705d46;
+  --color-accent-active: #5c4d3a;
+
+  --color-success: #5d8a66;
+  --color-warning: #c9a227;
+  --color-danger: #b85450;
+  --color-info: #6b8cae;
+
+  --color-border: rgba(139, 115, 85, 0.2);
+  --color-border-strong: rgba(139, 115, 85, 0.35);
+  --color-border-muted: rgba(139, 115, 85, 0.1);
+
+  /* Shadow - soft style */
+  --shadow-sm: 0 1px 3px rgba(139, 115, 85, 0.08);
+  --shadow-md: 0 2px 8px rgba(139, 115, 85, 0.12);
+  --shadow-lg: 0 4px 16px rgba(139, 115, 85, 0.16);
+
+  /* Logo hover - no glow */
+  --logo-hover-filter: none;
+
+  /* Border radius - subtle */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+
+  /* Button (full border shorthand) */
+  --btn-bg: var(--color-bg-tertiary);
+  --btn-bg-hover: var(--color-bg-elevated);
+  --btn-border: 1px solid var(--color-border-strong);
+  --btn-border-hover: 1px solid var(--color-accent);
+  --btn-danger-hover: #a04845;
+  --btn-danger-border: 1px solid var(--color-danger);
+
+  --btn-primary-bg: var(--color-accent);
+  --btn-primary-hover: var(--color-accent-hover);
+
+  /* Input (full border shorthand) */
+  --input-border: 1px solid var(--color-border-strong);
+  --input-border-focus: 1px solid var(--color-accent);
+
+  /* Panel */
+  --panel-bg: var(--color-bg-secondary);
+  --panel-border: 1px solid var(--color-border);
+
+  /* List */
+  --list-border: 1px dashed var(--color-border-muted);
+}
+
+/* ============================================
+   Base Element Styles
+   ============================================ */
+a {
+  font-weight: var(--font-medium);
+  color: var(--color-accent);
+  text-decoration: inherit;
+  transition: color var(--transition-fast);
+}
+
 a:hover {
-  color: #535bf2;
+  color: var(--color-accent-hover);
 }
 
 body {
@@ -31,38 +372,110 @@ body {
 }
 
 h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  font-size: var(--text-3xl);
+  line-height: var(--leading-tight);
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  border: var(--btn-border);
   padding: 0.6em 1.2em;
   font-size: 1em;
-  font-weight: 500;
+  font-weight: var(--font-medium);
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--btn-bg);
+  color: var(--btn-text);
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: border var(--transition-base), background-color var(--transition-base);
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:hover {
+  border: var(--btn-border-hover);
+  background-color: var(--btn-bg-hover);
+}
+
+button:focus,
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Primary button class */
+.btn-primary {
+  background-color: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border-color: var(--btn-primary-bg);
+}
+
+.btn-primary:hover {
+  background-color: var(--btn-primary-hover);
+  border-color: var(--btn-primary-hover);
+}
+
+/* Secondary button class */
+.btn-secondary {
+  background-color: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
+  border-color: var(--btn-secondary-bg);
+}
+
+.btn-secondary:hover {
+  background-color: var(--btn-secondary-hover);
+  border-color: var(--btn-secondary-hover);
+}
+
+/* Danger button class */
+.btn-danger {
+  color: var(--color-danger);
+  border: var(--btn-danger-border);
+}
+
+.btn-danger:hover {
+  background-color: var(--btn-danger-hover);
+  color: var(--btn-danger-text);
+  border: var(--btn-danger-border);
+}
+
+/* Input styles */
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="password"],
+select,
+textarea {
+  background-color: var(--input-bg);
+  border: var(--input-border);
+  border-radius: var(--radius-sm);
+  color: var(--input-text);
+  padding: var(--space-2);
+  font-family: inherit;
+  font-size: inherit;
+  transition: border var(--transition-fast);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border: var(--input-border-focus);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--input-placeholder);
+}
+
+/* Range input */
+input[type="range"] {
+  accent-color: var(--color-accent);
+}
+
+/* Checkbox */
+input[type="checkbox"] {
+  accent-color: var(--color-accent);
 }


### PR DESCRIPTION
## Summary
- CSSデザイントークンシステムを導入、スキン切替機能を実装
- 3スキン: Standard (OS追従), Brutalism, Paper

## Note
WS未接続時のエラー表示は別PRに分離しました → #74

## Test plan
- [ ] Standard ⇄ Brutalism ⇄ Paper 切替
- [ ] 各スキンでボーダー/シャドウが正しく表示
- [ ] hover時にレイアウトシフトなし
- [ ] pnpm -C apps/web build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)