### PR TITLE
feat(web): add recovery hints for updater check failures

### DIFF
--- a/apps/web/src/components/TauriStatusPanel.tsx
+++ b/apps/web/src/components/TauriStatusPanel.tsx
@@ -220,8 +220,16 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
   const updaterNotice = (() => {
     if (!updaterStatus) return null;
     if (updaterStatus.error) {
+      const details = [
+        updaterStatus.error,
+        "確認ポイント:",
+        "- ネットワーク接続と GitHub への到達性",
+        "- Release の latest.json / .app.tar.gz / .sig の有無",
+        "- docs/desktop-release の Updater 配布契約",
+        "Copy Debug bundle を添えて共有してください。",
+      ];
       return {
-        text: `${updaterStatus.error}\nCopy Debug bundle を添えて共有してください。`,
+        text: details.join("\n"),
         className: "debug-panel__alert--crash",
       };
     }


### PR DESCRIPTION
## Summary
- add short self-serve hints when manual update checks fail
- point users to network/GitHub reachability, release asset consistency, and the desktop release updater contract
- keep Copy Debug bundle as the support handoff path

## Verification
- pnpm -C apps/web lint
- pnpm -C apps/web build
- pnpm check:doc-sync
- git diff --check