### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cli-commentator/desktop",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "cli-commentator-desktop"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "process-wrap",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-commentator-desktop"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 [lib]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CLI Commentator",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "identifier": "com.cli-commentator.desktop",
   "build": {
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
## Summary
- bump desktop release version from `0.0.1` to `0.1.0`
- update version fields in:
  - `apps/desktop/src-tauri/tauri.conf.json`
  - `apps/desktop/package.json`
  - `apps/desktop/src-tauri/Cargo.toml`
  - `apps/desktop/src-tauri/Cargo.lock`

## Verification
- `CARGO_HOME=$PWD/.cargo CARGO_TARGET_DIR=$PWD/target-check cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `CARGO_HOME=$PWD/.cargo CARGO_TARGET_DIR=$PWD/target-check cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`

## Follow-up
- after merge, create and push tag `v0.1.0` from updated `main`
- verify `release-desktop` run and draft assets (`latest.json`, signatures, macOS targets)
