### PR TITLE
docs: update roadmap current state

### DIFF
--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -84,7 +84,7 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 
 ---
 
-## Current status (as of 2026-03-15)
+## Current status (as of 2026-05-08)
 **Done**
 - PR #1: detect boundary tests (mixed => generic, 50-line limit, exported constants)
 - PR #2: add roadmap docs (JA/EN + links from docs/README)
@@ -124,17 +124,27 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 - PR #218: suppress Codex progress commentary noise
 - PR #219: reduce duplicate input, lower TTS lag, and strengthen explanation prompts
 - PR #220: record Sprint 16 startup recovery evidence in the release evidence logs
+- Issues #214 and #215 are closed: Sprint 16 remaining / blocked work has been reclassified, and residual recovery-guidance cases are documented as fallback monitoring rather than active implementation blockers
+- PR #237: update `@types/node` for server and web, replacing the narrower #238 / #239 PRs
+- PR #241-242: refresh desktop release CI actions (`tauri-apps/tauri-action` v0.6.2 and `pnpm/action-setup` v5) with docs notes confirming no operator workflow changes
+- PR #244: update `tauri-plugin-updater` to 2.10.1 and document it as updater plugin maintenance
+- PR #249: refresh the Tauri runtime stack to the 2.11 series and document it as runtime maintenance; #248 was closed as superseded
+- As of 2026-05-08, open PR count is 0 and the dependency-maintenance backlog has been cleared
 
 **Now**
-- Sprint 16 core work is largely landed: startup failure classification, recovery guidance, distribution smoke, and evidence logging are now reflected on main
-- GitHub CI provides green evidence across `desktop_distribution_smoke`, `desktop_check`, `failure_regression`, and the standard test matrix
-- Remaining Sprint 16 work is narrowed to `#214` (done / remaining / blocked reclassification) and `#215` (audit residual `needs manual review` cases and decide on `spawn` sub-classification)
-- Signed release readiness remains blocked by `#138` (Apple certificate/secrets)
+- Release readiness is now concentrated on `#138`: Apple Developer ID certificate preparation, GitHub Secrets registration, `verify:apple-signing`, and a signed/notarized `release-desktop` smoke run
+- The unresolved work is operational readiness rather than a normal code implementation backlog: certificate issuance, `.p12` handling, `APPLE_CERTIFICATE` / password validation, and notarization evidence
+- Main is current after dependency-maintenance PR cleanup, with GitHub CI green across `docs_drift_guard`, `test`, `test_windows`, `desktop_check`, `desktop_distribution_smoke`, and CodeQL
 
 **Next**
-- As `#214`, reclassify Sprint 16 into `done / remaining / blocked` and compress carry-over candidates to one or two items
-- As `#215`, audit remaining `needs manual review` cases and decide whether `spawn` sub-classification belongs in this sprint or the next one
-- Resolve `#138` and resume signed/notarized release readiness work
+- Complete the human-side `#138` work: issue / export the Developer ID Application certificate, register required GitHub Secrets, and rerun the release smoke tag
+- Confirm signed/notarized desktop artifacts (`latest.json`, `.app.tar.gz`, `.sig`, `.dmg`) from the release workflow before declaring public signed distribution ready
+- Refresh release notes and operator docs only if the signed/notarized smoke run changes the existing release procedure
+
+**Later**
+- Continue dependency and desktop runtime maintenance through the docs drift guard path
+- Keep improving failure-regression summaries and recovery evidence as new concrete failure cases appear
+- Resume UX/commentary-quality improvements after signed release readiness is unblocked
 
 ---
 
@@ -170,16 +180,17 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 - Clean environment can complete install -> launch -> commentary start
 - Major startup failures can be triaged quickly
 
-**Status snapshot (2026-03-15)**
+**Status snapshot (2026-05-08)**
 - Done
   - Land startup failure alignment across server / desktop / web / smoke / runbook on main
   - Add negative-path distribution smoke coverage and keep `desktop_distribution_smoke` running in GitHub CI
   - Land known-category recovery coverage, commentary noise suppression, and input/TTS UX fixes on main
+  - Closed `#214` after recording the Sprint 16 done / remaining / blocked split
+  - Closed `#215` after confirming `needs manual review` remains the fallback for unknown / unstructured failures and deeper `spawn` sub-classification can wait for concrete cases
 - Remaining
-  - Keep `needs manual review` as the fallback for unknown / unstructured failures while continuing to collect concrete examples in `#215`
-  - Treat deeper `spawn` sub-classification as a next-sprint candidate unless concrete cases show the current buckets are insufficient
+  - Keep collecting concrete recovery examples through normal evidence logs when they appear
 - Blocked / Deferred
-  - Signed/notarized release readiness is still blocked by `#138`
+  - Signed/notarized release readiness is still blocked by `#138`, specifically Apple Developer ID certificate / GitHub Secrets / notarization validation
   - Clean-internal physical-machine evidence is tracked separately from CI evidence
 
 ### Sprint 17 (2026-03-26 to 2026-04-08): Observability & fallback hardening

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -89,7 +89,7 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 
 ---
 
-## 現在地（2026-03-15 時点）
+## 現在地（2026-05-08 時点）
 **Done**
 - PR #1：detect 境界テスト（混在→generic、50行制限、重要定数export）
 - PR #2：ロードマップ docs 追加（日英＋docs/READMEからリンク）
@@ -129,17 +129,27 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 - PR #218：Codex progress commentary noise を抑止
 - PR #219：入力重複抑止・TTS遅延短縮・explanation prompt 改善
 - PR #220：Sprint 16 起動復旧整合の証跡を release evidence log へ反映
+- `#214` / `#215` は closed。Sprint 16 の remaining / blocked 再整理と、recovery guidance 残件の fallback 監視扱いへの整理が完了
+- PR #237：server / web の `@types/node` を更新し、個別PR #238 / #239 を内包して整理
+- PR #241-242：desktop release CI actions（`tauri-apps/tauri-action` v0.6.2 / `pnpm/action-setup` v5）を更新し、運用手順変更なしの docs note を追加
+- PR #244：`tauri-plugin-updater` を 2.10.1 へ更新し、updater plugin maintenance として記録
+- PR #249：Tauri runtime stack を 2.11 系へ更新し、runtime maintenance として記録。#248 は内包済みとして close
+- 2026-05-08 時点で open PR は 0 件。依存更新PR群の整理は完了
 
 **Now**
-- Sprint 16 の主戦場はほぼ収束し、起動失敗分類 / recovery guidance / distribution smoke / evidence log の main 反映が完了
-- GitHub CI では `desktop_distribution_smoke` / `desktop_check` / `failure_regression` を含む主要 checks が green
-- 残件は `#214`（Sprint 16 の done / remaining / blocked 再整理）と `#215`（`要確認` 実例棚卸し、`spawn` 細分類判断）に圧縮
-- signed 配布 readiness は `#138`（Apple certificate/secrets）未解消のため継続保留
+- release readiness の焦点は `#138` に集約。Apple Developer ID certificate 準備、GitHub Secrets 登録、`verify:apple-signing`、signed/notarized `release-desktop` smoke が残件
+- 残っているのは通常のコード実装というより、証明書発行、`.p12` 取り扱い、`APPLE_CERTIFICATE` / password 検証、notarization 証跡の運用 readiness
+- main は依存更新PR整理後の状態で最新化済み。GitHub CI は `docs_drift_guard` / `test` / `test_windows` / `desktop_check` / `desktop_distribution_smoke` / CodeQL が green
 
 **Next**
-- `#214` として Sprint 16 を `done / remaining / blocked` で再整理し、持ち越し候補を 1-2 件へ圧縮する
-- `#215` として `要確認` に落ちる残件を棚卸しし、`spawn` 細分類を今 Sprint でやるか次 Sprint に送るか判断する
-- `#138` を解消し、signed/notarized release readiness を再開する
+- `#138` の人間側作業を完了する: Developer ID Application certificate の発行 / export、必要な GitHub Secrets 登録、release smoke tag の再実行
+- release workflow から signed/notarized desktop artifacts（`latest.json`, `.app.tar.gz`, `.sig`, `.dmg`）を確認してから、正式な signed 配布 ready と判断する
+- signed/notarized smoke により既存手順が変わる場合のみ、release notes / operator docs を追加更新する
+
+**Later**
+- dependency / desktop runtime maintenance は docs drift guard 経由で継続運用する
+- 新しい具体的な失敗例が出たら、failure regression summary と recovery evidence を継続強化する
+- signed release readiness が unblock された後、UX / 実況品質改善へ戻る
 
 ---
 
@@ -175,16 +185,17 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 - クリーン環境で「インストール→起動→実況開始」が通る
 - 主要な起動失敗パターンの一次切り分けが可能
 
-**現状整理（2026-03-15）**
+**現状整理（2026-05-08）**
 - Done
   - server / desktop / web / smoke / runbook の起動失敗分類整合を main へ反映
   - distribution smoke に negative path を追加し、GitHub CI 上で `desktop_distribution_smoke` を継続運用
   - recovery guidance の既知カテゴリ coverage、commentary noise suppression、入力/TTS UX 改善を main へ反映
+  - `#214` は closed。Sprint 16 の done / remaining / blocked 整理を記録
+  - `#215` は closed。`要確認` は未知 / 非構造化エラー用 fallback として維持、`spawn` 細分類は具体例が出るまで保留と整理
 - Remaining
-  - `要確認` は未知 / 非構造化エラー用 fallback として維持しつつ、具体的な実例は `#215` で継続監査
-  - `spawn` 細分類は current buckets で不足する実例が出るまで次 Sprint 候補として扱う
+  - 具体的な recovery 例が新しく出た場合は、通常の evidence log で継続収集する
 - Blocked / Deferred
-  - signed/notarized release readiness は `#138` 依存
+  - signed/notarized release readiness は `#138` 依存。具体的には Apple Developer ID certificate / GitHub Secrets / notarization validation が残件
   - clean internal 実機証跡は CI 証跡とは別管理
 
 ### Sprint 17（2026-03-26 〜 2026-04-08）: 可観測性とフォールバック強化

--- a/docs/roadmap-issues.en.md
+++ b/docs/roadmap-issues.en.md
@@ -152,16 +152,17 @@ Document certificate and secrets lifecycle operations (create/update/revoke).
 
 ## Sprint 16 (2026-03-12 to 2026-03-25)
 
-**Status (2026-03-15)**
+**Status (2026-05-08)**
 - Done
   - `server: strengthen startup-failure classification logs` is landed on main (PR #213)
   - `qa: add clean-environment smoke tests for desktop artifacts` is running in CI; `desktop_distribution_smoke` is green with negative-path coverage
   - known-category recovery coverage, commentary-noise suppression, and input/TTS UX fixes are also landed on main (PR #217-#219)
+  - `#214` is closed after the Sprint 16 done / remaining / blocked reclassification
+  - `#215` is closed after confirming `needs manual review` remains the fallback for unknown / unstructured failures and deeper `spawn` sub-classification is deferred until concrete cases appear
 - Remaining
-  - audit concrete examples that still fall into `needs manual review` under `desktop: improve startup failure recovery guidance in panel UI`
-  - leave an explicit memo on whether deeper `spawn` sub-classification belongs in this sprint
+  - keep collecting concrete recovery examples through normal evidence logs when they appear
 - Blocked / Deferred
-  - signed/notarized distribution readiness still depends on `#138`
+  - signed/notarized distribution readiness still depends on `#138` (Apple Developer ID certificate, GitHub Secrets, and notarization validation)
   - clean internal physical-machine evidence is tracked separately from CI evidence
 
 ### 16-1

--- a/docs/roadmap-issues.ja.md
+++ b/docs/roadmap-issues.ja.md
@@ -152,16 +152,17 @@ notarizationのsubmit/staple手順を自動化し、配布前作業を定常運�
 
 ## Sprint 16（2026-03-12 〜 2026-03-25）
 
-**Status（2026-03-15）**
+**Status（2026-05-08）**
 - Done
   - `server: 起動失敗の原因分類ログを強化` は main 反映済み（PR #213）
   - `qa: クリーン環境向け配布物スモークテストを追加` は CI 反映済み。negative path を含む `desktop_distribution_smoke` が green
   - recovery guidance の既知カテゴリ coverage、commentary noise 抑止、入力/TTS UX 改善も main 反映済み（PR #217-#219）
+  - `#214` は closed。Sprint 16 の done / remaining / blocked 再整理を完了
+  - `#215` は closed。`要確認` は未知 / 非構造化エラー用 fallback として維持し、`spawn` 細分類は具体例が出るまで保留と整理
 - Remaining
-  - `desktop: 起動失敗時の復旧ガイドUIを改善` のうち、`要確認` に落ちる実例棚卸し
-  - `spawn` 細分類を今 Sprint に含めるかの判断メモ
+  - 具体的な recovery 例が新しく出た場合は、通常の evidence log で継続収集する
 - Blocked / Deferred
-  - signed/notarized 配布 readiness は `#138` 依存
+  - signed/notarized 配布 readiness は `#138` 依存（Apple Developer ID certificate、GitHub Secrets、notarization validation）
   - clean internal 実機証跡は CI 証跡とは別管理
 
 ### 16-1


### PR DESCRIPTION
## Summary
- Update the roadmap current state to 2026-05-08.
- Mark #214 and #215 as closed/completed instead of active roadmap items.
- Reflect that open PRs are currently cleared and recent dependency-maintenance PRs have been processed.
- Reframe #138 as the primary remaining release-readiness item for Apple signing / notarization readiness, including Developer ID certificate, GitHub Secrets, `verify:apple-signing`, and signed/notarized release smoke validation.

## Validation
- `git diff --check`
- `node ./scripts/check-doc-sync.mjs --base-ref main`

## Notes
- Docs-only change.
- No app, package, or lockfile changes.