### PR TITLE
[codex] Harden unsigned desktop distribution smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,15 +234,7 @@ jobs:
             --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Verify desktop build outputs
-        run: |
-          set -euo pipefail
-          bundle_dir="apps/desktop/src-tauri/target/release/bundle"
-          test -d "${bundle_dir}"
-          if ! find "${bundle_dir}" -name "*.app" | grep -q .; then
-            echo "Desktop app bundle artifacts were not produced."
-            exit 1
-          fi
-          find "${bundle_dir}" -name "*.app"
+        run: node scripts/verify-desktop-bundle-artifacts.mjs apps/desktop/src-tauri/target/release/bundle --require app
 
       - name: Desktop distribution runtime smoke
         run: pnpm smoke:desktop-distribution

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -200,8 +200,8 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          releaseName: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && format('CLI Commentator {0} (signed smoke)', github.ref_name) || format('CLI Commentator {0}', github.ref_name) }}
-          releaseBody: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && 'Signed and notarized internal smoke build. Validate artifacts and keep the draft unpublished.' || 'See the assets to download and install this version.' }}
+          releaseName: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && format('CLI Commentator {0} (Signed Smoke)', github.ref_name) || format('CLI Commentator {0}', github.ref_name) }}
+          releaseBody: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') && 'Signed Smoke internal test build. Apple Developer ID signing and notarization were enabled; validate artifacts and keep the draft unpublished.' || 'See the assets to download and install this version.' }}
           releaseDraft: true
           prerelease: ${{ startsWith(github.ref_name, 'v0.0.0-smoke.') }}
           args: ${{ matrix.args }}
@@ -216,8 +216,8 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          releaseName: CLI Commentator ${{ github.ref_name }} (unsigned internal)
-          releaseBody: Unsigned internal test build from ${{ github.ref_name }}. Apple Developer ID signing/notarization is not configured.
+          releaseName: CLI Commentator ${{ github.ref_name }} (Unsigned Smoke)
+          releaseBody: Unsigned Smoke internal test build from ${{ github.ref_name }}. Apple Developer ID signing/notarization is not configured; Gatekeeper warnings are expected.
           releaseDraft: true
           prerelease: true
           args: ${{ matrix.args }}
@@ -258,14 +258,12 @@ jobs:
             fi
           fi
           test -d "${bundle_dir}"
-          find "${bundle_dir}" -name "*.dmg" | grep -q .
-          find "${bundle_dir}" -name "*.app.tar.gz" | grep -q .
-          find "${bundle_dir}" -name "*.app.tar.gz.sig" | grep -q .
+          node scripts/verify-desktop-bundle-artifacts.mjs "${bundle_dir}" --require dmg --require app-tar-gz --require sig
           echo "bundle_dir=${bundle_dir}" >> "$GITHUB_OUTPUT"
 
       - name: Upload smoke artifacts (token fallback)
         if: ${{ steps.release_token.outputs.write_capable != 'true' && startsWith(github.ref_name, 'v0.0.0-smoke.') }}
         uses: actions/upload-artifact@v7
         with:
-          name: smoke-bundle-${{ steps.fallback_target.outputs.triple }}
+          name: unsigned-smoke-bundle-${{ steps.fallback_target.outputs.triple }}
           path: ${{ steps.fallback_build.outputs.bundle_dir }}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,31 @@ struct UpdaterCheckStatus {
     error: Option<String>,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopDiagnostics {
+    version: String,
+    platform: String,
+    arch: String,
+    log_dir: Option<String>,
+    config_dir: Option<String>,
+}
+
+fn path_to_string(path: Result<std::path::PathBuf, tauri::Error>) -> Option<String> {
+    path.ok().map(|value| value.display().to_string())
+}
+
+#[tauri::command]
+fn desktop_diagnostics(app: tauri::AppHandle) -> DesktopDiagnostics {
+    DesktopDiagnostics {
+        version: app.package_info().version.to_string(),
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        log_dir: path_to_string(app.path().app_log_dir()),
+        config_dir: path_to_string(app.path().app_config_dir()),
+    }
+}
+
 #[tauri::command]
 fn autostart_status(app: tauri::AppHandle) -> Result<bool, String> {
     app.autolaunch()
@@ -112,6 +137,7 @@ pub fn run() {
             autostart_status,
             autostart_enable,
             autostart_disable,
+            desktop_diagnostics,
             updater_check
         ])
         .on_window_event(|window, event| {

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -436,6 +436,16 @@
   gap: var(--space-2);
 }
 
+.debug-panel__diagnostic-list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.debug-panel__diagnostic-path {
+  display: grid;
+  gap: 6px;
+}
+
 .debug-panel__command {
   display: grid;
   gap: 6px;

--- a/apps/web/src/components/TauriStatusPanel.tsx
+++ b/apps/web/src/components/TauriStatusPanel.tsx
@@ -12,6 +12,14 @@ type UpdaterCheckStatus = {
   error: string | null;
 };
 
+type DesktopDiagnostics = {
+  version: string;
+  platform: string;
+  arch: string;
+  logDir: string | null;
+  configDir: string | null;
+};
+
 type TauriStatusPanelProps = {
   onStatusChange?: (status: ServerStatusDetail | null) => void;
 };
@@ -39,6 +47,8 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
   const [autostartLoading, setAutostartLoading] = useState(false);
   const [updaterStatus, setUpdaterStatus] = useState<UpdaterCheckStatus | null>(null);
   const [updaterLoading, setUpdaterLoading] = useState(false);
+  const [diagnostics, setDiagnostics] = useState<DesktopDiagnostics | null>(null);
+  const [copiedDiagnosticPath, setCopiedDiagnosticPath] = useState<string | null>(null);
   const [copiedRecoveryCommand, setCopiedRecoveryCommand] = useState<string | null>(null);
 
   useEffect(() => {
@@ -76,20 +86,24 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
     if (!isTauri) return;
     let cancelled = false;
 
-    const fetchAutostart = async () => {
+    const fetchDesktopMetadata = async () => {
       const core = getTauriCore();
       if (!core) return;
       try {
-        const result = await core.invoke("autostart_status");
+        const [autostartResult, diagnosticsResult] = await Promise.all([
+          core.invoke("autostart_status"),
+          core.invoke("desktop_diagnostics"),
+        ]);
         if (cancelled) return;
-        setAutostartEnabled(Boolean(result));
+        setAutostartEnabled(Boolean(autostartResult));
+        setDiagnostics(diagnosticsResult as DesktopDiagnostics);
       } catch (err) {
         if (cancelled) return;
         setInvokeError(errorToMessage(err));
       }
     };
 
-    fetchAutostart();
+    fetchDesktopMetadata();
     return () => {
       cancelled = true;
     };
@@ -227,6 +241,18 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
     }, 1600);
   };
 
+  const handleCopyDiagnosticPath = async (value: string) => {
+    const copied = await copyWithFallback(value);
+    if (!copied) {
+      setInvokeError("パスのコピーに失敗しました。");
+      return;
+    }
+    setCopiedDiagnosticPath(value);
+    window.setTimeout(() => {
+      setCopiedDiagnosticPath((current) => (current === value ? null : current));
+    }, 1600);
+  };
+
   return (
     <div className="debug-panel">
       <div className="debug-panel__title">Desktop Server</div>
@@ -262,6 +288,20 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
             <span className="debug-panel__label">Updater</span>
             <span>{updaterLabel}</span>
           </div>
+          {diagnostics && (
+            <>
+              <div className="debug-panel__row">
+                <span className="debug-panel__label">Version</span>
+                <span>v{diagnostics.version}</span>
+              </div>
+              <div className="debug-panel__row">
+                <span className="debug-panel__label">Platform</span>
+                <span>
+                  {diagnostics.platform}/{diagnostics.arch}
+                </span>
+              </div>
+            </>
+          )}
           {status.transitioned_at && (
             <div className="debug-panel__meta">
               状態更新: {new Date(status.transitioned_at).toLocaleTimeString()}
@@ -286,6 +326,46 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
         <div className={`debug-panel__alert ${updaterNotice.className}`}>
           <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "inherit" }}>{updaterNotice.text}</pre>
         </div>
+      )}
+      {diagnostics && (
+        <section className="debug-panel__recovery-card" aria-label="desktop diagnostics">
+          <div className="debug-panel__recovery-header">
+            <div className="debug-panel__meta">Troubleshooting</div>
+            <div className="debug-panel__recovery-summary">問い合わせ時は Version、Platform、Logs path を添えてください。</div>
+          </div>
+          <div className="debug-panel__diagnostic-list">
+            {diagnostics.logDir && (
+              <div className="debug-panel__diagnostic-path">
+                <span className="debug-panel__recovery-label">Logs path</span>
+                <code className="debug-panel__command-code">{diagnostics.logDir}</code>
+                <button
+                  type="button"
+                  className="debug-panel__copy-btn"
+                  onClick={() => {
+                    void handleCopyDiagnosticPath(diagnostics.logDir ?? "");
+                  }}
+                >
+                  {copiedDiagnosticPath === diagnostics.logDir ? "Copied" : "Copy"}
+                </button>
+              </div>
+            )}
+            {diagnostics.configDir && (
+              <div className="debug-panel__diagnostic-path">
+                <span className="debug-panel__recovery-label">Config path</span>
+                <code className="debug-panel__command-code">{diagnostics.configDir}</code>
+                <button
+                  type="button"
+                  className="debug-panel__copy-btn"
+                  onClick={() => {
+                    void handleCopyDiagnosticPath(diagnostics.configDir ?? "");
+                  }}
+                >
+                  {copiedDiagnosticPath === diagnostics.configDir ? "Copied" : "Copy"}
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
       )}
       {failureGuidance && (
         <section className="debug-panel__recovery-card" aria-label="startup recovery guidance">

--- a/docs/release-runbook.en.md
+++ b/docs/release-runbook.en.md
@@ -166,8 +166,64 @@ Notes:
 5. Validate Draft Release assets
    - signed mode: signed/notarized artifacts
    - signed smoke mode (`v0.0.0-smoke.*` with Apple secrets present): signed/notarized artifacts, `isDraft=true`, `isPrerelease=true`
-   - unsigned mode: internal-test artifacts (Gatekeeper warning expected)
+   - unsigned mode: internal-test artifacts (`Unsigned Smoke`, `isDraft=true`, `isPrerelease=true`; Gatekeeper warning expected)
 6. Publish draft when validation is complete
+
+## 2.5) Unsigned Install Cheats
+
+Current `release-desktop` smoke automation publishes macOS artifacts (`.dmg`, `.app.tar.gz`, `.sig`) from the macOS matrix. Use the Windows/Linux notes when equivalent artifacts are produced by a local build or a future release matrix.
+
+### macOS unsigned install
+
+1. Download the `.dmg` from the `Unsigned Smoke` Draft Release.
+2. Open the `.dmg`.
+3. Drag `CLI Commentator.app` into `Applications`.
+4. Launch from Finder.
+
+If macOS blocks first launch:
+
+1. In Finder, right-click `CLI Commentator.app`.
+2. Choose `Open`.
+3. Confirm the unsigned-app warning.
+4. If the button is still blocked, open `System Settings` -> `Privacy & Security`, then choose `Open Anyway` for CLI Commentator.
+
+Common warnings:
+
+- `cannot be opened because the developer cannot be verified`: expected for unsigned smoke builds; use Finder right-click -> `Open`.
+- `was blocked from use because it is not from an identified developer`: expected for unsigned smoke builds; use `Privacy & Security` -> `Open Anyway`.
+- `is damaged and can't be opened`: remove quarantine only for an internal smoke artifact that came from this repository release, then retry:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/CLI Commentator.app"
+```
+
+### Windows unsigned install
+
+When Windows artifacts are produced:
+
+1. Download the installer/archive from the `Unsigned Smoke` release.
+2. If SmartScreen appears, choose `More info`.
+3. Confirm the publisher is unknown/unsigned, then choose `Run anyway`.
+4. If Microsoft Defender blocks the file, keep the file only when it came from the repository release, then retry after the Defender prompt allows it.
+
+### Linux unsigned install
+
+When Linux artifacts are produced:
+
+1. Download the archive or AppImage from the `Unsigned Smoke` release.
+2. For AppImage-style artifacts, add execute permission:
+
+```bash
+chmod +x ./CLI-Commentator*.AppImage
+```
+
+3. Run it from a terminal first so startup errors stay visible.
+
+```bash
+./CLI-Commentator*.AppImage
+```
+
+For `.tar.gz` archives, extract the archive and run the included executable from the extracted directory.
 
 ## 3) Failure recovery playbook
 

--- a/docs/release-runbook.ja.md
+++ b/docs/release-runbook.ja.md
@@ -167,8 +167,64 @@ pnpm smoke:desktop-distribution
 5. Draft Release の成果物を確認
    - signedモード: 署名/notarization済み成果物
    - signed smokeモード（Apple secrets 登録済みの `v0.0.0-smoke.*`）: 署名/notarization済み成果物、`isDraft=true`、`isPrerelease=true`
-   - unsignedモード: 内部検証用成果物（Gatekeeper警告あり）
+   - unsignedモード: 内部検証用成果物（`Unsigned Smoke`, `isDraft=true`, `isPrerelease=true`; Gatekeeper警告あり）
 6. 問題なければ Draft を Publish
+
+## 2.5) Unsigned install cheats
+
+現在の `release-desktop` smoke automation は macOS matrix から macOS artifacts（`.dmg`, `.app.tar.gz`, `.sig`）を生成する。Windows/Linux の手順は、ローカル build または将来の release matrix で該当 artifacts を生成した場合に使う。
+
+### macOS unsigned install
+
+1. `Unsigned Smoke` Draft Release から `.dmg` をダウンロード
+2. `.dmg` を開く
+3. `CLI Commentator.app` を `Applications` にドラッグ
+4. Finder から起動
+
+初回起動で macOS にブロックされた場合:
+
+1. Finder で `CLI Commentator.app` を右クリック
+2. `開く` を選ぶ
+3. unsigned app の警告を確認して開く
+4. それでもブロックされる場合は `システム設定` -> `プライバシーとセキュリティ` を開き、CLI Commentator の `このまま開く` を選ぶ
+
+代表的な警告:
+
+- `開発元を検証できないため開けません`: unsigned smoke builds では想定内。Finder の右クリック -> `開く` を使う。
+- `未確認の開発元からのアプリケーション`: unsigned smoke builds では想定内。`プライバシーとセキュリティ` -> `このまま開く` を使う。
+- `壊れているため開けません`: この repository release から取得した internal smoke artifact に限り quarantine を外して再試行する。
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/CLI Commentator.app"
+```
+
+### Windows unsigned install
+
+Windows artifacts を生成した場合:
+
+1. `Unsigned Smoke` release から installer/archive をダウンロード
+2. SmartScreen が出たら `詳細情報` を選ぶ
+3. publisher が unknown/unsigned であることを確認し、`実行` を選ぶ
+4. Microsoft Defender がブロックした場合は、この repository release から取得した artifact であることを確認してから、Defender prompt で許可して再試行する
+
+### Linux unsigned install
+
+Linux artifacts を生成した場合:
+
+1. `Unsigned Smoke` release から archive または AppImage をダウンロード
+2. AppImage 形式なら実行権限を付ける
+
+```bash
+chmod +x ./CLI-Commentator*.AppImage
+```
+
+3. 最初は terminal から実行し、startup error が見える状態で確認する
+
+```bash
+./CLI-Commentator*.AppImage
+```
+
+`.tar.gz` の場合は archive を展開し、展開先の executable を実行する。
 
 ## 3) 障害時の復旧手順
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke:llm": "bash ./scripts/smoke-llm.sh",
     "verify:apple-signing:detect": "node ./scripts/verify-apple-signing-secrets.mjs --mode detect",
     "verify:apple-signing": "node ./scripts/verify-apple-signing-secrets.mjs --mode require",
+    "verify:desktop-bundle-artifacts": "node ./scripts/verify-desktop-bundle-artifacts.mjs",
     "verify:internal-release": "node ./scripts/verify-internal-release-readiness.mjs",
     "verify:release-token": "node ./scripts/verify-release-token-permissions.mjs --mode require-write",
     "verify:updater": "node ./scripts/verify-updater-config.mjs"

--- a/scripts/verify-desktop-bundle-artifacts.mjs
+++ b/scripts/verify-desktop-bundle-artifacts.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const REQUIREMENTS = {
+  app: {
+    label: ".app bundle",
+    match: (filePath, stats) => stats.isDirectory() && filePath.endsWith(".app"),
+  },
+  dmg: {
+    label: ".dmg installer",
+    match: (filePath, stats) => stats.isFile() && filePath.endsWith(".dmg"),
+  },
+  "app-tar-gz": {
+    label: ".app.tar.gz updater archive",
+    match: (filePath, stats) => stats.isFile() && filePath.endsWith(".app.tar.gz"),
+  },
+  sig: {
+    label: ".sig updater signature",
+    match: (filePath, stats) => stats.isFile() && filePath.endsWith(".sig"),
+  },
+};
+
+function fail(message) {
+  console.error(`[desktop-artifacts] ERROR: ${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {
+    bundleDir: null,
+    requirements: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--require") {
+      const next = argv[index + 1];
+      if (!next) fail("--require needs one of: app, dmg, app-tar-gz, sig");
+      if (!REQUIREMENTS[next]) fail(`Unknown artifact requirement: ${next}`);
+      args.requirements.push(next);
+      index += 1;
+      continue;
+    }
+    if (value === "--help" || value === "-h") {
+      console.log(
+        [
+          "Usage: node scripts/verify-desktop-bundle-artifacts.mjs <bundle-dir> [--require <kind>...]",
+          "",
+          "Kinds: app, dmg, app-tar-gz, sig",
+        ].join("\n")
+      );
+      process.exit(0);
+    }
+    if (!args.bundleDir) {
+      args.bundleDir = value;
+      continue;
+    }
+    fail(`Unexpected argument: ${value}`);
+  }
+
+  if (!args.bundleDir) fail("Bundle directory is required");
+  if (args.requirements.length === 0) args.requirements.push("app");
+  return args;
+}
+
+function walk(rootDir) {
+  const found = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || !existsSync(current)) continue;
+    const entries = readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      const stats = statSync(fullPath);
+      found.push({ path: fullPath, stats });
+      if (entry.isDirectory() && !entry.name.endsWith(".app")) {
+        stack.push(fullPath);
+      }
+    }
+  }
+  return found.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function directorySize(rootDir) {
+  let total = 0;
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const stats = statSync(current);
+    if (stats.isFile()) {
+      total += stats.size;
+      continue;
+    }
+    if (!stats.isDirectory()) continue;
+    for (const entry of readdirSync(current)) {
+      stack.push(path.join(current, entry));
+    }
+  }
+  return total;
+}
+
+function artifactSize(entry) {
+  return entry.stats.isDirectory() ? directorySize(entry.path) : entry.stats.size;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const bundleDir = path.resolve(args.bundleDir);
+  if (!existsSync(bundleDir)) fail(`Bundle directory does not exist: ${bundleDir}`);
+
+  const entries = walk(bundleDir);
+  for (const requirement of args.requirements) {
+    const rule = REQUIREMENTS[requirement];
+    const matches = entries.filter((entry) => rule.match(entry.path, entry.stats));
+    if (matches.length === 0) fail(`Missing required artifact: ${rule.label}`);
+
+    for (const match of matches) {
+      const size = artifactSize(match);
+      if (size <= 0) fail(`Artifact is empty: ${match.path}`);
+      console.log(`[desktop-artifacts] ${rule.label}: ${path.relative(process.cwd(), match.path)} (${size} bytes)`);
+    }
+  }
+
+  console.log("[desktop-artifacts] Desktop bundle artifact checks passed.");
+}
+
+main();


### PR DESCRIPTION
## Summary

- Clarify `Unsigned Smoke` versus `Signed Smoke` release metadata in `release-desktop`.
- Add OS-specific unsigned install steps to the desktop release runbook.
- Add a Tauri desktop diagnostics command and show version/platform/log/config paths in the Desktop Server panel.
- Add a reusable desktop bundle artifact verifier and wire it into CI/release fallback checks.

## Validation

- `actionlint -color`
- `pnpm check:doc-sync`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web build`
- `git diff --check`
- `node scripts/verify-desktop-bundle-artifacts.mjs <fake-bundle> --require app --require dmg --require app-tar-gz --require sig`

## Note

Local `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` could not run because this machine does not currently have `cargo` on PATH. The PR CI `desktop_check` job should cover Rust/Tauri compilation.