### PR TITLE
test(release): verify desktop bundle contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "concurrently": "^9.0.0",
     "cross-env": "^10.1.0",
+    "plist": "^5.0.0",
+    "tar": "^7.5.15",
     "wait-on": "^9.0.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      plist:
+        specifier: ^5.0.0
+        version: 5.0.0
+      tar:
+        specifier: ^7.5.15
+        version: 7.5.15
       wait-on:
         specifier: ^9.0.5
         version: 9.0.5
@@ -491,6 +497,10 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -948,6 +958,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1019,6 +1033,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1462,6 +1480,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1523,6 +1549,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  plist@5.0.0:
+    resolution: {integrity: sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==}
+    engines: {node: '>=18'}
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
@@ -1629,6 +1659,10 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1847,6 +1881,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
   xterm-addon-fit@0.8.0:
     resolution: {integrity: sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==}
     deprecated: This package is now deprecated. Move to @xterm/addon-fit instead.
@@ -1863,6 +1901,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2249,6 +2291,10 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2652,6 +2698,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xmldom/xmldom@0.9.10': {}
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -2720,6 +2768,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chownr@3.0.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3149,6 +3199,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -3197,6 +3253,11 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  plist@5.0.0:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      xmlbuilder: 15.1.1
 
   postcss@8.5.13:
     dependencies:
@@ -3324,6 +3385,14 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tinybench@2.9.0: {}
 
@@ -3478,6 +3547,8 @@ snapshots:
 
   ws@8.20.0: {}
 
+  xmlbuilder@15.1.1: {}
+
   xterm-addon-fit@0.8.0(xterm@5.3.0):
     dependencies:
       xterm: 5.3.0
@@ -3487,6 +3558,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/scripts/verify-desktop-bundle-artifacts.mjs
+++ b/scripts/verify-desktop-bundle-artifacts.mjs
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
+import * as plist from "plist";
+import * as tar from "tar";
+
+const EXPECTED_BUNDLE_IDENTIFIER = "com.cli-commentator.desktop";
+const EXPECTED_BUNDLE_EXECUTABLE = "cli-commentator-desktop";
+const EXPECTED_PLATFORM_ASSETS = {
+  "darwin-aarch64": "aarch64.app.tar.gz",
+  "darwin-aarch64-app": "aarch64.app.tar.gz",
+  "darwin-x86_64": "x64.app.tar.gz",
+  "darwin-x86_64-app": "x64.app.tar.gz",
+};
 
 const REQUIREMENTS = {
   app: {
@@ -106,12 +117,198 @@ function artifactSize(entry) {
   return entry.stats.isDirectory() ? directorySize(entry.path) : entry.stats.size;
 }
 
-function main() {
+function normalizeTarPath(value) {
+  return value.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function hasTarEntry(entries, predicate) {
+  return entries.some((entry) => predicate(normalizeTarPath(entry)));
+}
+
+async function listTarEntries(archivePath) {
+  const entries = [];
+  await tar.t({
+    file: archivePath,
+    onentry(entry) {
+      entries.push(normalizeTarPath(entry.path));
+    },
+  });
+  return entries.sort((a, b) => a.localeCompare(b));
+}
+
+async function readTarEntry(archivePath, entryPath) {
+  const chunks = [];
+  let found = false;
+  await tar.t({
+    file: archivePath,
+    onentry(entry) {
+      if (normalizeTarPath(entry.path) !== entryPath) {
+        entry.resume();
+        return;
+      }
+      found = true;
+      entry.on("data", (chunk) => chunks.push(chunk));
+    },
+  });
+  if (!found) fail(`Missing archive entry: ${archivePath} -> ${entryPath}`);
+  return Buffer.concat(chunks);
+}
+
+function parseLatestJson(bundleDir, entries) {
+  const latestMatches = entries
+    .filter((entry) => entry.stats.isFile() && path.basename(entry.path) === "latest.json")
+    .map((entry) => entry.path);
+  if (latestMatches.length === 0) return null;
+  if (latestMatches.length > 1) fail(`Found multiple latest.json files: ${latestMatches.join(", ")}`);
+
+  const latestPath = latestMatches[0];
+
+  let latest;
+  try {
+    latest = JSON.parse(readFileSync(latestPath, "utf8"));
+  } catch (error) {
+    fail(`latest.json is not valid JSON: ${latestPath} (${error.message})`);
+  }
+
+  for (const key of ["version", "notes", "pub_date", "platforms"]) {
+    if (!Object.hasOwn(latest, key)) fail(`latest.json missing required key: ${key}`);
+  }
+  if (typeof latest.version !== "string" || latest.version.trim().length === 0) {
+    fail("latest.json version must be a non-empty string");
+  }
+  if (typeof latest.notes !== "string") fail("latest.json notes must be a string");
+  if (Number.isNaN(Date.parse(latest.pub_date))) fail(`latest.json pub_date is not parseable: ${latest.pub_date}`);
+  if (!latest.platforms || typeof latest.platforms !== "object" || Array.isArray(latest.platforms)) {
+    fail("latest.json platforms must be an object");
+  }
+
+  return { path: latestPath, data: latest };
+}
+
+function validateLatestJson(latest, entries) {
+  if (!latest) return;
+
+  const assetNames = new Set(
+    entries.filter((entry) => entry.stats.isFile()).map((entry) => path.basename(entry.path))
+  );
+
+  for (const [platform, expectedAssetSuffix] of Object.entries(EXPECTED_PLATFORM_ASSETS)) {
+    const platformEntry = latest.data.platforms[platform];
+    if (!platformEntry) fail(`latest.json missing platform entry: ${platform}`);
+    if (typeof platformEntry.url !== "string" || platformEntry.url.trim().length === 0) {
+      fail(`latest.json ${platform}.url must be a non-empty string`);
+    }
+    if (typeof platformEntry.signature !== "string" || platformEntry.signature.trim().length === 0) {
+      fail(`latest.json ${platform}.signature must be a non-empty string`);
+    }
+
+    let basename;
+    try {
+      basename = path.posix.basename(new URL(platformEntry.url).pathname);
+    } catch (error) {
+      fail(`latest.json ${platform}.url is not a valid URL: ${platformEntry.url}`);
+    }
+
+    if (!basename.endsWith(expectedAssetSuffix)) {
+      fail(`latest.json ${platform}.url points to unexpected asset: ${basename}`);
+    }
+    if (!assetNames.has(basename)) {
+      fail(`latest.json ${platform}.url points to missing asset: ${basename}`);
+    }
+  }
+
+  console.log(`[desktop-artifacts] latest.json: ${path.relative(process.cwd(), latest.path)} (${latest.data.version})`);
+}
+
+function validateInfoPlist(plistData, archivePath, latest) {
+  if (plistData.CFBundleIdentifier !== EXPECTED_BUNDLE_IDENTIFIER) {
+    fail(
+      `${archivePath} Info.plist CFBundleIdentifier mismatch: expected ${EXPECTED_BUNDLE_IDENTIFIER}, got ${plistData.CFBundleIdentifier}`
+    );
+  }
+  if (plistData.CFBundleExecutable !== EXPECTED_BUNDLE_EXECUTABLE) {
+    fail(
+      `${archivePath} Info.plist CFBundleExecutable mismatch: expected ${EXPECTED_BUNDLE_EXECUTABLE}, got ${plistData.CFBundleExecutable}`
+    );
+  }
+
+  const bundleVersion = plistData.CFBundleShortVersionString;
+  const expectedVersion = latest?.data.version;
+  if (expectedVersion) {
+    if (bundleVersion !== expectedVersion) {
+      fail(`${archivePath} Info.plist version mismatch: latest.json=${expectedVersion}, Info.plist=${bundleVersion}`);
+    }
+    return;
+  }
+
+  if (typeof bundleVersion !== "string" || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(bundleVersion)) {
+    fail(`${archivePath} Info.plist CFBundleShortVersionString is not semver-like: ${bundleVersion}`);
+  }
+}
+
+async function validateAppTarGzArchive(archivePath, latest) {
+  let entries;
+  try {
+    entries = await listTarEntries(archivePath);
+  } catch (error) {
+    fail(`Unable to read .app.tar.gz archive: ${archivePath} (${error.message})`);
+  }
+
+  const infoPlists = entries.filter((entry) => /(^|\/)[^/]+\.app\/Contents\/Info\.plist$/.test(entry));
+  if (infoPlists.length === 0) fail(`${archivePath} missing *.app/Contents/Info.plist`);
+  if (infoPlists.length > 1) fail(`${archivePath} contains multiple Info.plist files: ${infoPlists.join(", ")}`);
+
+  const infoPlistPath = infoPlists[0];
+  const appRoot = infoPlistPath.slice(0, -"/Contents/Info.plist".length);
+  const infoPlistBuffer = await readTarEntry(archivePath, infoPlistPath);
+  let plistData;
+  try {
+    plistData = plist.parse(infoPlistBuffer.toString("utf8"));
+  } catch (error) {
+    fail(`${archivePath} Info.plist could not be parsed: ${error.message}`);
+  }
+
+  validateInfoPlist(plistData, archivePath, latest);
+
+  const executablePath = `${appRoot}/Contents/MacOS/${EXPECTED_BUNDLE_EXECUTABLE}`;
+  if (!entries.includes(executablePath)) fail(`${archivePath} missing app executable: ${executablePath}`);
+
+  if (!hasTarEntry(entries, (entry) => entry.startsWith(`${appRoot}/Contents/Resources/`) && entry !== `${appRoot}/Contents/Resources/`)) {
+    fail(`${archivePath} missing non-empty Contents/Resources`);
+  }
+
+  const hasServerResource = hasTarEntry(
+    entries,
+    (entry) =>
+      entry.includes("/Contents/Resources/resources/server/package.json") ||
+      entry.includes("/Contents/Resources/resources/server/dist/") ||
+      entry.includes("/Contents/Resources/resources/server/src/")
+  );
+  if (!hasServerResource) fail(`${archivePath} missing bundled server resources marker`);
+
+  const hasNodePtyResource = hasTarEntry(
+    entries,
+    (entry) =>
+      entry.includes("/node_modules/node-pty/") ||
+      entry.includes("/node_modules/node-pty-prebuilt-multiarch/") ||
+      entry.includes("/prebuilds/darwin-")
+  );
+  if (!hasNodePtyResource) fail(`${archivePath} missing node-pty/prebuilds marker`);
+
+  console.log(
+    `[desktop-artifacts] .app.tar.gz contents: ${path.relative(process.cwd(), archivePath)} (${appRoot}, ${plistData.CFBundleShortVersionString})`
+  );
+}
+
+async function main() {
   const args = parseArgs(process.argv.slice(2));
   const bundleDir = path.resolve(args.bundleDir);
   if (!existsSync(bundleDir)) fail(`Bundle directory does not exist: ${bundleDir}`);
 
   const entries = walk(bundleDir);
+  const latest = parseLatestJson(bundleDir, entries);
+  validateLatestJson(latest, entries);
+
   for (const requirement of args.requirements) {
     const rule = REQUIREMENTS[requirement];
     const matches = entries.filter((entry) => rule.match(entry.path, entry.stats));
@@ -121,10 +318,11 @@ function main() {
       const size = artifactSize(match);
       if (size <= 0) fail(`Artifact is empty: ${match.path}`);
       console.log(`[desktop-artifacts] ${rule.label}: ${path.relative(process.cwd(), match.path)} (${size} bytes)`);
+      if (requirement === "app-tar-gz") await validateAppTarGzArchive(match.path, latest);
     }
   }
 
   console.log("[desktop-artifacts] Desktop bundle artifact checks passed.");
 }
 
-main();
+main().catch((error) => fail(error?.message || String(error)));


### PR DESCRIPTION
## Summary
- extend desktop bundle artifact verification to inspect .app.tar.gz contents without macOS-only tools
- validate Info.plist identity/executable/version, bundled server/node-pty markers, and latest.json platform asset URLs/signatures
- add tar/plist dev dependencies for portable archive and plist parsing

## Verification
- pnpm verify:desktop-bundle-artifacts /tmp/release-desktop-assets-v0.0.0-smoke.20260509-135214 --require dmg --require app-tar-gz --require sig
- node scripts/verify-desktop-bundle-artifacts.mjs /tmp/desktop-bundle-positive/out --require app-tar-gz
- negative: missing latest.json asset URL fails
- negative: missing Info.plist archive fails
- pnpm check:doc-sync
- git diff --check