### PR TITLE
perf(web): lazy-load xterm terminal pane

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
-import "xterm/css/xterm.css";
-import { Terminal } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
 import { ProfileSelector } from "./components/ProfileSelector";
 import { ProfileEditor } from "./components/ProfileEditor";
+import type { TerminalPaneHandle, TerminalPaneTheme } from "./components/TerminalPane";
 import {
   isTTSSupported,
   speak,
@@ -40,7 +38,6 @@ import {
   type LaunchDraft,
   type LaunchPresetId,
 } from "./lib/session-launcher";
-import { createTerminalInputGate } from "./lib/terminal-input";
 import type {
   CommentaryDisplayMode,
   Style,
@@ -52,6 +49,8 @@ import type {
   ServerToClientMessage,
   PtyUnavailablePayload,
 } from "./types";
+
+const TerminalPane = lazy(() => import("./components/TerminalPane"));
 
 export type Skin = "standard" | "cli";
 
@@ -76,7 +75,7 @@ function isSkin(value: string | null): value is Skin {
   return value === "standard" || value === "cli";
 }
 
-function getTerminalTheme(skin: Skin) {
+function getTerminalTheme(skin: Skin): TerminalPaneTheme {
   if (skin === "cli") {
     return {
       background: "#081019",
@@ -603,11 +602,7 @@ export default function App() {
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingEditIdRef = useRef<string | null>(null);
   const logContainerRef = useRef<HTMLDivElement | null>(null);
-  const terminalContainerRef = useRef<HTMLDivElement | null>(null);
-  const terminalRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const terminalBacklogRef = useRef("");
-  const terminalInputGateRef = useRef(createTerminalInputGate());
+  const terminalPaneRef = useRef<TerminalPaneHandle | null>(null);
   const shouldStickLogRef = useRef(true);
 
   // Profile state
@@ -633,6 +628,7 @@ export default function App() {
   const [ttsSettingsOpen, setTtsSettingsOpen] = useState(false);
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const [voicesLoaded, setVoicesLoaded] = useState(false);
+  const [pendingTerminalOutput, setPendingTerminalOutput] = useState("");
   const ttsSupported = isTTSSupported();
   const ttsEnabledRef = useRef(ttsEnabled);
   const ttsSettingsRef = useRef(ttsSettings);
@@ -653,9 +649,10 @@ export default function App() {
     return `ws://localhost:${port}`;
   }, [defaultWsPort, isTauriRuntime, tauriServerPort]);
 
+  const terminalTheme = useMemo(() => getTerminalTheme(skin), [skin]);
+
   const sendTerminalInput = useCallback((data: string) => {
     if (!data) return;
-    if (!terminalInputGateRef.current.shouldForward(data)) return;
     if (wsRef.current?.readyState !== WebSocket.OPEN) {
       setPtyError("サーバーに接続されていません");
       return;
@@ -695,101 +692,6 @@ export default function App() {
       setVoicesLoaded(true);
     });
   }, [ttsSupported]);
-
-  useEffect(() => {
-    const host = terminalContainerRef.current;
-    if (!host || terminalRef.current) return;
-    let disposed = false;
-    let frameId: number | null = null;
-
-    const fitAddon = new FitAddon();
-    const terminal = new Terminal({
-      convertEol: true,
-      cursorBlink: true,
-      fontFamily: "var(--font-mono)",
-      fontSize: 13,
-      lineHeight: 1.35,
-      scrollback: 5000,
-      theme: getTerminalTheme(skin),
-    });
-
-    terminal.loadAddon(fitAddon);
-    terminal.open(host);
-    const scheduleFit = () => {
-      if (disposed) return;
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
-      }
-      frameId = window.requestAnimationFrame(() => {
-        frameId = null;
-        if (disposed) return;
-        try {
-          fitAddon.fit();
-          terminal.focus();
-        } catch (error) {
-          if (import.meta.env.DEV) {
-            console.debug("xterm fit skipped", error);
-          }
-        }
-      });
-    };
-
-    scheduleFit();
-    terminal.onData((data) => {
-      sendTerminalInput(data);
-    });
-
-    const textarea = terminal.textarea;
-    const handleCompositionStart = () => {
-      terminalInputGateRef.current.noteCompositionStart();
-    };
-    const handleCompositionEnd = () => {
-      terminalInputGateRef.current.noteCompositionEnd();
-    };
-    const handlePaste = () => {
-      terminalInputGateRef.current.notePaste();
-    };
-    textarea?.addEventListener("compositionstart", handleCompositionStart);
-    textarea?.addEventListener("compositionend", handleCompositionEnd);
-    textarea?.addEventListener("paste", handlePaste);
-
-    if (terminalBacklogRef.current) {
-      terminal.write(terminalBacklogRef.current);
-      terminalBacklogRef.current = "";
-    }
-
-    terminalRef.current = terminal;
-    fitAddonRef.current = fitAddon;
-
-    const resizeObserver =
-      typeof ResizeObserver === "function"
-        ? new ResizeObserver(() => {
-            scheduleFit();
-          })
-        : null;
-    resizeObserver?.observe(host);
-
-    return () => {
-      disposed = true;
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
-      }
-      resizeObserver?.disconnect();
-      textarea?.removeEventListener("compositionstart", handleCompositionStart);
-      textarea?.removeEventListener("compositionend", handleCompositionEnd);
-      textarea?.removeEventListener("paste", handlePaste);
-      terminal.dispose();
-      terminalRef.current = null;
-      fitAddonRef.current = null;
-    };
-  }, [sendTerminalInput, skin]);
-
-  useEffect(() => {
-    const terminal = terminalRef.current;
-    if (!terminal) return;
-    terminal.options.theme = getTerminalTheme(skin);
-    fitAddonRef.current?.fit();
-  }, [skin]);
 
   // TTS cleanup on unmount (prevent orphan speech on reload/navigation)
   useEffect(() => {
@@ -903,20 +805,24 @@ export default function App() {
 
   const writeToTerminal = useCallback((data: string) => {
     if (!data) return;
-    const terminal = terminalRef.current;
+    const terminal = terminalPaneRef.current;
     if (!terminal) {
-      terminalBacklogRef.current += data;
-      if (terminalBacklogRef.current.length > TERMINAL_OUTPUT_MAX_CHARS) {
-        terminalBacklogRef.current = terminalBacklogRef.current.slice(-TERMINAL_OUTPUT_MAX_CHARS);
-      }
+      setPendingTerminalOutput((prev) => {
+        const next = prev + data;
+        return next.length > TERMINAL_OUTPUT_MAX_CHARS ? next.slice(-TERMINAL_OUTPUT_MAX_CHARS) : next;
+      });
       return;
     }
     terminal.write(data);
   }, []);
 
   const clearTerminal = useCallback(() => {
-    terminalBacklogRef.current = "";
-    terminalRef.current?.clear();
+    setPendingTerminalOutput("");
+    terminalPaneRef.current?.clear();
+  }, []);
+
+  const handlePendingTerminalOutputFlushed = useCallback(() => {
+    setPendingTerminalOutput("");
   }, []);
 
   const handleTTSPresetChange = (presetId: TTSPresetSelectValue) => {
@@ -1089,7 +995,7 @@ export default function App() {
               // Clear commentary items when PTY restarts
               setItems([]);
               clearTerminal();
-              terminalInputGateRef.current.reset();
+              terminalPaneRef.current?.resetInputGate();
               clearPendingSpeech();
               stopSpeech();
               setProfileError(null);
@@ -1206,7 +1112,7 @@ export default function App() {
     setCurrentSessionLabel(session.name?.trim() || session.cmd);
     wsRef.current.send(JSON.stringify({ kind: "launchSession", session }));
     window.setTimeout(() => {
-      terminalRef.current?.focus();
+      terminalPaneRef.current?.focus();
     }, 0);
   };
 
@@ -1506,12 +1412,18 @@ export default function App() {
                 </button>
               </div>
             </div>
-            <div
-              ref={terminalContainerRef}
-              className="terminal-panel__screen terminal-panel__screen--xterm"
-              onClick={() => terminalRef.current?.focus()}
-              role="presentation"
-            />
+            <Suspense
+              fallback={<div className="terminal-panel__screen terminal-panel__screen--xterm" role="presentation" />}
+            >
+              <TerminalPane
+                ref={terminalPaneRef}
+                className="terminal-panel__screen terminal-panel__screen--xterm"
+                onData={sendTerminalInput}
+                onPendingOutputFlushed={handlePendingTerminalOutputFlushed}
+                pendingOutput={pendingTerminalOutput}
+                theme={terminalTheme}
+              />
+            </Suspense>
           </div>
 
           <div className="panel workspace-subpanel">

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -1,0 +1,190 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import "xterm/css/xterm.css";
+import { Terminal } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import { createTerminalInputGate } from "../lib/terminal-input";
+
+const TERMINAL_OUTPUT_MAX_CHARS = 24000;
+
+export type TerminalPaneTheme = {
+  background: string;
+  foreground: string;
+  cursor: string;
+  selectionBackground: string;
+};
+
+export type TerminalPaneHandle = {
+  clear: () => void;
+  focus: () => void;
+  resetInputGate: () => void;
+  write: (data: string) => void;
+};
+
+type TerminalPaneProps = {
+  className: string;
+  onData: (data: string) => void;
+  onPendingOutputFlushed: () => void;
+  pendingOutput: string;
+  theme: TerminalPaneTheme;
+};
+
+function trimTerminalOutput(value: string): string {
+  return value.length > TERMINAL_OUTPUT_MAX_CHARS ? value.slice(-TERMINAL_OUTPUT_MAX_CHARS) : value;
+}
+
+const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function TerminalPane(
+  { className, onData, onPendingOutputFlushed, pendingOutput, theme },
+  ref
+) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const backlogRef = useRef("");
+  const terminalInputGateRef = useRef(createTerminalInputGate());
+
+  const appendOutput = useCallback((data: string) => {
+    if (!data) return;
+    const terminal = terminalRef.current;
+    if (!terminal) {
+      backlogRef.current = trimTerminalOutput(backlogRef.current + data);
+      return;
+    }
+    terminal.write(data);
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      clear() {
+        backlogRef.current = "";
+        terminalRef.current?.clear();
+      },
+      focus() {
+        terminalRef.current?.focus();
+      },
+      resetInputGate() {
+        terminalInputGateRef.current.reset();
+      },
+      write(data: string) {
+        appendOutput(data);
+      },
+    }),
+    [appendOutput]
+  );
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || terminalRef.current) return;
+
+    let disposed = false;
+    let frameId: number | null = null;
+
+    const fitAddon = new FitAddon();
+    const terminal = new Terminal({
+      convertEol: true,
+      cursorBlink: true,
+      fontFamily: "var(--font-mono)",
+      fontSize: 13,
+      lineHeight: 1.35,
+      scrollback: 5000,
+      theme,
+    });
+
+    const scheduleFit = () => {
+      if (disposed) return;
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        if (disposed) return;
+        try {
+          fitAddon.fit();
+          terminal.focus();
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.debug("xterm fit skipped", error);
+          }
+        }
+      });
+    };
+
+    terminal.loadAddon(fitAddon);
+    terminal.open(host);
+    scheduleFit();
+
+    terminal.onData((data) => {
+      if (!terminalInputGateRef.current.shouldForward(data)) return;
+      onData(data);
+    });
+
+    const textarea = terminal.textarea;
+    const handleCompositionStart = () => {
+      terminalInputGateRef.current.noteCompositionStart();
+    };
+    const handleCompositionEnd = () => {
+      terminalInputGateRef.current.noteCompositionEnd();
+    };
+    const handlePaste = () => {
+      terminalInputGateRef.current.notePaste();
+    };
+
+    textarea?.addEventListener("compositionstart", handleCompositionStart);
+    textarea?.addEventListener("compositionend", handleCompositionEnd);
+    textarea?.addEventListener("paste", handlePaste);
+
+    if (backlogRef.current) {
+      terminal.write(backlogRef.current);
+      backlogRef.current = "";
+    }
+
+    terminalRef.current = terminal;
+    fitAddonRef.current = fitAddon;
+
+    const resizeObserver =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(() => {
+            scheduleFit();
+          })
+        : null;
+    resizeObserver?.observe(host);
+
+    return () => {
+      disposed = true;
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      resizeObserver?.disconnect();
+      textarea?.removeEventListener("compositionstart", handleCompositionStart);
+      textarea?.removeEventListener("compositionend", handleCompositionEnd);
+      textarea?.removeEventListener("paste", handlePaste);
+      terminal.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [onData, theme]);
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    terminal.options.theme = theme;
+    fitAddonRef.current?.fit();
+  }, [theme]);
+
+  useEffect(() => {
+    if (!pendingOutput) return;
+    appendOutput(pendingOutput);
+    onPendingOutputFlushed();
+  }, [appendOutput, onPendingOutputFlushed, pendingOutput]);
+
+  return (
+    <div
+      ref={hostRef}
+      className={className}
+      onClick={() => terminalRef.current?.focus()}
+      role="presentation"
+    />
+  );
+});
+
+export default TerminalPane;


### PR DESCRIPTION
## Summary

- extract xterm / xterm-addon-fit setup from `App.tsx` into `TerminalPane`
- lazy-load the terminal pane with `React.lazy` and `Suspense`
- keep terminal output stable by buffering pending lines before the pane mounts
- preserve existing terminal behavior while reducing the initial web bundle size
- intentionally avoid manual chunk configuration and first try a low-risk feature split around xterm

## Result

- main web chunk reduced from 530.7 KB to 250.5 KB
- terminal code now ships as a separate 282.4 KB chunk
- web build chunk size warning no longer appears

## Verification

- `pnpm -C apps/web build`
- `pnpm -C apps/web exec vite build --sourcemap`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test -- --run`

## Manual check

- initial screen renders without layout breakage
- xterm appears correctly after lazy load
- initial prompt/output is displayed
- terminal input round-trip works (`echo codex-terminal-check`)
- resize updates terminal rows correctly
- restarting does not create duplicate terminal DOM instances
- no browser console errors observed