### PR TITLE
feat(profile): fetch full profile detail on edit via WS

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -312,6 +312,22 @@ wss.on("connection", async (ws) => {
           break;
         }
 
+        case "getProfile": {
+          try {
+            const id = msg.id;
+            if (!id) throw new Error("Missing profile id");
+            const profile = await profileManager.get(id);
+            if (!profile) {
+              ws.send(JSON.stringify({ kind: "profileError", error: `Profile not found: ${id}` }));
+            } else {
+              ws.send(JSON.stringify({ kind: "profileDetail", profile }));
+            }
+          } catch (err) {
+            ws.send(JSON.stringify({ kind: "profileError", error: String(err) }));
+          }
+          break;
+        }
+
         case "saveProfile": {
           try {
             const input = msg.profile;

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,4 +1,4 @@
-import type { ProfileSummary, CreateProfileInput, UpdateProfileInput } from "./profile/types.js";
+import type { Profile, ProfileSummary, CreateProfileInput, UpdateProfileInput } from "./profile/types.js";
 
 export type Style = "standard" | "kansai" | "zundamon";
 export type DetectedSource = "claude" | "codex" | "generic";
@@ -40,6 +40,7 @@ export type WsOutgoing =
   | { kind: "profiles"; profiles: ProfileSummary[]; activeId: string | null }
   | { kind: "profileSaved"; profile: ProfileSummary; activeId: string | null }
   | { kind: "profileDeleted"; id: string; activeId: string | null }
+  | { kind: "profileDetail"; profile: Profile }
   | { kind: "profileError"; error: string }
   // PTY messages
   | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
@@ -49,6 +50,7 @@ export type WsIncoming =
   | { kind: "setStyle"; style: Style }
   // Profile messages
   | { kind: "getProfiles" }
+  | { kind: "getProfile"; id: string }
   | { kind: "saveProfile"; profile: CreateProfileInput & { id?: string } }
   | { kind: "deleteProfile"; id: string }
   | { kind: "setActiveProfile"; id: string | null };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,7 @@ type Msg =
   | { kind: "profiles"; profiles: ProfileSummary[]; activeId: string | null }
   | { kind: "profileSaved"; profile: ProfileSummary; activeId: string | null }
   | { kind: "profileDeleted"; id: string; activeId: string | null }
+  | { kind: "profileDetail"; profile: Profile }
   | { kind: "profileError"; error: string }
   | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
   | { kind: "ptyError"; error: string };
@@ -162,12 +163,14 @@ export default function App() {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingEditIdRef = useRef<string | null>(null);
 
   // Profile state
   const [profiles, setProfiles] = useState<ProfileSummary[]>([]);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
-  const [editingProfile, setEditingProfile] = useState<Profile | null | "new">(null);
+  const [editingProfile, setEditingProfile] = useState<Profile | null | "new" | "loading">(null);
   const [profileError, setProfileError] = useState<string | null>(null);
+  const profilesRef = useRef<ProfileSummary[]>([]);
 
   // TTS state
   const [ttsEnabled, setTtsEnabledState] = useState(() => getTTSEnabled());
@@ -198,6 +201,11 @@ export default function App() {
   useEffect(() => {
     ttsSettingsRef.current = ttsSettings;
   }, [ttsSettings]);
+
+  // Profile ref sync (to avoid stale closure in WebSocket handler)
+  useEffect(() => {
+    profilesRef.current = profiles;
+  }, [profiles]);
 
   // Load available voices
   useEffect(() => {
@@ -297,7 +305,7 @@ export default function App() {
               }
               break;
             case "profileSaved":
-              if ("profile" in msg) {
+              if ("profile" in msg && "activeId" in msg) {
                 setProfiles((prev) => {
                   const exists = prev.some((p) => p.id === msg.profile.id);
                   if (exists) {
@@ -316,9 +324,29 @@ export default function App() {
                 setActiveProfileId(msg.activeId);
               }
               break;
+            case "profileDetail":
+              if ("kind" in msg && msg.kind === "profileDetail") {
+                // Verify this is the response for the pending edit request
+                if (pendingEditIdRef.current === msg.profile.id) {
+                  setEditingProfile(msg.profile);
+                  pendingEditIdRef.current = null;
+                }
+              }
+              break;
             case "profileError":
               if ("error" in msg) {
                 setProfileError(msg.error);
+                // If a profile detail fetch was pending, fall back to summary data
+                const pid = pendingEditIdRef.current;
+                if (pid) {
+                  pendingEditIdRef.current = null;
+                  const summary = profilesRef.current.find((p) => p.id === pid);
+                  if (summary) {
+                    setEditingProfile(stubProfileFromSummary(summary));
+                  } else {
+                    setEditingProfile(null);
+                  }
+                }
               }
               break;
             case "ptyRestart":
@@ -383,6 +411,18 @@ export default function App() {
     }
   };
 
+  // Build a stub Profile from summary data with defaults (fallback when detail fetch fails)
+  const stubProfileFromSummary = (summary: ProfileSummary): Profile => ({
+    id: summary.id,
+    name: summary.name,
+    cmd: summary.cmd,
+    args: [],
+    style: "kansai",
+    logSource: "auto",
+    createdAt: 0,
+    updatedAt: 0,
+  });
+
   // Profile handlers
   const handleSelectProfile = (id: string | null) => {
     setProfileError(null);
@@ -394,21 +434,14 @@ export default function App() {
   };
 
   const handleEditProfile = (id: string) => {
-    const profile = profiles.find((p) => p.id === id);
-    if (profile) {
-      // For editing, we need full profile data - for now, create a partial one
-      // In a more complete implementation, we'd fetch the full profile
-      setEditingProfile({
-        id: profile.id,
-        name: profile.name,
-        cmd: profile.cmd,
-        args: [],
-        style: "kansai",
-        logSource: "auto",
-        createdAt: 0,
-        updatedAt: 0,
-      });
+    setProfileError(null);
+    if (wsRef.current?.readyState !== WebSocket.OPEN) {
+      setProfileError("サーバーに接続されていません");
+      return;
     }
+    pendingEditIdRef.current = id;
+    setEditingProfile("loading");
+    wsRef.current.send(JSON.stringify({ kind: "getProfile", id }));
   };
 
   const handleCreateProfile = () => {
@@ -456,6 +489,7 @@ export default function App() {
   const handleCancelEdit = () => {
     setEditingProfile(null);
     setProfileError(null);
+    pendingEditIdRef.current = null;
   };
 
   const sourceLabel =
@@ -693,7 +727,19 @@ export default function App() {
       </div>
 
       {/* Profile Editor Modal */}
-      {editingProfile && (
+      {editingProfile === "loading" && (
+        <div className="modal-backdrop">
+          <div className="modal">
+            <h2 className="modal__title">プロファイルを読み込み中...</h2>
+            <div className="form-actions">
+              <button type="button" onClick={handleCancelEdit}>
+                キャンセル
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {editingProfile && editingProfile !== "loading" && (
         <ProfileEditor
           profile={editingProfile === "new" ? null : editingProfile}
           error={profileError}


### PR DESCRIPTION
## Summary
- Add `getProfile` / `profileDetail` WebSocket message pair to fetch full profile data when clicking Edit
- Frontend shows loading state and fills editor with real values (args, style, logSource, cwd, llmProvider) once received
- Fallback: if detail fetch fails, open editor with summary-derived stub (preserves previous behavior)
- Offline: Edit is blocked when WS is not OPEN (aligns with #83)

## Changes
- `apps/server/src/types.ts`: add `getProfile` (incoming) + `profileDetail` (outgoing)
- `apps/server/src/index.ts`: handle `getProfile` via `profileManager.get(id)`
- `apps/web/src/App.tsx`: request detail on edit, loading modal, handle `profileDetail`, fallback on `profileError`

## How to test
- `pnpm -C apps/server test` — 269 tests pass
- `pnpm -C apps/web build` — TypeScript + Vite build pass
- Manual:
  1. Create profile with non-default fields (args/style/logSource/cwd etc)
  2. Edit → confirm loading indicator → confirm real values populated
  3. Disconnect server → Edit should show offline error
  4. If profile not found → profileError then fallback behavior

> **Note:** `pnpm -C apps/server exec tsc --noEmit` has pre-existing type errors (anthropic.ts, pty/manager.ts, test files) unrelated to this change.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)