### PR TITLE
docs: reclassify Sprint 16 remaining work

### DIFF
--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -84,7 +84,7 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 
 ---
 
-## Current status (as of 2026-02-18)
+## Current status (as of 2026-03-15)
 **Done**
 - PR #1: detect boundary tests (mixed => generic, 50-line limit, exported constants)
 - PR #2: add roadmap docs (JA/EN + links from docs/README)
@@ -119,23 +119,22 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 - PR #174: structure server startup-failure classification logs (failure codes + fallback results + regression tests)
 - PR #175: structure server runtime state-transition logs (`[server/state-event]` + integration assertions)
 - PR #178: add v0.2.0 RC decision evidence templates and align links across checklist/runbook/docs index
+- PR #213: align startup failure classification across server / desktop / web / distribution smoke / runbook
+- PR #217: extend known-category recovery guidance test coverage
+- PR #218: suppress Codex progress commentary noise
+- PR #219: reduce duplicate input, lower TTS lag, and strengthen explanation prompts
+- PR #220: record Sprint 16 startup recovery evidence in the release evidence logs
 
 **Now**
-- Ran 2026-02-18 local preflight (`verify:updater`, web lint+build, `CLI_COMMENTATOR_FORCE_NO_PTY=1` server test, failure regression 34/34, desktop distribution smoke) and all checks passed
-- Hardened test assumptions for `CLI_COMMENTATOR_FORCE_NO_PTY=1` by skipping node-pty-required restart failure coverage in that mode, so runbook preflight commands are reproducible
-- Resumed `release-desktop` smoke runs and logged `smoke.01` / `smoke.02` failure causes (missing sidecar node binaries, unsupported runner label, release creation permission error)
-- Added sidecar prepare/verify steps in `.github/workflows/release-desktop.yml` and moved x64 to `macos-15-intel` (`smoke.03` confirmed successful bundling on both arm64/x64)
-- Updated `docs/release-runbook.*` and `docs/release-evidence-log.*` with same-day evidence
-- Merged PR #186 (`fix(release): preflight release write permissions`) and introduced `Verify release publish permissions`
-- Validated preflight + token fallback path with `v0.0.0-smoke.20260219-test` (`release-desktop` run `22185152032`)
-- Configured `GH_RELEASE_TOKEN` and confirmed Draft Release path recovery with `v0.0.0-smoke.20260220-211548` (run `22223734792`)
-- Continue operating docs drift guard and smoke matrix to accumulate v0.2.0 RC readiness evidence
+- Sprint 16 core work is largely landed: startup failure classification, recovery guidance, distribution smoke, and evidence logging are now reflected on main
+- GitHub CI provides green evidence across `desktop_distribution_smoke`, `desktop_check`, `failure_regression`, and the standard test matrix
+- Remaining Sprint 16 work is narrowed to `#214` (done / remaining / blocked reclassification) and `#215` (audit residual `needs manual review` cases and decide on `spawn` sub-classification)
 - Signed release readiness remains blocked by `#138` (Apple certificate/secrets)
 
 **Next**
-- Resolve `#138`, register `APPLE_CERTIFICATE`, and make `pnpm verify:apple-signing` pass
-- While paid Apple certificates are deferred, continue unsigned-internal validation with `v0.0.0-smoke.*` tags
-- Continue expanding startup-failure regression coverage (distribution startup and signing-mode differences)
+- As `#214`, reclassify Sprint 16 into `done / remaining / blocked` and compress carry-over candidates to one or two items
+- As `#215`, audit remaining `needs manual review` cases and decide whether `spawn` sub-classification belongs in this sprint or the next one
+- Resolve `#138` and resume signed/notarized release readiness work
 
 ---
 
@@ -170,6 +169,18 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 **Definition of done**
 - Clean environment can complete install -> launch -> commentary start
 - Major startup failures can be triaged quickly
+
+**Status snapshot (2026-03-15)**
+- Done
+  - Land startup failure alignment across server / desktop / web / smoke / runbook on main
+  - Add negative-path distribution smoke coverage and keep `desktop_distribution_smoke` running in GitHub CI
+  - Land known-category recovery coverage, commentary noise suppression, and input/TTS UX fixes on main
+- Remaining
+  - Audit residual cases that still fall into `needs manual review`
+  - Leave an explicit decision memo on whether deeper `spawn` sub-classification belongs in Sprint 16
+- Blocked / Deferred
+  - Signed/notarized release readiness is still blocked by `#138`
+  - Clean-internal physical-machine evidence is tracked separately from CI evidence
 
 ### Sprint 17 (2026-03-26 to 2026-04-08): Observability & fallback hardening
 **Issue drafts**

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -89,7 +89,7 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 
 ---
 
-## 現在地（2026-02-18 時点）
+## 現在地（2026-03-15 時点）
 **Done**
 - PR #1：detect 境界テスト（混在→generic、50行制限、重要定数export）
 - PR #2：ロードマップ docs 追加（日英＋docs/READMEからリンク）
@@ -124,23 +124,22 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 - PR #174：server起動失敗分類ログを構造化（分類コード + fallback結果 + 回帰テスト）
 - PR #175：server状態遷移ログを構造化（`[server/state-event]` + 統合テスト検証）
 - PR #178：v0.2.0 RC判定証跡テンプレートを追加（RC checklist / runbook / docs indexの導線を統一）
+- PR #213：起動失敗分類を server / desktop / web / distribution smoke / runbook で整合
+- PR #217：recovery guidance の既知カテゴリ test coverage を拡張
+- PR #218：Codex progress commentary noise を抑止
+- PR #219：入力重複抑止・TTS遅延短縮・explanation prompt 改善
+- PR #220：Sprint 16 起動復旧整合の証跡を release evidence log へ反映
 
 **Now**
-- 2026-02-18 のローカル事前検証を実施（`verify:updater` / web lint+build / `CLI_COMMENTATOR_FORCE_NO_PTY=1` server test / failure regression 34/34 / desktop distribution smoke がPass）
-- `CLI_COMMENTATOR_FORCE_NO_PTY=1` 実行時に node-pty 必須ケースを skip するテスト前提を補強し、Runbook のローカル検証コマンドを再現可能化
-- `release-desktop` の smoke 実行を再開し、`smoke.01` / `smoke.02` の失敗要因（sidecar node不足、runner unsupported、release作成権限）を証跡へ反映
-- `.github/workflows/release-desktop.yml` に sidecar 準備/検証ステップを追加し、x86 runner を `macos-15-intel` へ修正（`smoke.03` で arm64/x64 両bundle生成を確認）
-- `docs/release-runbook.*` / `docs/release-evidence-log.*` を当日証跡で更新
-- PR #186（`fix(release): preflight release write permissions`）をマージし、`Verify release publish permissions` を導入
-- `v0.0.0-smoke.20260219-test`（`release-desktop` run `22185152032`）で preflight + token fallback 経路の成功を確認
-- `GH_RELEASE_TOKEN` を設定し、`v0.0.0-smoke.20260220-211548`（run `22223734792`）で Draft Release 復旧を確認
-- docs drift guard と smoke matrix を運用し、v0.2.0 RC 判断材料を継続蓄積
-- `#138`（Apple certificate/secrets）未解消のため signed 配布判定は保留
+- Sprint 16 の主戦場はほぼ収束し、起動失敗分類 / recovery guidance / distribution smoke / evidence log の main 反映が完了
+- GitHub CI では `desktop_distribution_smoke` / `desktop_check` / `failure_regression` を含む主要 checks が green
+- 残件は `#214`（Sprint 16 の done / remaining / blocked 再整理）と `#215`（`要確認` 実例棚卸し、`spawn` 細分類判断）に圧縮
+- signed 配布 readiness は `#138`（Apple certificate/secrets）未解消のため継続保留
 
 **Next**
-- `#138` を解消し、`APPLE_CERTIFICATE` を登録したうえで `pnpm verify:apple-signing` をPassさせる
-- Apple有償証明書を導入しない期間は `v0.0.0-smoke.*` タグで unsigned internal 検証を継続する
-- 起動障害系の回帰ケースを継続拡張（配布物起動/署名モード差分を含む）
+- `#214` として Sprint 16 を `done / remaining / blocked` で再整理し、持ち越し候補を 1-2 件へ圧縮する
+- `#215` として `要確認` に落ちる残件を棚卸しし、`spawn` 細分類を今 Sprint でやるか次 Sprint に送るか判断する
+- `#138` を解消し、signed/notarized release readiness を再開する
 
 ---
 
@@ -175,6 +174,18 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 **完了条件**
 - クリーン環境で「インストール→起動→実況開始」が通る
 - 主要な起動失敗パターンの一次切り分けが可能
+
+**現状整理（2026-03-15）**
+- Done
+  - server / desktop / web / smoke / runbook の起動失敗分類整合を main へ反映
+  - distribution smoke に negative path を追加し、GitHub CI 上で `desktop_distribution_smoke` を継続運用
+  - recovery guidance の既知カテゴリ coverage、commentary noise suppression、入力/TTS UX 改善を main へ反映
+- Remaining
+  - `要確認` に落ちる残件棚卸し
+  - `spawn` 細分類を今 Sprint に含めるかの判断メモ
+- Blocked / Deferred
+  - signed/notarized release readiness は `#138` 依存
+  - clean internal 実機証跡は CI 証跡とは別管理
 
 ### Sprint 17（2026-03-26 〜 2026-04-08）: 可観測性とフォールバック強化
 **Issue案**

--- a/docs/roadmap-issues.en.md
+++ b/docs/roadmap-issues.en.md
@@ -152,6 +152,18 @@ Document certificate and secrets lifecycle operations (create/update/revoke).
 
 ## Sprint 16 (2026-03-12 to 2026-03-25)
 
+**Status (2026-03-15)**
+- Done
+  - `server: strengthen startup-failure classification logs` is landed on main (PR #213)
+  - `qa: add clean-environment smoke tests for desktop artifacts` is running in CI; `desktop_distribution_smoke` is green with negative-path coverage
+  - known-category recovery coverage, commentary-noise suppression, and input/TTS UX fixes are also landed on main (PR #217-#219)
+- Remaining
+  - audit concrete examples that still fall into `needs manual review` under `desktop: improve startup failure recovery guidance in panel UI`
+  - leave an explicit memo on whether deeper `spawn` sub-classification belongs in this sprint
+- Blocked / Deferred
+  - signed/notarized distribution readiness still depends on `#138`
+  - clean internal physical-machine evidence is tracked separately from CI evidence
+
 ### 16-1
 **Title**
 `qa: add clean-environment smoke tests for desktop artifacts`
@@ -166,9 +178,9 @@ Add smoke tests for install-to-first-launch flow in clean environments.
 - Verify first launch and commentary start
 
 ## Tasks
-- [ ] Define smoke scenarios
-- [ ] Run on representative environments
-- [ ] Record failure patterns
+- [x] Define smoke scenarios
+- [x] Run on representative environments (GitHub CI `desktop_distribution_smoke`)
+- [x] Record failure patterns (negative path: `sidecar_server_entry_missing`)
 
 ## Definition of Done
 - install -> launch -> commentary start is reproducible
@@ -189,9 +201,11 @@ Improve desktop panel guidance so users can recover from startup failures quickl
 - Show immediate recovery actions
 
 ## Tasks
-- [ ] Classify error messages
-- [ ] Update recovery hints
-- [ ] Add regression checks for panel output
+- [x] Classify error messages
+- [x] Update recovery hints
+- [x] Add regression coverage for known categories
+- [ ] Audit examples that still fall into `needs manual review`
+- [ ] Record whether deeper `spawn` sub-classification belongs in the next sprint
 
 ## Definition of Done
 - Major startup failures show actionable recovery guidance
@@ -212,9 +226,9 @@ Improve startup-failure logs with explicit categories and recovery context.
 - Add context needed for fast triage
 
 ## Tasks
-- [ ] Design log fields
-- [ ] Implement classification logic
-- [ ] Add tests
+- [x] Design log fields
+- [x] Implement classification logic
+- [x] Add tests
 
 ## Definition of Done
 - Major startup failures are diagnosable from logs

--- a/docs/roadmap-issues.ja.md
+++ b/docs/roadmap-issues.ja.md
@@ -152,6 +152,18 @@ notarizationのsubmit/staple手順を自動化し、配布前作業を定常運�
 
 ## Sprint 16（2026-03-12 〜 2026-03-25）
 
+**Status（2026-03-15）**
+- Done
+  - `server: 起動失敗の原因分類ログを強化` は main 反映済み（PR #213）
+  - `qa: クリーン環境向け配布物スモークテストを追加` は CI 反映済み。negative path を含む `desktop_distribution_smoke` が green
+  - recovery guidance の既知カテゴリ coverage、commentary noise 抑止、入力/TTS UX 改善も main 反映済み（PR #217-#219）
+- Remaining
+  - `desktop: 起動失敗時の復旧ガイドUIを改善` のうち、`要確認` に落ちる実例棚卸し
+  - `spawn` 細分類を今 Sprint に含めるかの判断メモ
+- Blocked / Deferred
+  - signed/notarized 配布 readiness は `#138` 依存
+  - clean internal 実機証跡は CI 証跡とは別管理
+
 ### 16-1
 **Title**
 `qa: クリーン環境向け配布物スモークテストを追加`
@@ -166,9 +178,9 @@ notarizationのsubmit/staple手順を自動化し、配布前作業を定常運�
 - 初回起動と実況開始確認
 
 ## Tasks
-- [ ] テスト手順を定義
-- [ ] 代表環境で実行
-- [ ] 失敗パターンを記録
+- [x] テスト手順を定義
+- [x] 代表環境で実行（GitHub CI `desktop_distribution_smoke`）
+- [x] 失敗パターンを記録（negative path: `sidecar_server_entry_missing`）
 
 ## Definition of Done
 - install -> launch -> commentary start が再現できる
@@ -189,9 +201,11 @@ notarizationのsubmit/staple手順を自動化し、配布前作業を定常運�
 - 復旧手順の即時提示
 
 ## Tasks
-- [ ] エラー文言を分類
-- [ ] 復旧ガイド文言を更新
-- [ ] UI表示の回帰テストを追加
+- [x] エラー文言を分類
+- [x] 復旧ガイド文言を更新
+- [x] 既知カテゴリの回帰テストを追加
+- [ ] `要確認` に落ちる実例を棚卸しする
+- [ ] `spawn` 細分類を次 Sprint に送るか判断メモを残す
 
 ## Definition of Done
 - 主要失敗ケースで復旧手順を提示できる
@@ -212,9 +226,9 @@ notarizationのsubmit/staple手順を自動化し、配布前作業を定常運�
 - 復旧に必要なコンテキスト出力
 
 ## Tasks
-- [ ] ログ項目を設計
-- [ ] 分類ロジックを実装
-- [ ] テストを追加
+- [x] ログ項目を設計
+- [x] 分類ロジックを実装
+- [x] テストを追加
 
 ## Definition of Done
 - 代表障害の原因をログのみで判別できる


### PR DESCRIPTION
## Summary

Reclassify Sprint 16 work into done / remaining / blocked based on current main.

## Changes
- update `docs/ROADMAP.ja.md` / `.en.md` current status to reflect merged Sprint 16 work
- add a Sprint 16 status snapshot to ROADMAP with `done / remaining / blocked`
- update `docs/roadmap-issues.ja.md` / `.en.md` task checkboxes for the three Sprint 16 pillars
- narrow remaining work to:
  - `#215` recovery guidance residual audit
  - `#138` signed/notarized release readiness

## Why
After PR #213 and follow-up PRs #217-#220, Sprint 16 was no longer accurately represented in the roadmap docs. This update makes the remaining scope explicit.

Closes #214