### PR TITLE
chore(web): clear profile error on action start

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -385,6 +385,7 @@ export default function App() {
 
   // Profile handlers
   const handleSelectProfile = (id: string | null) => {
+    setProfileError(null);
     if (wsRef.current?.readyState !== WebSocket.OPEN) {
       setProfileError("サーバーに接続されていません");
       return;
@@ -416,6 +417,7 @@ export default function App() {
   };
 
   const handleDeleteProfile = (id: string) => {
+    setProfileError(null);
     if (wsRef.current?.readyState !== WebSocket.OPEN) {
       setProfileError("サーバーに接続されていません");
       return;
@@ -433,6 +435,7 @@ export default function App() {
     logSource: SourceState["mode"];
     llmProvider: string;
   }) => {
+    setProfileError(null);
     if (wsRef.current?.readyState !== WebSocket.OPEN) {
       setProfileError("サーバーに接続されていません。再接続を待ってください。");
       return;


### PR DESCRIPTION
## Summary
- Clear `profileError` at the start of each profile operation (Select/Delete/Save)
- Prevents stale error messages from persisting when multiple operations are attempted in sequence

## Changes
- `apps/web/src/App.tsx`: Added `setProfileError(null)` at the start of:
  - `handleSelectProfile`
  - `handleDeleteProfile`
  - `handleSaveProfile`

## Test plan
- [ ] WS切断中にSelect/Delete/Save → エラー表示
- [ ] 続けて別操作 → 古いエラーがクリアされ新しいエラー表示
- [ ] WS復帰 → エラー自動消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)