### PR TITLE
docs(roadmap): record #215 audit outcome and sprint handoff

### DIFF
--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -176,8 +176,8 @@ Build a minimal MVP that reliably works, then expand once value is proven.
   - Add negative-path distribution smoke coverage and keep `desktop_distribution_smoke` running in GitHub CI
   - Land known-category recovery coverage, commentary noise suppression, and input/TTS UX fixes on main
 - Remaining
-  - Audit residual cases that still fall into `needs manual review`
-  - Leave an explicit decision memo on whether deeper `spawn` sub-classification belongs in Sprint 16
+  - Keep `needs manual review` as the fallback for unknown / unstructured failures while continuing to collect concrete examples in `#215`
+  - Treat deeper `spawn` sub-classification as a next-sprint candidate unless concrete cases show the current buckets are insufficient
 - Blocked / Deferred
   - Signed/notarized release readiness is still blocked by `#138`
   - Clean-internal physical-machine evidence is tracked separately from CI evidence

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -181,8 +181,8 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
   - distribution smoke に negative path を追加し、GitHub CI 上で `desktop_distribution_smoke` を継続運用
   - recovery guidance の既知カテゴリ coverage、commentary noise suppression、入力/TTS UX 改善を main へ反映
 - Remaining
-  - `要確認` に落ちる残件棚卸し
-  - `spawn` 細分類を今 Sprint に含めるかの判断メモ
+  - `要確認` は未知 / 非構造化エラー用 fallback として維持しつつ、具体的な実例は `#215` で継続監査
+  - `spawn` 細分類は current buckets で不足する実例が出るまで次 Sprint 候補として扱う
 - Blocked / Deferred
   - signed/notarized release readiness は `#138` 依存
   - clean internal 実機証跡は CI 証跡とは別管理

--- a/docs/release-evidence-log.en.md
+++ b/docs/release-evidence-log.en.md
@@ -323,12 +323,13 @@ Related docs:
   - signed/notarized release readiness remains blocked by `#138`
   - clean internal physical-machine evidence is tracked separately from CI evidence
 - Remaining gap:
-  - deeper `spawn` sub-classification (`spawn_node_missing`, etc.) remains a follow-up candidate
+  - `needs manual review` remains as the intentional fallback for unknown or unstructured failures, not as a known-category gap on main
+  - deeper `spawn` sub-classification (`spawn_node_missing`, etc.) remains a next-sprint candidate unless concrete examples prove the current buckets insufficient
 
 ### Follow-up
 - [x] Record Sprint 16 startup recovery alignment and UX evidence in the evidence log
-- [ ] Re-audit `#215` remaining `needs manual review` cases and document the `spawn` sub-classification decision
-- [ ] Update ROADMAP / roadmap-issues `done / remaining / blocked` as `#214`
+- [x] Re-audit `#215` and record the current fallback / `spawn` defer decision
+- [x] Update ROADMAP / roadmap-issues `done / remaining / blocked` as `#214`
 - [ ] Resolve `#138` and resume signed/notarized release readiness work
 - Owner: maintainers
 - Due: 2026-03-18

--- a/docs/release-evidence-log.ja.md
+++ b/docs/release-evidence-log.ja.md
@@ -323,12 +323,13 @@
   - signed/notarized release readiness は `#138` 未解消のため未達
   - clean internal 実機証跡は CI 証跡とは別管理
 - Remaining gap:
-  - `spawn` の細分類（`spawn_node_missing` など）は次の残件候補
+  - `要確認` は main 再監査時点で既知カテゴリ漏れではなく、未知 / 非構造化エラー向け fallback として残している
+  - `spawn` の細分類（`spawn_node_missing` など）は、具体的な実例が出るまで次 Sprint の残件候補とする
 
 ### Follow-up
 - [x] Sprint 16 の起動復旧整合と UX 修正の証跡を evidence log へ追記
-- [ ] `#215` の `要確認` 実例棚卸しと `spawn` 細分類判断メモを整理
-- [ ] `#214` として ROADMAP / roadmap-issues の `done / remaining / blocked` を更新
+- [x] `#215` の再監査メモを残し、`要確認` fallback / `spawn` 細分類 defer 方針を確認
+- [x] `#214` として ROADMAP / roadmap-issues の `done / remaining / blocked` を更新
 - [ ] `#138` を解消し signed/notarized release readiness を再開
 - Owner: maintainers
 - Due: 2026-03-18


### PR DESCRIPTION
## Summary
- record the #215 audit outcome in roadmap and release evidence docs
- clarify that `要確認` currently remains as the fallback for unknown / unstructured failures
- note that fine-grained `spawn_*` classification is deferred unless concrete production examples justify it

## Details
- update Sprint 16 / Sprint 17 roadmap notes in both Japanese and English docs
- align release evidence log wording with the current main-branch audit result
- reflect that #214 is completed via #221 and #215 remains open as the parent issue for follow-up decisions

## Testing
- docs only
- no runtime or behavior changes