### PR TITLE
[codex] Apple signing readiness smoke workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
       - main
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
   docs_drift_guard:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -200,10 +200,10 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          releaseName: CLI Commentator ${{ github.ref_name }}
-          releaseBody: See the assets to download and install this version.
+          releaseName: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && format('CLI Commentator {0} (signed smoke)', github.ref_name) || format('CLI Commentator {0}', github.ref_name) }}
+          releaseBody: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && 'Signed and notarized internal smoke build. Validate artifacts and keep the draft unpublished.' || 'See the assets to download and install this version.' }}
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') }}
           args: ${{ matrix.args }}
 
       - name: Build and draft release (unsigned internal)

--- a/docs/docs-update-flow.en.md
+++ b/docs/docs-update-flow.en.md
@@ -54,6 +54,7 @@ Use the Doc Freshness checklist in `.github/pull_request_template.md` and enforc
 
 ## CI Guard (Issue #132)
 
+- `actionlint` runs on pull requests and `main` pushes to statically check GitHub Actions workflow files.
 - On pull requests, `docs_drift_guard` runs `scripts/check-doc-sync.mjs`.
 - If LLM/desktop-distribution implementation changes without matching docs updates, CI fails.
 - Use `[skip-doc-sync-check]` in the PR body only for explicit exceptions, and include the reason.

--- a/docs/docs-update-flow.en.md
+++ b/docs/docs-update-flow.en.md
@@ -56,6 +56,7 @@ Use the Doc Freshness checklist in `.github/pull_request_template.md` and enforc
 
 - `actionlint` runs on pull requests and `main` pushes to statically check GitHub Actions workflow files.
 - On pull requests, `docs_drift_guard` runs `scripts/check-doc-sync.mjs`.
+- Local runs include committed, staged, unstaged, and untracked file changes.
 - If LLM/desktop-distribution implementation changes without matching docs updates, CI fails.
 - Use `[skip-doc-sync-check]` in the PR body only for explicit exceptions, and include the reason.
 

--- a/docs/docs-update-flow.ja.md
+++ b/docs/docs-update-flow.ja.md
@@ -54,6 +54,7 @@
 
 ## CIガード（Issue #132）
 
+- GitHub Actions workflow file の静的検証として、PR と `main` push で `actionlint` を実行する。
 - PR では `docs_drift_guard` ジョブが `scripts/check-doc-sync.mjs` を実行する。
 - 対象実装（LLM/desktop配布系）が変わったのに主要docsが未更新の場合、CI は失敗する。
 - 例外運用が必要な場合のみ、PR本文に `[skip-doc-sync-check]` を明記し、理由を添える。

--- a/docs/docs-update-flow.ja.md
+++ b/docs/docs-update-flow.ja.md
@@ -56,6 +56,7 @@
 
 - GitHub Actions workflow file の静的検証として、PR と `main` push で `actionlint` を実行する。
 - PR では `docs_drift_guard` ジョブが `scripts/check-doc-sync.mjs` を実行する。
+- ローカル実行では commit 済み、stage 済み、未stage、untracked の差分を対象にする。
 - 対象実装（LLM/desktop配布系）が変わったのに主要docsが未更新の場合、CI は失敗する。
 - 例外運用が必要な場合のみ、PR本文に `[skip-doc-sync-check]` を明記し、理由を添える。
 

--- a/docs/release-runbook.en.md
+++ b/docs/release-runbook.en.md
@@ -34,6 +34,7 @@ Related docs:
 - `Apple secrets present`
   - Runs code signing + notarization
   - Produces release-candidate artifacts
+  - For `v0.0.0-smoke.*` tags, still runs the signed/notarized path but marks the Draft Release as prerelease and keeps it for internal evidence only
 - `Apple secrets missing`
   - Workflow continues in unsigned internal mode
   - Draft Release is generated only for `v0.0.0-smoke.*` tags (internal testing only)
@@ -101,6 +102,19 @@ Related docs:
   - `gh secret list --repo gatyoukatyou/cli-commentator` shows Apple secrets are present except `APPLE_CERTIFICATE`
   - signed/notarized distribution remains blocked by `#138`
 
+## 0.8) Current #138 Signing Readiness Snapshot (2026-05-09)
+
+- Repository secrets:
+  - Present: `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`
+  - Missing: `APPLE_CERTIFICATE`
+- Local shell checks:
+  - `pnpm verify:apple-signing:detect` only inspects environment variables in the current shell, not repository secret names.
+  - Therefore, a local run can report all Apple secrets as missing even when repository secrets already exist.
+- Remaining blocker:
+  - Issue/export a Developer ID Application certificate with its private key as `.p12`
+  - Base64-encode the `.p12` and register it as `APPLE_CERTIFICATE`
+  - Rotate `APPLE_CERTIFICATE_PASSWORD` at the same time if the `.p12` export password changes
+
 ## 1) Pre-release checks (required)
 
 ### 1-1. Local verification
@@ -151,6 +165,7 @@ Notes:
 4. Confirm `release-desktop` workflow passes
 5. Validate Draft Release assets
    - signed mode: signed/notarized artifacts
+   - signed smoke mode (`v0.0.0-smoke.*` with Apple secrets present): signed/notarized artifacts, `isDraft=true`, `isPrerelease=true`
    - unsigned mode: internal-test artifacts (Gatekeeper warning expected)
 6. Publish draft when validation is complete
 
@@ -178,6 +193,12 @@ Actions:
 2. Set `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`
 3. Export values in the same shell and run `pnpm verify:apple-signing` (require mode) for format validation
 4. Re-run with a new tag and confirm signed mode
+   - Check `Detect Apple signing/notarization mode`: `enabled=true`
+   - Check `Configure macOS keychain for code signing`: certificate import succeeds
+   - Check `Detect code signing identity`: a Developer ID identity is detected
+   - Check `Log notarization configuration`: expected Apple Team ID/account domain is logged
+   - Check `Build and draft release (signed + notarized)`: succeeds for both arm64/x64 jobs
+   - Check Draft Release assets include `latest.json`, `.app.tar.gz`, `.sig`, and `.dmg`
 5. If budget is not available yet, run `pnpm verify:apple-signing:detect` to confirm missing-secret state only
 6. If budget is not available yet, continue using unsigned mode for internal validation
    - unsigned mode is allowed only with `v0.0.0-smoke.*` tags

--- a/docs/release-runbook.ja.md
+++ b/docs/release-runbook.ja.md
@@ -34,6 +34,7 @@
 - `Apple secrets あり`
   - 従来どおり署名 + notarization を実施
   - 正式配布候補の成果物を生成
+  - `v0.0.0-smoke.*` タグでは signed/notarized 経路を実行しつつ、Draft Release は prerelease として内部証跡用に残す
 - `Apple secrets なし`
   - workflow は unsigned internal モードで継続
   - `v0.0.0-smoke.*` タグのみ Draft Release を作成（内部検証用途）
@@ -101,6 +102,19 @@
   - `gh secret list --repo gatyoukatyou/cli-commentator` 上で Apple secrets は `APPLE_CERTIFICATE` のみ未登録
   - signed/notarized 配布は引き続き `#138` の解消待ち
 
+## 0.8) 現在の #138 署名 readiness snapshot（2026-05-09）
+
+- Repository secrets:
+  - 登録済み: `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`
+  - 未登録: `APPLE_CERTIFICATE`
+- ローカル shell の確認:
+  - `pnpm verify:apple-signing:detect` は現在の shell の環境変数だけを見る。GitHub repository secret 名の存在は見ない。
+  - そのため、repository secrets が登録済みでも、ローカル実行では Apple secrets がすべて missing と表示されることがある。
+- 残 blocker:
+  - Developer ID Application certificate を private key 付きで `.p12` export
+  - `.p12` を base64 化して `APPLE_CERTIFICATE` に登録
+  - `.p12` export password を変える場合は `APPLE_CERTIFICATE_PASSWORD` も同時更新
+
 ## 1) リリース前チェック（必須）
 
 ### 1-1. ローカル検証
@@ -152,6 +166,7 @@ pnpm smoke:desktop-distribution
 4. Actions の `release-desktop` 実行を確認
 5. Draft Release の成果物を確認
    - signedモード: 署名/notarization済み成果物
+   - signed smokeモード（Apple secrets 登録済みの `v0.0.0-smoke.*`）: 署名/notarization済み成果物、`isDraft=true`、`isPrerelease=true`
    - unsignedモード: 内部検証用成果物（Gatekeeper警告あり）
 6. 問題なければ Draft を Publish
 
@@ -179,6 +194,12 @@ pnpm smoke:desktop-distribution
 2. `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` を登録
 3. 同じシェルに値を展開し `pnpm verify:apple-signing`（require mode）で形式検証
 4. Secrets を追加後、新しいタグで signedモード実行を確認
+   - `Detect Apple signing/notarization mode`: `enabled=true`
+   - `Configure macOS keychain for code signing`: certificate import 成功
+   - `Detect code signing identity`: Developer ID identity 検出
+   - `Log notarization configuration`: 期待する Apple Team ID/account domain が表示される
+   - `Build and draft release (signed + notarized)`: arm64/x64 両jobで成功
+   - Draft Release assets に `latest.json`, `.app.tar.gz`, `.sig`, `.dmg` が揃う
 5. 予算都合で未設定の場合は `pnpm verify:apple-signing:detect` で不足状態のみ確認
 6. 予算都合で未設定の場合は内部検証用途として運用継続
    - unsigned 実行は `v0.0.0-smoke.*` タグでのみ可能

--- a/scripts/check-doc-sync.mjs
+++ b/scripts/check-doc-sync.mjs
@@ -49,6 +49,21 @@ function run(command) {
   return execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
 
+function parseFileList(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function runFileList(command) {
+  try {
+    return parseFileList(run(command));
+  } catch {
+    return [];
+  }
+}
+
 function parseArgs(argv) {
   const parsed = {
     baseRef: process.env.GITHUB_BASE_REF || "main",
@@ -105,22 +120,33 @@ function readPullRequestBody() {
 function getChangedFiles(baseRef, headRef) {
   const ranges = [`origin/${baseRef}...${headRef}`, `${baseRef}...${headRef}`];
   let lastError = null;
+  let committedFiles = [];
+  let resolvedRange = false;
 
   for (const range of ranges) {
     try {
       const output = run(`git diff --name-only --diff-filter=ACMRTUXB ${range}`);
-      return output
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean);
+      committedFiles = parseFileList(output);
+      resolvedRange = true;
+      break;
     } catch (error) {
       lastError = error;
     }
   }
 
-  throw new Error(
-    `Could not resolve git diff range for base '${baseRef}' and head '${headRef}'. ${String(lastError)}`
-  );
+  if (!resolvedRange) {
+    throw new Error(
+      `Could not resolve git diff range for base '${baseRef}' and head '${headRef}'. ${String(lastError)}`
+    );
+  }
+
+  const localFiles = [
+    ...runFileList("git diff --name-only --diff-filter=ACMRTUXB"),
+    ...runFileList("git diff --cached --name-only --diff-filter=ACMRTUXB"),
+    ...runFileList("git ls-files --others --exclude-standard"),
+  ];
+
+  return [...new Set([...committedFiles, ...localFiles])].sort();
 }
 
 function main() {


### PR DESCRIPTION
## Summary

- Mark signed `v0.0.0-smoke.*` desktop releases as prerelease drafts with signed-smoke naming/body.
- Add a current #138 Apple signing readiness snapshot and explicit signed/notarized verification steps to the release runbook.
- Add an `actionlint` CI job for workflow static checks.
- Update `check-doc-sync` so local runs include committed, staged, unstaged, and untracked changes.

## Validation

- `actionlint -color`
- `pnpm check:doc-sync`
- `git diff --check`
- YAML parse for `.github/workflows/*.yml`
- `gh secret list --repo gatyoukatyou/cli-commentator` confirms `APPLE_CERTIFICATE` is still the missing Apple signing secret.

## Remaining #138 work

`APPLE_CERTIFICATE` still needs to be registered from the base64-encoded Developer ID Application `.p12`. After that, run a fresh `v0.0.0-smoke.*` tag against this branch/commit and confirm the signed + notarized path, Draft Release metadata, and artifacts.