### PR TITLE
test(server): lock pty-unavailable contract for node-pty failures

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,13 +10,19 @@ import { comment } from "./styles/index.js";
 import { getAutoDetectedSource, resetAutoDetection } from "./rulesets/index.js";
 import * as profileManager from "./profile/manager.js";
 import type { ProfileSummary } from "./profile/types.js";
-import { createPTYManager, configFromProfile, configFromEnv, getNodePtyError, type PTYConfig } from "./pty/index.js";
+import {
+  createPTYManager,
+  configFromProfile,
+  configFromEnv,
+  getNodePtyError,
+  classifyPtyFailure,
+  createPtyUnavailableMessage,
+  type PTYConfig,
+} from "./pty/index.js";
 import { createFileTail, resolveFileFallback, type FileTail } from "./input/index.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
-const PTY_UNAVAILABLE_SUGGESTION =
-  "INPUT_MODE=file INPUT_FILE=/path/to/log pnpm dev:server で file 監視モードが使用可能です。";
 
 // Input mode configuration
 type InputMode = "pty" | "file";
@@ -61,18 +67,6 @@ let currentlyRunningProfileId: string | null = null; // Track which profile the 
 // PTY availability state (for graceful degradation when node-pty build fails)
 let ptyAvailable = true;
 let ptyInitError: string | null = null;
-
-function toErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function createPtyUnavailableMessage(error: string): WsOutgoing {
-  return {
-    kind: "ptyUnavailable",
-    error,
-    suggestion: PTY_UNAVAILABLE_SUGGESTION,
-  };
-}
 
 function markPtyUnavailable(error: string): void {
   ptyAvailable = false;
@@ -299,20 +293,18 @@ async function restartPTY(profileId: string | null): Promise<void> {
     // Update tracking
     currentlyRunningProfileId = profileId;
   } catch (err) {
-    const errorMessage = toErrorMessage(err);
-    const loadError = getNodePtyError();
-    if (loadError || errorMessage.includes("node-pty not available")) {
-      const unavailableError = loadError ?? errorMessage;
-      markPtyUnavailable(unavailableError);
-      broadcast(createPtyUnavailableMessage(unavailableError));
+    const failure = classifyPtyFailure(err, getNodePtyError());
+    if (failure.kind === "ptyUnavailable") {
+      markPtyUnavailable(failure.error);
+      broadcast(createPtyUnavailableMessage(failure.error));
       if (tryStartFileFallback("restart")) {
         console.warn(`[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY restart failure.`);
       }
-      console.error("[WARN] PTY restart failed because node-pty is unavailable:", unavailableError);
+      console.error("[WARN] PTY restart failed because node-pty is unavailable:", failure.error);
       return;
     }
 
-    broadcast({ kind: "ptyError", error: errorMessage });
+    broadcast({ kind: "ptyError", error: failure.error });
     console.error("Failed to restart PTY:", err);
   } finally {
     restartInFlight = false;
@@ -601,15 +593,17 @@ if (INPUT_MODE === "pty") {
     runtimeInputMode = "pty";
     enableStdinPassthrough();
   } catch (err) {
-    const errorMessage = toErrorMessage(err);
-    const loadError = getNodePtyError();
-    const unavailableError = loadError ?? errorMessage;
-    markPtyUnavailable(unavailableError);
-    if (tryStartFileFallback("startup")) {
-      console.warn(`[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY startup failure.`);
+    const failure = classifyPtyFailure(err, getNodePtyError());
+    if (failure.kind === "ptyUnavailable") {
+      markPtyUnavailable(failure.error);
+      if (tryStartFileFallback("startup")) {
+        console.warn(`[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY startup failure.`);
+      }
+      console.error("[WARN] PTY initialization failed:", ptyInitError);
+      console.error("[INFO] Server will continue without PTY. Use INPUT_MODE=file for file monitoring.");
+    } else {
+      console.error("[ERROR] PTY initialization failed:", failure.error);
     }
-    console.error("[WARN] PTY initialization failed:", ptyInitError);
-    console.error("[INFO] Server will continue without PTY. Use INPUT_MODE=file for file monitoring.");
   }
 } else {
   // File mode: early validation before setupFileTail

--- a/apps/server/src/pty/index.ts
+++ b/apps/server/src/pty/index.ts
@@ -7,3 +7,11 @@ export {
   type PTYConfig,
   type PTYManager,
 } from "./manager.js";
+
+export {
+  classifyPtyFailure,
+  createPtyUnavailableMessage,
+  getErrorMessage,
+  PTY_UNAVAILABLE_SUGGESTION,
+  type PtyFailure,
+} from "./unavailable.js";

--- a/apps/server/src/pty/unavailable.ts
+++ b/apps/server/src/pty/unavailable.ts
@@ -1,0 +1,34 @@
+import type { WsOutgoing } from "../types.js";
+
+export const PTY_UNAVAILABLE_SUGGESTION =
+  "INPUT_MODE=file INPUT_FILE=/path/to/log pnpm dev:server で file 監視モードが使用可能です。";
+
+export type PtyFailure =
+  | { kind: "ptyUnavailable"; error: string }
+  | { kind: "ptyError"; error: string };
+
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function classifyPtyFailure(err: unknown, nodePtyError: string | null): PtyFailure {
+  const errorMessage = getErrorMessage(err);
+  if (nodePtyError) {
+    return { kind: "ptyUnavailable", error: nodePtyError };
+  }
+  if (errorMessage.includes("node-pty not available")) {
+    return { kind: "ptyUnavailable", error: errorMessage };
+  }
+  return { kind: "ptyError", error: errorMessage };
+}
+
+export function createPtyUnavailableMessage(
+  error: string,
+  suggestion: string = PTY_UNAVAILABLE_SUGGESTION
+): Extract<WsOutgoing, { kind: "ptyUnavailable" }> {
+  return {
+    kind: "ptyUnavailable",
+    error,
+    suggestion,
+  };
+}

--- a/apps/server/src/tests/pty.unavailable.test.ts
+++ b/apps/server/src/tests/pty.unavailable.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPtyFailure,
+  createPtyUnavailableMessage,
+  getErrorMessage,
+  PTY_UNAVAILABLE_SUGGESTION,
+} from "../pty/unavailable.js";
+
+describe("pty/unavailable", () => {
+  describe("getErrorMessage", () => {
+    it("extracts message from Error instance", () => {
+      expect(getErrorMessage(new Error("boom"))).toBe("boom");
+    });
+
+    it("stringifies unknown values", () => {
+      expect(getErrorMessage("plain-error")).toBe("plain-error");
+      expect(getErrorMessage(42)).toBe("42");
+    });
+  });
+
+  describe("classifyPtyFailure", () => {
+    it("classifies as ptyUnavailable when getNodePtyError value exists", () => {
+      const result = classifyPtyFailure(new Error("other failure"), "node-pty not available: missing binary");
+      expect(result).toEqual({
+        kind: "ptyUnavailable",
+        error: "node-pty not available: missing binary",
+      });
+    });
+
+    it("classifies as ptyUnavailable when error message includes node-pty sentinel", () => {
+      const result = classifyPtyFailure(new Error("node-pty not available: ABI mismatch"), null);
+      expect(result).toEqual({
+        kind: "ptyUnavailable",
+        error: "node-pty not available: ABI mismatch",
+      });
+    });
+
+    it("classifies as ptyError for non node-pty failures", () => {
+      const result = classifyPtyFailure(new Error("spawn ENOENT"), null);
+      expect(result).toEqual({
+        kind: "ptyError",
+        error: "spawn ENOENT",
+      });
+    });
+  });
+
+  describe("createPtyUnavailableMessage", () => {
+    it("builds ptyUnavailable payload with default suggestion", () => {
+      expect(createPtyUnavailableMessage("node-pty missing")).toEqual({
+        kind: "ptyUnavailable",
+        error: "node-pty missing",
+        suggestion: PTY_UNAVAILABLE_SUGGESTION,
+      });
+    });
+
+    it("accepts custom suggestion", () => {
+      expect(createPtyUnavailableMessage("node-pty missing", "custom suggestion")).toEqual({
+        kind: "ptyUnavailable",
+        error: "node-pty missing",
+        suggestion: "custom suggestion",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract PTY failure classification into `pty/unavailable.ts` so the node-pty unavailable contract is testable
- Ensure restart/startup paths in `apps/server/src/index.ts` use the shared classifier instead of ad-hoc string handling
- Add focused tests for:
  - `classifyPtyFailure()` (`ptyUnavailable` vs `ptyError`)
  - `createPtyUnavailableMessage()` payload (`error` + `suggestion`)
  - `getErrorMessage()` normalization

## Why
This locks the Windows mitigation behavior so `node-pty` load failures consistently produce `ptyUnavailable` (not `ptyError`) and keeps WS contract regression-resistant.

## Testing
- pnpm -C apps/server test
- pnpm -C apps/server exec tsc --noEmit
- pnpm -C apps/web lint
- pnpm -C apps/web build
