### PR TITLE
chore: make server typecheck pass and add CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Server tests
         run: pnpm -C apps/server test
 
+      - name: Server typecheck
+        run: pnpm -C apps/server exec tsc --noEmit
+
       - name: Web build
         run: pnpm -C apps/web build
 
@@ -59,6 +62,9 @@ jobs:
 
       - name: Server tests
         run: pnpm -C apps/server test
+
+      - name: Server typecheck
+        run: pnpm -C apps/server exec tsc --noEmit
 
       - name: Web build
         run: pnpm -C apps/web build

--- a/apps/server/src/llm/providers/anthropic.ts
+++ b/apps/server/src/llm/providers/anthropic.ts
@@ -1,5 +1,5 @@
 import type { LLMAdapter } from "../adapter.js";
-import type { GenerateTextRequest, GenerateTextResponse } from "../types.js";
+import type { ChatMessage, GenerateTextRequest, GenerateTextResponse } from "../types.js";
 import { CommentError } from "../../errors.js";
 
 const DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
@@ -67,10 +67,10 @@ export function createAnthropicAdapter(
         .join("\n\n");
 
       const messages: AnthropicMessage[] = req.messages
-        .filter((m) => m.role !== "system")
+        .filter((m): m is ChatMessage & { role: "user" | "assistant" } => m.role !== "system")
         .map((m) => ({
           role: m.role,
-          content: [{ type: "text", text: m.content }],
+          content: [{ type: "text" as const, text: m.content }],
         }));
 
       const body: AnthropicRequest = {

--- a/apps/server/src/tests/comment.errors.test.ts
+++ b/apps/server/src/tests/comment.errors.test.ts
@@ -108,7 +108,7 @@ describe("comment() error classification", () => {
 
     const { comment } = await import("../styles/index.js");
 
-    const ev: Event = { ts: Date.now(), type: "cmd", summary: "test" };
+    const ev: Event = { ts: Date.now(), type: "stdout", summary: "test" };
     await comment(ev, "standard");
 
     expect(warnSpy).toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe("comment() error classification", () => {
     // Must re-import after setting env vars
     const { comment } = await import("../styles/index.js");
 
-    const ev: Event = { ts: Date.now(), type: "cmd", summary: "test" };
+    const ev: Event = { ts: Date.now(), type: "stdout", summary: "test" };
     await comment(ev, "standard");
 
     expect(warnSpy).toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe("comment() error classification", () => {
 
     const { comment } = await import("../styles/index.js");
 
-    const ev: Event = { ts: Date.now(), type: "cmd", summary: "test" };
+    const ev: Event = { ts: Date.now(), type: "stdout", summary: "test" };
     await comment(ev, "standard");
 
     expect(logSpy).toHaveBeenCalled();

--- a/apps/server/src/tests/comment.timeout.test.ts
+++ b/apps/server/src/tests/comment.timeout.test.ts
@@ -37,7 +37,7 @@ describe("comment() timeout behavior", () => {
 
     const ev: Event = {
       ts: Date.now(),
-      type: "cmd",
+      type: "stdout",
       summary: "テストコマンド",
     };
 
@@ -62,7 +62,7 @@ describe("comment() timeout behavior", () => {
 
     const ev: Event = {
       ts: Date.now(),
-      type: "cmd",
+      type: "stdout",
       summary: "テストコマンド",
     };
 
@@ -94,7 +94,7 @@ describe("comment() timeout behavior", () => {
 
     const ev: Event = {
       ts: Date.now(),
-      type: "cmd",
+      type: "stdout",
       summary: "テスト",
     };
 


### PR DESCRIPTION
## Summary
- server の `tsc --noEmit` が通るように型エラーを修正
- CI に typecheck ステップを追加して再発を防止

## Changes
| File | Description |
|------|-------------|
| `apps/server/src/llm/providers/anthropic.ts` | 型ガードで non-system メッセージを絞り込み |
| `apps/server/src/tests/comment.errors.test.ts` | `"cmd"` → `"stdout"` (有効な EventType) |
| `apps/server/src/tests/comment.timeout.test.ts` | `"cmd"` → `"stdout"` (有効な EventType) |
| `.github/workflows/ci.yml` | Server typecheck step 追加 (ubuntu + windows) |

## Test plan
- [x] `pnpm -C apps/server test` (270 tests pass)
- [x] `pnpm -C apps/server exec tsc --noEmit` (success)
- [x] `pnpm -C apps/web build` (success)
- [ ] CI passes (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.ai/code)