### PR TITLE
docs: add aion-ops bootstrap to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,24 @@
 # cli-commentator AI Agent Instructions
 
+<!-- aion-ops bootstrap v2026-07-02 | 正本: gatyoukatyou/aion-ops -->
+
+## 共通運用ルール（正本 = aion-ops）
+
+このリポジトリの3AI運用（KURO / Gino / JEM + HUMAN）の共通ルールは、`gatyoukatyou/aion-ops` を唯一の正本とする。
+
+作業開始時は、まず次を確認する。
+
+1. `aion-ops/docs/operations/minimal-operating-rules.md`
+2. `aion-ops/docs/operations/todoist-operation-rules.md`
+3. `aion-ops/docs/operations/github-workflow.md`
+4. `aion-ops/agents/kuro-claude.md`
+5. `aion-ops/templates/handoff-brief-template.md`
+
+ここにはルール本体を書き写さない。矛盾時は aion-ops を優先し、迷えば停止してHUMAN確認。
+mainへ直接pushしない。mergeはHUMANのみ。
+
+<!-- /aion-ops bootstrap -->
+
 ## Project Identity
 - **Project**: cli-commentator
 - **Repository**: https://github.com/gatyoukatyou/cli-commentator
@@ -10,9 +29,9 @@
 
 | Agent | Tool | Role |
 |-------|------|------|
-| KURO | Claude Code | 設計・実装（プライマリ） |
-| Codex | OpenAI Codex CLI | レビュー・小規模修正 |
-| JEM | Gemini CLI | 教育レポート・要約・UX助言 |
+| KURO | Claude Code | 現場把握・全体構想・実装/PR主担当 |
+| Gino | ChatGPT / Codex | HUMAN相談役・別視点検証・軽量PR補助 |
+| JEM | Gemini / NotebookLM | 資料読解・翻訳・要約・UX助言 |
 
 ## Safety Guardrails
 


### PR DESCRIPTION
## 何をしたか

`AGENTS.md` に aion-ops 正本参照ブロックを追加し、AI Team Roles を現在の3AI体制に合わせました。

## 変更点

- `AGENTS.md` 冒頭に aion-ops bootstrap v2026-07-02 の短縮参照ブロックを追加
- AI Team Roles を KURO / Gino / JEM に整理
- `CLAUDE.md` は既存内容が大きいため今回は直接変更せず、エージェント共通入口である `AGENTS.md` を対象にしました

## 確認してほしいこと

- 判断: cli-commentatorでは `AGENTS.md` をaion-ops参照入口として扱ってよいか
- 未対応: `.gitignore` への `.aion-ops/` 追記は、既存ファイルに機微行がありGino側更新が安全チェックで止まったため未実施
- リスク: 低い。docsのみ
- Todoist/gate: cli-commentatorへaion-opsブートストラップを展開する / gate/human