### PR TITLE
ci: enrich failure_regression summary routes

### DIFF
--- a/apps/server/src/tests/failure-regression-summary.test.ts
+++ b/apps/server/src/tests/failure-regression-summary.test.ts
@@ -51,6 +51,13 @@ describe("scripts/summarize-failure-regression", () => {
         ].join("\n"),
         "utf-8"
       );
+      await fs.writeFile(
+        path.join(captureDir, "explicit-file-profile.log"),
+        [
+          '[server/state-event] {"ts":3,"trigger":"file_tail_started","from":"restarting","to":"file_running","inputMode":"file","profileId":"profile-2","detail":"tail -f /tmp/profile.log","context":{"inputFile":"/tmp/profile.log"}}',
+        ].join("\n"),
+        "utf-8"
+      );
 
       await summarizeFailureRegression({ reportPath, outputPath, captureDir });
 
@@ -60,23 +67,35 @@ describe("scripts/summarize-failure-regression", () => {
       expect(markdown).toContain("`node_pty_unavailable` x2");
       expect(markdown).toContain("`activated` x1");
       expect(markdown).toContain("`file_not_found` x1");
-      expect(markdown).toContain("`file_tail_started` x1");
+      expect(markdown).toContain("`file_tail_started` x2");
       expect(markdown).toContain("`restart_failed` x1");
+      expect(markdown).toContain("`explicit_file_profile` x1");
+      expect(markdown).toContain("`restart_fallback_unavailable` x1");
+      expect(markdown).toContain("`startup_fallback_activated` x1");
       expect(markdown).toContain("`startup-restart-fallback`");
+      expect(markdown).toContain("routes=restart_fallback_unavailable, startup_fallback_activated");
+      expect(markdown).toContain("routes=explicit_file_profile");
+      expect(markdown).toContain("startup sample: startup/ptyUnavailable code=node_pty_unavailable");
+      expect(markdown).toContain("state sample: file_tail_started restarting->file_running inputMode=file profile=profile-2");
 
       const structuredSummary = JSON.parse(
         await fs.readFile(path.join(tempDir, "structured-log-summary.json"), "utf-8")
       );
       expect(structuredSummary).toMatchObject({
         found: true,
-        scenarioCount: 1,
+        scenarioCount: 2,
         startupFailureCount: 2,
-        serverStateEventCount: 2,
+        serverStateEventCount: 3,
       });
       expect(structuredSummary.startupFailureCodes).toEqual([{ value: "node_pty_unavailable", count: 2 }]);
       expect(structuredSummary.fallbackReasons).toEqual([
         { value: "activated", count: 1 },
         { value: "file_not_found", count: 1 },
+      ]);
+      expect(structuredSummary.routeLabels).toEqual([
+        { value: "explicit_file_profile", count: 1 },
+        { value: "restart_fallback_unavailable", count: 1 },
+        { value: "startup_fallback_activated", count: 1 },
       ]);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/scripts/summarize-failure-regression-lib.mjs
+++ b/scripts/summarize-failure-regression-lib.mjs
@@ -106,6 +106,113 @@ export function parseStructuredLogLines(raw) {
   return { startupFailures, serverStateEvents, parseErrors };
 }
 
+function toBooleanText(value) {
+  return value === true ? "true" : value === false ? "false" : "unknown";
+}
+
+function summarizeStartupFailureSample(failure) {
+  return {
+    context: failure?.context ? String(failure.context) : "unknown",
+    kind: failure?.kind ? String(failure.kind) : "unknown",
+    code: failure?.code ? String(failure.code) : "unknown",
+    inputMode: failure?.inputMode ? String(failure.inputMode) : "unknown",
+    fallbackReason: failure?.fallback?.reason ? String(failure.fallback.reason) : "none",
+    fallbackActivated: failure?.fallback?.activated,
+    command: failure?.target?.cmd ? String(failure.target.cmd) : null,
+    cwd: failure?.target?.cwd ? String(failure.target.cwd) : null,
+    inputFile: failure?.target?.inputFile ? String(failure.target.inputFile) : null,
+  };
+}
+
+function summarizeServerStateSample(event) {
+  return {
+    trigger: event?.trigger ? String(event.trigger) : "unknown",
+    from: event?.from ? String(event.from) : "unknown",
+    to: event?.to ? String(event.to) : "unknown",
+    inputMode: event?.inputMode ? String(event.inputMode) : "unknown",
+    profileId: event?.profileId ? String(event.profileId) : null,
+    fallbackReason: event?.context?.fallbackReason ? String(event.context.fallbackReason) : null,
+    failureKind: event?.context?.failureKind ? String(event.context.failureKind) : null,
+    inputFile: event?.context?.inputFile ? String(event.context.inputFile) : null,
+    detail: event?.detail ? String(event.detail) : null,
+  };
+}
+
+function deriveScenarioRouteLabels(parsed) {
+  const labels = new Set();
+  const startupFailures = parsed.startupFailures ?? [];
+  const serverStateEvents = parsed.serverStateEvents ?? [];
+
+  const hasStartupFailure = (predicate) => startupFailures.some(predicate);
+  const hasStateEvent = (predicate) => serverStateEvents.some(predicate);
+
+  if (
+    hasStartupFailure((failure) => failure?.context === "startup" && failure?.fallback?.activated === true) &&
+    hasStateEvent((event) => event?.trigger === "file_tail_started" && event?.from === "starting" && event?.to === "file_running")
+  ) {
+    labels.add("startup_fallback_activated");
+  }
+
+  if (
+    hasStartupFailure(
+      (failure) =>
+        failure?.context === "startup" &&
+        failure?.kind === "ptyUnavailable" &&
+        failure?.fallback?.activated === false
+    ) &&
+    hasStateEvent((event) => event?.trigger === "startup_failed" && event?.from === "starting" && event?.to === "failed")
+  ) {
+    labels.add("startup_fallback_unavailable");
+  }
+
+  if (
+    hasStartupFailure((failure) => failure?.context === "restart" && failure?.fallback?.activated === true) &&
+    hasStateEvent(
+      (event) =>
+        (event?.trigger === "restart_fallback_file" || event?.trigger === "file_tail_started") &&
+        event?.from === "restarting" &&
+        event?.to === "file_running"
+    )
+  ) {
+    labels.add("restart_fallback_activated");
+  }
+
+  if (
+    hasStartupFailure(
+      (failure) =>
+        failure?.context === "restart" &&
+        failure?.kind === "ptyUnavailable" &&
+        failure?.fallback?.activated === false
+    ) &&
+    hasStateEvent((event) => event?.trigger === "restart_failed" && event?.from === "restarting" && event?.to === "failed")
+  ) {
+    labels.add("restart_fallback_unavailable");
+  }
+
+  if (
+    hasStartupFailure((failure) => failure?.context === "startup" && failure?.kind === "configError") &&
+    hasStateEvent((event) => event?.trigger === "startup_failed" && event?.from === "starting" && event?.to === "failed")
+  ) {
+    labels.add("file_mode_invalid_config");
+  }
+
+  if (
+    !hasStartupFailure((failure) => failure?.context === "restart") &&
+    hasStateEvent(
+      (event) =>
+        event?.trigger === "file_tail_started" &&
+        event?.from === "restarting" &&
+        event?.to === "file_running" &&
+        event?.inputMode === "file" &&
+        event?.profileId
+    )
+  ) {
+    labels.add("explicit_file_profile");
+  }
+
+  return [...labels].sort((a, b) => a.localeCompare(b));
+}
+
 function summarizeScenario(fileName, parsed) {
   const startupCodes = new Set();
   const startupFallbackReasons = new Set();
@@ -131,6 +238,9 @@ function summarizeScenario(fileName, parsed) {
     startupFallbackReasons: [...startupFallbackReasons],
     startupContexts: [...startupContexts],
     stateTriggers: [...stateTriggers],
+    routeLabels: deriveScenarioRouteLabels(parsed),
+    startupSamples: parsed.startupFailures.slice(0, 3).map(summarizeStartupFailureSample),
+    serverStateSamples: parsed.serverStateEvents.slice(0, 3).map(summarizeServerStateSample),
     parseErrors: parsed.parseErrors,
   };
 }
@@ -146,6 +256,7 @@ export async function collectStructuredLogCaptureSummary(captureDir) {
     startupFailureCodes: [],
     fallbackReasons: [],
     serverStateTriggers: [],
+    routeLabels: [],
     scenarios: [],
     parseErrors: [],
   };
@@ -167,6 +278,7 @@ export async function collectStructuredLogCaptureSummary(captureDir) {
   const startupCodeCounts = new Map();
   const fallbackReasonCounts = new Map();
   const stateTriggerCounts = new Map();
+  const routeLabelCounts = new Map();
 
   for (const fileName of logFiles) {
     const raw = await fs.readFile(path.join(captureDir, fileName), "utf-8");
@@ -190,12 +302,44 @@ export async function collectStructuredLogCaptureSummary(captureDir) {
     for (const event of parsed.serverStateEvents) {
       incrementCounter(stateTriggerCounts, event?.trigger);
     }
+    for (const label of scenario.routeLabels) {
+      incrementCounter(routeLabelCounts, label);
+    }
   }
 
   summary.startupFailureCodes = toSortedCountList(startupCodeCounts);
   summary.fallbackReasons = toSortedCountList(fallbackReasonCounts);
   summary.serverStateTriggers = toSortedCountList(stateTriggerCounts);
+  summary.routeLabels = toSortedCountList(routeLabelCounts);
   return summary;
+}
+
+function formatStartupSample(sample) {
+  const parts = [
+    `${sample.context}/${sample.kind}`,
+    `code=${sample.code}`,
+    `inputMode=${sample.inputMode}`,
+    `fallback=${sample.fallbackReason}`,
+    `activated=${toBooleanText(sample.fallbackActivated)}`,
+  ];
+  if (sample.command) parts.push(`cmd=${sample.command}`);
+  if (sample.cwd) parts.push(`cwd=${sample.cwd}`);
+  if (sample.inputFile) parts.push(`inputFile=${sample.inputFile}`);
+  return parts.join(" ");
+}
+
+function formatServerStateSample(sample) {
+  const parts = [
+    `${sample.trigger}`,
+    `${sample.from}->${sample.to}`,
+    `inputMode=${sample.inputMode}`,
+  ];
+  if (sample.profileId) parts.push(`profile=${sample.profileId}`);
+  if (sample.fallbackReason) parts.push(`fallback=${sample.fallbackReason}`);
+  if (sample.failureKind) parts.push(`failureKind=${sample.failureKind}`);
+  if (sample.inputFile) parts.push(`inputFile=${sample.inputFile}`);
+  if (sample.detail) parts.push(`detail=${sample.detail}`);
+  return parts.join(" ");
 }
 
 function renderStructuredLogSection(structuredSummary) {
@@ -214,6 +358,7 @@ function renderStructuredLogSection(structuredSummary) {
   lines.push(
     `- Server state events: ${structuredSummary.serverStateEventCount} (${formatCountList(structuredSummary.serverStateTriggers)})`
   );
+  lines.push(`- Route labels: ${formatCountList(structuredSummary.routeLabels)}`);
 
   if (structuredSummary.parseErrors.length > 0) {
     lines.push(`- Parse errors: ${structuredSummary.parseErrors.length}`);
@@ -234,7 +379,15 @@ function renderStructuredLogSection(structuredSummary) {
         scenario.serverStateEventCount > 0
           ? `${scenario.serverStateEventCount} state-event (${scenario.stateTriggers.join(", ") || "unknown"})`
           : "no state-event";
-      lines.push(`- \`${scenario.scenario}\`: ${startupInfo}; ${fallbackInfo}; ${stateInfo}`);
+      const routeInfo =
+        scenario.routeLabels.length > 0 ? `routes=${scenario.routeLabels.join(", ")}` : "routes=none";
+      lines.push(`- \`${scenario.scenario}\`: ${routeInfo}; ${startupInfo}; ${fallbackInfo}; ${stateInfo}`);
+      for (const sample of scenario.startupSamples) {
+        lines.push(`  - startup sample: ${formatStartupSample(sample)}`);
+      }
+      for (const sample of scenario.serverStateSamples) {
+        lines.push(`  - state sample: ${formatServerStateSample(sample)}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- enrich `failure_regression` summary output with route labels and representative structured-log samples
- make `startup_fallback_activated`, `restart_fallback_unavailable`, and `explicit_file_profile` paths readable from the summary alone
- extend the summary regression test and aggregate artifact coverage

## Details
- derive scenario-level route labels from `structured-log-captures`
- include representative `startup/failure` and `server/state-event` samples in the markdown summary
- write route label counts into `structured-log-summary.json`
- add an explicit file profile capture fixture to the summary test

## Testing
- `pnpm -C apps/server exec vitest run src/tests/failure-regression-summary.test.ts`

Closes #211