### PR TITLE
docs: add CI & Dependabot maintenance notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,3 +299,9 @@ pnpm dev:desktop:managed
 # - PID
 # - Crash/Orphan detection
 ```
+
+## CI & Maintenance
+
+- pnpm workspace では依存更新PRに `pnpm-lock.yaml` が必ず含まれること（無いと lockfile mismatch で CI が落ちやすい）
+- Dependabot PR が DIRTY/CONFLICTING のまま `@dependabot rebase` が効かない場合は `@dependabot recreate` が有効なことがある
+- このリポは merge commit 禁止 → **squash merge** を標準とする


### PR DESCRIPTION
## Summary
- CLAUDE.md 末尾に CI & Maintenance セクションを追加
- pnpm lockfile mismatch、Dependabot rebase/recreate、squash merge 運用ルールを記載

## Test plan
- [x] `pnpm -C apps/server test` — 269 tests pass
- [x] `pnpm -C apps/web build` — TS + Vite build pass
- [ ] CI green 確認後 squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)