### PR TITLE
docs: refocus roadmap on local app polish

### DIFF
--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -130,21 +130,23 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 - PR #244: update `tauri-plugin-updater` to 2.10.1 and document it as updater plugin maintenance
 - PR #249: refresh the Tauri runtime stack to the 2.11 series and document it as runtime maintenance; #248 was closed as superseded
 - As of 2026-05-08, open PR count is 0 and the dependency-maintenance backlog has been cleared
+- PR #259 made Desktop sidecar preparation idempotent, so `dev:desktop:managed` can safely verify and regenerate bundled sidecar assets before startup
 
 **Now**
-- Release readiness is now concentrated on `#138`: Apple Developer ID certificate preparation, GitHub Secrets registration, `verify:apple-signing`, and a signed/notarized `release-desktop` smoke run
-- The unresolved work is operational readiness rather than a normal code implementation backlog: certificate issuance, `.p12` handling, `APPLE_CERTIFICATE` / password validation, and notarization evidence
-- Main is current after dependency-maintenance PR cleanup, with GitHub CI green across `docs_drift_guard`, `test`, `test_windows`, `desktop_check`, `desktop_distribution_smoke`, and CodeQL
+- Because we are not issuing an Apple Developer ID certificate for now, `#138` is treated as Deferred. Signed distribution readiness remains important, but we will return to it when certificate issuance and external distribution preparation resume
+- The near-term focus is local desktop app polish / local readiness instead of release readiness. The priority is a desktop app that starts reliably on a local machine and makes the next step obvious
+- Main is current after PR #259, with GitHub CI green across `test`, `test_windows`, `desktop_check`, `desktop_distribution_smoke`, and CodeQL
 
 **Next**
-- Complete the human-side `#138` work: issue / export the Developer ID Application certificate, register required GitHub Secrets, and rerun the release smoke tag
-- Confirm signed/notarized desktop artifacts (`latest.json`, `.app.tar.gz`, `.sig`, `.dmg`) from the release workflow before declaring public signed distribution ready
-- Refresh release notes and operator docs only if the signed/notarized smoke run changes the existing release procedure
+- Make the local `pnpm dev:desktop:managed` startup path easier to follow, especially first setup, sidecar/server startup waiting, and recovery guidance when startup fails
+- Consider a local readiness check script that can validate a clean checkout path, for example by running `ensure:desktop-sidecar`, web lint/build, server tests, and desktop cargo tests in order
+- Improve the standalone Web UI disconnected state and the Desktop managed flow that asks users to press Start before commentary can begin
+- Separate release readiness from local readiness so signing/notarization details do not dominate the local-use experience
 
 **Later**
 - Continue dependency and desktop runtime maintenance through the docs drift guard path
 - Keep improving failure-regression summaries and recovery evidence as new concrete failure cases appear
-- Resume UX/commentary-quality improvements after signed release readiness is unblocked
+- Return to `#138` when Apple Developer ID certificate issuance and distribution preparation resume, then run the signed/notarized `release-desktop` smoke and record evidence
 
 ---
 

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -135,21 +135,23 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 - PR #244：`tauri-plugin-updater` を 2.10.1 へ更新し、updater plugin maintenance として記録
 - PR #249：Tauri runtime stack を 2.11 系へ更新し、runtime maintenance として記録。#248 は内包済みとして close
 - 2026-05-08 時点で open PR は 0 件。依存更新PR群の整理は完了
+- PR #259：Desktop sidecar prepare を冪等化し、`dev:desktop:managed` 起動前に同梱sidecarを安全に確認・再生成できるようにした
 
 **Now**
-- release readiness の焦点は `#138` に集約。Apple Developer ID certificate 準備、GitHub Secrets 登録、`verify:apple-signing`、signed/notarized `release-desktop` smoke が残件
-- 残っているのは通常のコード実装というより、証明書発行、`.p12` 取り扱い、`APPLE_CERTIFICATE` / password 検証、notarization 証跡の運用 readiness
-- main は依存更新PR整理後の状態で最新化済み。GitHub CI は `docs_drift_guard` / `test` / `test_windows` / `desktop_check` / `desktop_distribution_smoke` / CodeQL が green
+- Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
+- 直近の焦点は release readiness ではなく local desktop app polish / local readiness。ローカルで安定して起動し、迷わず使えるデスクトップアプリとしての完成度を優先する
+- main は PR #259 反映後の状態で最新化済み。GitHub CI は `test` / `test_windows` / `desktop_check` / `desktop_distribution_smoke` / CodeQL が green
 
 **Next**
-- `#138` の人間側作業を完了する: Developer ID Application certificate の発行 / export、必要な GitHub Secrets 登録、release smoke tag の再実行
-- release workflow から signed/notarized desktop artifacts（`latest.json`, `.app.tar.gz`, `.sig`, `.dmg`）を確認してから、正式な signed 配布 ready と判断する
-- signed/notarized smoke により既存手順が変わる場合のみ、release notes / operator docs を追加更新する
+- `pnpm dev:desktop:managed` のローカル起動導線をさらに分かりやすくする。初回セットアップ、sidecar/server 起動待ち、失敗時の復旧案内を local 利用者目線で磨く
+- clean checkout から local readiness を確認できるスクリプトを検討する。例: `ensure:desktop-sidecar`、web lint/build、server test、desktop cargo test を順に実行する小さな検証入口
+- Web UI 単体起動時の「切断」表示と、Desktop managed 起動時の「まず Start する」導線を整理する
+- release readiness と local readiness の情報を分け、ローカル利用時に署名・notarization 関連情報が前面に出すぎないようにする
 
 **Later**
 - dependency / desktop runtime maintenance は docs drift guard 経由で継続運用する
 - 新しい具体的な失敗例が出たら、failure regression summary と recovery evidence を継続強化する
-- signed release readiness が unblock された後、UX / 実況品質改善へ戻る
+- Apple Developer ID 証明書の発行・配布準備を再開する段階で `#138` に戻り、signed/notarized `release-desktop` smoke と証跡記録を実施する
 
 ---
 


### PR DESCRIPTION
Refocuses the near-term roadmap on local desktop app polish while keeping #138 deferred until Apple Developer ID signing is revisited.