### PR TITLE
fix(release): restrict unsigned fallback to smoke tags

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -140,6 +140,14 @@ jobs:
           echo "::warning::Building unsigned artifacts for internal testing (Developer ID / notarization not configured)."
           echo "::warning::Missing secrets: ${{ steps.apple_signing.outputs.missing }}"
 
+      - name: Enforce signed mode for non-smoke tags
+        if: ${{ steps.apple_signing.outputs.enabled != 'true' && startsWith(github.ref_name, 'v') && !startsWith(github.ref_name, 'v0.0.0-smoke.') }}
+        run: |
+          set -euo pipefail
+          echo "::error::Apple signing/notarization secrets are required for non-smoke release tags: ${{ github.ref_name }}"
+          echo "::error::Either configure Apple secrets or use a smoke tag (v0.0.0-smoke.*) for unsigned internal validation."
+          exit 1
+
       - name: Web lint
         run: pnpm -C apps/web lint
 
@@ -175,7 +183,7 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: Build and draft release (unsigned internal)
-        if: ${{ steps.apple_signing.outputs.enabled != 'true' }}
+        if: ${{ steps.apple_signing.outputs.enabled != 'true' && startsWith(github.ref_name, 'v0.0.0-smoke.') }}
         uses: tauri-apps/tauri-action@v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release-runbook.en.md
+++ b/docs/release-runbook.en.md
@@ -28,7 +28,8 @@ Target workflow: `.github/workflows/release-desktop.yml`.
   - Produces release-candidate artifacts
 - `Apple secrets missing`
   - Workflow continues in unsigned internal mode
-  - Draft Release is generated for internal testing only (not for production distribution)
+  - Draft Release is generated only for `v0.0.0-smoke.*` tags (internal testing only)
+  - Normal `vX.Y.Z` tags fail fast and require signed mode
 
 ## 0.5) Latest Dry-Run Record (2026-02-13)
 
@@ -95,6 +96,7 @@ Actions:
 2. Set `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`
 3. Re-run with a new tag and confirm signed mode
 4. If budget is not available yet, continue using unsigned mode for internal validation
+   - unsigned mode is allowed only with `v0.0.0-smoke.*` tags
 
 ### Case C: `tauri-action` build/signing fails
 

--- a/docs/release-runbook.ja.md
+++ b/docs/release-runbook.ja.md
@@ -28,7 +28,8 @@
   - 正式配布候補の成果物を生成
 - `Apple secrets なし`
   - workflow は unsigned internal モードで継続
-  - Draft Release は作成されるが、内部検証用途（正式配布には使わない）
+  - `v0.0.0-smoke.*` タグのみ Draft Release を作成（内部検証用途）
+  - 通常の `vX.Y.Z` タグではエラー終了し、署名モードを強制
 
 ## 0.5) 最新ドライラン結果（2026-02-13）
 
@@ -96,6 +97,7 @@ CLI_COMMENTATOR_FORCE_NO_PTY=1 pnpm -C apps/server test
 2. `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` を登録
 3. Secrets を追加後、新しいタグで signedモード実行を確認
 4. 予算都合で未設定の場合は内部検証用途として運用継続
+   - unsigned 実行は `v0.0.0-smoke.*` タグでのみ可能
 
 ### ケースC: `tauri-action` で署名/ビルド失敗
 


### PR DESCRIPTION
## Summary
- restrict unsigned fallback mode to smoke tags only (`v0.0.0-smoke.*`)
- prevent accidental unsigned drafts on normal release tags (`vX.Y.Z`)
- update JA/EN runbooks to match the stricter policy

## Changes
- `.github/workflows/release-desktop.yml`
  - add guard step: fail fast when Apple secrets are missing on non-smoke tags
  - allow `Build and draft release (unsigned internal)` only on `v0.0.0-smoke.*`
- `docs/release-runbook.ja.md`
  - document smoke-only unsigned operation
- `docs/release-runbook.en.md`
  - document smoke-only unsigned operation

## Verification
- smoke run passed with new guard in place:
  - https://github.com/gatyoukatyou/cli-commentator/actions/runs/21990513441
- release generated as expected:
  - `CLI Commentator v0.0.0-smoke.8 (unsigned internal)`

## Why this matters
- keeps cost-saving unsigned workflow for internal validation
- avoids accidental non-signed artifacts for real release tags
