### PR TITLE
fix(web): profile actions show error when WS disconnected

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -274,11 +274,15 @@
   color: var(--color-fg-secondary);
 }
 
-/* Error message */
+/* Error message (used in ProfileSelector and ProfileEditor modal) */
 .error-message {
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.10);
   color: var(--color-danger);
   font-size: var(--text-sm);
-  margin-top: var(--space-2);
 }
 
 /* Skin selector */

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -261,6 +261,7 @@ export default function App() {
         if (cancelled) return;
         console.log("WebSocket connected");
         setConnectionStatus("connected");
+        setProfileError(null); // Clear WS offline error on reconnect
         reconnectAttemptRef.current = 0;
       };
 
@@ -384,9 +385,11 @@ export default function App() {
 
   // Profile handlers
   const handleSelectProfile = (id: string | null) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ kind: "setActiveProfile", id }));
+    if (wsRef.current?.readyState !== WebSocket.OPEN) {
+      setProfileError("サーバーに接続されていません");
+      return;
     }
+    wsRef.current.send(JSON.stringify({ kind: "setActiveProfile", id }));
   };
 
   const handleEditProfile = (id: string) => {
@@ -413,9 +416,11 @@ export default function App() {
   };
 
   const handleDeleteProfile = (id: string) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ kind: "deleteProfile", id }));
+    if (wsRef.current?.readyState !== WebSocket.OPEN) {
+      setProfileError("サーバーに接続されていません");
+      return;
     }
+    wsRef.current.send(JSON.stringify({ kind: "deleteProfile", id }));
   };
 
   const handleSaveProfile = (input: {
@@ -428,19 +433,21 @@ export default function App() {
     logSource: SourceState["mode"];
     llmProvider: string;
   }) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      const profile: CreateProfileInput & { id?: string } = {
-        id: input.id,
-        name: input.name,
-        cmd: input.cmd,
-        args: input.args.split(" ").filter(Boolean),
-        cwd: input.cwd || undefined,
-        style: input.style,
-        logSource: input.logSource,
-        llmProvider: input.llmProvider as CreateProfileInput["llmProvider"],
-      };
-      wsRef.current.send(JSON.stringify({ kind: "saveProfile", profile }));
+    if (wsRef.current?.readyState !== WebSocket.OPEN) {
+      setProfileError("サーバーに接続されていません。再接続を待ってください。");
+      return;
     }
+    const profile: CreateProfileInput & { id?: string } = {
+      id: input.id,
+      name: input.name,
+      cmd: input.cmd,
+      args: input.args.split(" ").filter(Boolean),
+      cwd: input.cwd || undefined,
+      style: input.style,
+      logSource: input.logSource,
+      llmProvider: input.llmProvider as CreateProfileInput["llmProvider"],
+    };
+    wsRef.current.send(JSON.stringify({ kind: "saveProfile", profile }));
   };
 
   const handleCancelEdit = () => {
@@ -683,6 +690,7 @@ export default function App() {
       {editingProfile && (
         <ProfileEditor
           profile={editingProfile === "new" ? null : editingProfile}
+          error={profileError}
           onSave={handleSaveProfile}
           onCancel={handleCancelEdit}
         />

--- a/apps/web/src/components/ProfileEditor.tsx
+++ b/apps/web/src/components/ProfileEditor.tsx
@@ -14,6 +14,7 @@ type ProfileInput = {
 
 type Props = {
   profile?: Profile | null;
+  error?: string | null;
   onSave: (profile: ProfileInput) => void;
   onCancel: () => void;
 };
@@ -67,7 +68,7 @@ function profileToInput(profile: Profile): ProfileInput {
   };
 }
 
-export function ProfileEditor({ profile, onSave, onCancel }: Props) {
+export function ProfileEditor({ profile, error, onSave, onCancel }: Props) {
   const [input, setInput] = useState<ProfileInput>(createEmptyInput);
 
   useEffect(() => {
@@ -207,6 +208,8 @@ export function ProfileEditor({ profile, onSave, onCancel }: Props) {
               ※ APIキーは環境変数で設定してください
             </div>
           </div>
+
+          {error && <div className="error-message">{error}</div>}
 
           <div className="form-actions">
             <button


### PR DESCRIPTION
## Summary
- WS未接続時、Profile作成/選択/削除が無反応にならないようエラー表示を追加
- モーダル内にエラー表示（`.error-message` クラス使用）
- WS復帰時にエラー自動クリア

## Changes
- `handleSelectProfile`: 接続チェック + エラー表示
- `handleDeleteProfile`: 接続チェック + エラー表示  
- `handleSaveProfile`: 接続チェック + 再接続案内付きエラー表示
- `ProfileEditor`: `error` prop + `.error-message` クラスで表示
- `ws.onopen`: `setProfileError(null)` で復帰時にエラークリア

## Note
- #73マージ後にリベース済み
- `.error-message` は #73側のトークン定義を拡張して利用（背景・ボーダー追加）

## Test plan
- [ ] サーバー停止状態でプロファイル選択 → ProfileSelector下にエラー表示
- [ ] サーバー停止状態でプロファイル削除 → ProfileSelector下にエラー表示
- [ ] サーバー停止状態でプロファイル作成 → **モーダル内にエラー表示**
- [ ] サーバー起動後 → **エラーが自動で消える**
- [ ] 再操作 → 正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)