### PR TITLE
perf(web): lazy-load profile editor modal

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
 import { ProfileSelector } from "./components/ProfileSelector";
-import { ProfileEditor } from "./components/ProfileEditor";
 import type { TerminalPaneHandle, TerminalPaneTheme } from "./components/TerminalPane";
 import {
   isTTSSupported,
@@ -51,6 +50,11 @@ import type {
 } from "./types";
 
 const TerminalPane = lazy(() => import("./components/TerminalPane"));
+const ProfileEditor = lazy(() =>
+  import("./components/ProfileEditor").then((module) => ({
+    default: module.ProfileEditor,
+  }))
+);
 
 export type Skin = "standard" | "cli";
 
@@ -1800,14 +1804,29 @@ export default function App() {
         </div>
       )}
       {editingProfile && editingProfile !== "loading" && (
-        <ProfileEditor
-          key={profileEditorKey}
-          profile={editingProfile === "new" ? null : editingProfile}
-          error={profileError}
-          isWsOpen={connectionStatus === "connected"}
-          onSave={handleSaveProfile}
-          onCancel={handleCancelEdit}
-        />
+        <Suspense
+          fallback={
+            <div className="modal-backdrop">
+              <div className="modal">
+                <h2 className="modal__title">プロファイルエディターを読み込み中...</h2>
+                <div className="form-actions">
+                  <button type="button" onClick={handleCancelEdit}>
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            </div>
+          }
+        >
+          <ProfileEditor
+            key={profileEditorKey}
+            profile={editingProfile === "new" ? null : editingProfile}
+            error={profileError}
+            isWsOpen={connectionStatus === "connected"}
+            onSave={handleSaveProfile}
+            onCancel={handleCancelEdit}
+          />
+        </Suspense>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- lazy-load `ProfileEditor` from `App.tsx` with `React.lazy` and `Suspense`
- only load the profile editor chunk when the new/edit modal is opened
- keep the modal UX stable with a lightweight loading fallback while the chunk is fetched

## Result

- main web chunk reduced from 250.5 KB to 244.9 KB
- profile editor code now ships as a separate 6.15 KB chunk
- web build still completes without chunk size warnings

## Verification

- `pnpm -C apps/web build`
- `pnpm -C apps/web exec vite build --sourcemap`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test -- --run`

## Manual check

- opening `＋ 新規` loads and displays the profile editor modal correctly
- opening `編集` loads and displays the existing profile data correctly
- cancel closes the modal normally after lazy load
- no browser console errors observed