### PR TITLE
chore: make node-pty optional and degrade gracefully

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,8 +8,10 @@
   },
   "dependencies": {
     "dotenv": "^17.2.3",
-    "node-pty": "^1.1.0",
     "ws": "^8.19.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.10",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,7 +10,7 @@ import { comment } from "./styles/index.js";
 import { getAutoDetectedSource, resetAutoDetection } from "./rulesets/index.js";
 import * as profileManager from "./profile/manager.js";
 import type { ProfileSummary } from "./profile/types.js";
-import { createPTYManager, configFromProfile, configFromEnv, type PTYConfig } from "./pty/index.js";
+import { createPTYManager, configFromProfile, configFromEnv, getNodePtyError, type PTYConfig } from "./pty/index.js";
 import { createFileTail, type FileTail } from "./input/index.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
@@ -54,6 +54,10 @@ let sourceState: SourceState = {
 let restartInFlight = false;
 let queuedProfileId: string | null | undefined = undefined; // undefined means no queue
 let currentlyRunningProfileId: string | null = null; // Track which profile the PTY is running with
+
+// PTY availability state (for graceful degradation when node-pty build fails)
+let ptyAvailable = true;
+let ptyInitError: string | null = null;
 
 // rate limit: max once per 2s (error is always allowed)
 let lastEmit = 0;
@@ -286,12 +290,28 @@ async function restartPTY(profileId: string | null): Promise<void> {
 }
 
 // --- WebSocket connection handler ---
+// Helper to send a message to a single client
+function sendTo(client: typeof wss.clients extends Set<infer T> ? T : never, msg: WsOutgoing) {
+  if (client.readyState === 1) {
+    client.send(JSON.stringify(msg));
+  }
+}
+
 wss.on("connection", async (ws) => {
   // Send initial state including profiles
   const profiles = await profileManager.list();
   const activeId = await profileManager.getActiveId();
   ws.send(JSON.stringify({ kind: "hello", style: currentStyle, source: sourceState }));
   ws.send(JSON.stringify({ kind: "profiles", profiles, activeId }));
+
+  // Notify client if PTY is unavailable (e.g., node-pty build failed)
+  if (!ptyAvailable && ptyInitError) {
+    sendTo(ws, {
+      kind: "ptyUnavailable",
+      error: ptyInitError,
+      suggestion: "INPUT_MODE=file INPUT_FILE=/path/to/log pnpm dev:server で file 監視モードが使用可能です。",
+    });
+  }
 
   ws.on("message", async (buf) => {
     try {
@@ -483,7 +503,19 @@ if (INPUT_MODE === "pty") {
 
   // Launch initial PTY with environment config
   const initialConfig = configFromEnv();
-  setupPTY(initialConfig, null);
+  try {
+    setupPTY(initialConfig, null);
+  } catch (err) {
+    ptyAvailable = false;
+    ptyInitError = err instanceof Error ? err.message : String(err);
+    // Also check for lazy-load error from getNodePtyError()
+    const loadError = getNodePtyError();
+    if (loadError) {
+      ptyInitError = loadError;
+    }
+    console.error("[WARN] PTY initialization failed:", ptyInitError);
+    console.error("[INFO] Server will continue without PTY. Use INPUT_MODE=file for file monitoring.");
+  }
 } else {
   // File mode: early validation before setupFileTail
   if (!INPUT_FILE) {

--- a/apps/server/src/pty/index.ts
+++ b/apps/server/src/pty/index.ts
@@ -2,6 +2,8 @@ export {
   createPTYManager,
   configFromProfile,
   configFromEnv,
+  isNodePtyAvailable,
+  getNodePtyError,
   type PTYConfig,
   type PTYManager,
 } from "./manager.js";

--- a/apps/server/src/pty/manager.ts
+++ b/apps/server/src/pty/manager.ts
@@ -1,6 +1,68 @@
-import * as pty from "node-pty";
-import type { IPty, IPtyForkOptions } from "node-pty";
+import { createRequire } from "node:module";
 import type { Profile } from "../profile/types.js";
+
+// Local type definitions (to avoid runtime import of node-pty)
+type IPty = {
+  onData: (cb: (data: string) => void) => { dispose: () => void };
+  onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => { dispose: () => void };
+  write: (data: string) => void;
+  kill: (signal?: string) => void;
+  resize: (cols: number, rows: number) => void;
+};
+
+type IPtyForkOptions = {
+  name?: string;
+  cols?: number;
+  rows?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+  useConpty?: boolean;
+};
+
+type NodePty = {
+  spawn: (cmd: string, args: string[], options: IPtyForkOptions) => IPty;
+};
+
+// Lazy-loaded node-pty state
+let nodePty: NodePty | null = null;
+let nodePtyError: string | null = null;
+
+/**
+ * Lazily load node-pty module.
+ * Throws if node-pty is not available (e.g., build failed on Windows without Visual C++ Build Tools).
+ */
+function loadNodePty(): NodePty {
+  if (nodePty) return nodePty;
+  if (nodePtyError) throw new Error(nodePtyError);
+
+  try {
+    const require = createRequire(import.meta.url);
+    nodePty = require("node-pty") as NodePty;
+    return nodePty;
+  } catch (err) {
+    nodePtyError = `node-pty not available: ${err instanceof Error ? err.message : String(err)}. Use INPUT_MODE=file for file monitoring mode.`;
+    throw new Error(nodePtyError);
+  }
+}
+
+/**
+ * Check if node-pty is available without throwing.
+ */
+export function isNodePtyAvailable(): boolean {
+  try {
+    loadNodePty();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the error message if node-pty failed to load.
+ */
+export function getNodePtyError(): string | null {
+  return nodePtyError;
+}
 
 /**
  * PTY configuration for spawning a terminal
@@ -76,6 +138,9 @@ export function createPTYManager(): PTYManager {
     },
 
     spawn(config: PTYConfig): IPty {
+      // Load node-pty lazily (throws if unavailable)
+      const pty = loadNodePty();
+
       // Kill existing PTY if any
       if (currentPty) {
         try {

--- a/apps/server/src/tests/pty.smoke.test.ts
+++ b/apps/server/src/tests/pty.smoke.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { isNodePtyAvailable } from "../pty/manager.js";
+
+const canRunPtyTests = isNodePtyAvailable();
+
+describe.skipIf(!canRunPtyTests)("PTY smoke test", () => {
+  it("spawns a simple command and receives output", async () => {
+    const { createPTYManager } = await import("../pty/manager.js");
+    const manager = createPTYManager();
+
+    const isWindows = process.platform === "win32";
+    const cmd = isWindows ? "cmd.exe" : "bash";
+    const args = isWindows ? ["/c", "echo", "hello-pty-smoke"] : ["-lc", "echo hello-pty-smoke"];
+
+    const ptyProcess = manager.spawn({
+      cmd,
+      args,
+      cwd: process.cwd(),
+    });
+
+    const output = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      const timeout = setTimeout(() => {
+        manager.kill();
+        reject(new Error("PTY timeout after 5s"));
+      }, 5000);
+
+      ptyProcess.onData((chunk) => {
+        data += chunk;
+        if (data.includes("hello-pty-smoke")) {
+          clearTimeout(timeout);
+          manager.kill();
+          resolve(data);
+        }
+      });
+
+      ptyProcess.onExit(() => {
+        clearTimeout(timeout);
+        resolve(data);
+      });
+    });
+
+    expect(output).toContain("hello-pty-smoke");
+  });
+});

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -44,7 +44,8 @@ export type WsOutgoing =
   | { kind: "profileError"; error: string }
   // PTY messages
   | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
-  | { kind: "ptyError"; error: string };
+  | { kind: "ptyError"; error: string }
+  | { kind: "ptyUnavailable"; error: string; suggestion: string };
 
 export type WsIncoming =
   | { kind: "setStyle"; style: Style }

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -304,3 +304,43 @@
   color: var(--color-fg-muted);
   margin-top: var(--space-2);
 }
+
+/* PTY Error Banner (node-pty unavailable) */
+.pty-error-banner {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-toast);
+  padding: var(--space-4);
+  background: var(--color-danger);
+  color: white;
+  border-bottom: 2px solid var(--color-border-strong);
+  margin-bottom: var(--space-4);
+  border-radius: var(--radius-md);
+  text-align: left;
+}
+
+.pty-error-banner strong {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-size: var(--text-lg);
+}
+
+.pty-error-banner p {
+  margin: var(--space-2) 0;
+}
+
+.pty-error-banner .suggestion {
+  font-size: var(--text-sm);
+  opacity: 0.9;
+}
+
+.pty-error-banner a {
+  color: white;
+  text-decoration: underline;
+}
+
+.pty-error-banner code {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,8 @@ type Msg =
   | { kind: "profileDetail"; profile: Profile }
   | { kind: "profileError"; error: string }
   | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
-  | { kind: "ptyError"; error: string };
+  | { kind: "ptyError"; error: string }
+  | { kind: "ptyUnavailable"; error: string; suggestion: string };
 
 type LegacyHello = { type: "hello"; style: Style };
 
@@ -171,6 +172,9 @@ export default function App() {
   const [editingProfile, setEditingProfile] = useState<Profile | null | "new" | "loading">(null);
   const [profileError, setProfileError] = useState<string | null>(null);
   const profilesRef = useRef<ProfileSummary[]>([]);
+
+  // PTY unavailable state (when node-pty build fails)
+  const [ptyUnavailable, setPtyUnavailable] = useState<{ error: string; suggestion: string } | null>(null);
 
   // TTS state
   const [ttsEnabled, setTtsEnabledState] = useState(() => getTTSEnabled());
@@ -359,6 +363,11 @@ export default function App() {
                 setProfileError(`PTY Error: ${msg.error}`);
               }
               break;
+            case "ptyUnavailable":
+              if ("error" in msg && "suggestion" in msg) {
+                setPtyUnavailable({ error: msg.error, suggestion: msg.suggestion });
+              }
+              break;
             default:
               break;
           }
@@ -513,6 +522,24 @@ export default function App() {
 
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "var(--space-4)" }}>
+      {/* PTY unavailable error banner */}
+      {ptyUnavailable && (
+        <div className="pty-error-banner">
+          <strong>PTY 初期化エラー</strong>
+          <p>{ptyUnavailable.error}</p>
+          <p className="suggestion">{ptyUnavailable.suggestion}</p>
+          <p>
+            <a
+              href="https://github.com/gatyoukatyou/cli-commentator/blob/main/docs/getting-started.ja.md#troubleshooting"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              トラブルシューティング
+            </a>
+          </p>
+        </div>
+      )}
+
       <TauriDebugPanel />
       <h1>CLI 実況（MVP）</h1>
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -140,7 +140,22 @@ set PTY_USE_CONPTY=0 && pnpm dev:server
 
 #### node-pty がビルドに失敗する
 
-Visual C++ Build Tools が必要です。
+node-pty のビルドには Visual C++ Build Tools が必要ですが、
+ビルドできない環境でも **file モード** で cli-commentator を使用できます。
+
+**file モードで起動する例:**
+
+```bash
+# 監視したいログファイルを指定
+INPUT_MODE=file INPUT_FILE=/path/to/your-app.log pnpm dev:server
+
+# 別ターミナルで Web UI を起動
+pnpm dev:web
+```
+
+**根本解決したい場合:**
+
+Visual C++ Build Tools をインストールしてください。
 
 **推奨:** Visual Studio Installer で「C++ によるデスクトップ開発」ワークロードをインストール
 
@@ -149,6 +164,12 @@ Visual C++ Build Tools が必要です。
 2. 「変更」→「ワークロード」タブ
 3. 「C++ によるデスクトップ開発」にチェック → インストール
 ```
+
+または [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) を直接インストール:
+
+1. 「C++ によるデスクトップ開発」ワークロードを選択
+2. Node.js を再インストール（または `npm config set msvs_version 2022`）
+3. `pnpm install` を再実行
 
 > **注:** `npm install --global windows-build-tools` は環境によっては途中で止まる報告があるため非推奨。
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,13 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
-      node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^25.0.10
@@ -2635,11 +2636,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-addon-api@7.1.1: {}
+  node-addon-api@7.1.1:
+    optional: true
 
   node-pty@1.1.0:
     dependencies:
       node-addon-api: 7.1.1
+    optional: true
 
   node-releases@2.0.27: {}
 


### PR DESCRIPTION
## Summary
- node-pty を optionalDependencies に移し、lazy-load で起動不能を回避
- PTY 初期化失敗時もサーバを継続起動し、Web UI に ptyUnavailable を通知
- PTY smoke test を追加（node-pty 無い場合はskip）
- Windows の回避策（file モード）を docs に追記

## Changes
| File | Description |
|------|-------------|
| `apps/server/package.json` | node-pty → optionalDependencies |
| `apps/server/src/pty/manager.ts` | lazy-load with createRequire, add isNodePtyAvailable/getNodePtyError |
| `apps/server/src/pty/index.ts` | Export new functions |
| `apps/server/src/index.ts` | PTY init try-catch, ptyUnavailable message |
| `apps/server/src/types.ts` | Add ptyUnavailable type |
| `apps/server/src/tests/pty.smoke.test.ts` | New PTY smoke test |
| `apps/web/src/App.tsx` | ptyUnavailable banner |
| `apps/web/src/App.css` | Banner styles |
| `docs/getting-started.ja.md` | File mode workaround docs |

## Test plan
- [x] `pnpm -C apps/server test` (270 tests pass)
- [x] `pnpm -C apps/web build` (success)
- [ ] CI passes on ubuntu + windows

🤖 Generated with [Claude Code](https://claude.ai/code)