### PR TITLE
docs: AGENTS.mdガードレールをCodex Cloud等のremoteなし環境に対応

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,16 +35,24 @@ mainへ直接pushしない。mergeはHUMANのみ。
 
 ## Safety Guardrails
 
-Before any read/write operation, verify:
+Before any read/write operation, verify repo identity:
 
 ```bash
+# 1) Marker check (works in all environments, including cloud sandboxes)
 test -f pnpm-workspace.yaml
-git remote -v | grep -q "gatyoukatyou/cli-commentator"
+grep -q '"name": "cli-commentator"' package.json
+
+# 2) Remote check (only applies when a remote is configured)
+git remote -v
 ```
 
-### STOP IMMEDIATELY if any check fails
-- Wrong remote (not cli-commentator)
-- Not at repo root
+Remote check rules:
+- If `git remote -v` outputs one or more remotes, they MUST contain `gatyoukatyou/cli-commentator`.
+- If no remote is configured (e.g. Codex Cloud / CI sandboxes mount the repo without remotes), rely on the marker check above and proceed.
+
+### STOP IMMEDIATELY if
+- Marker check fails (wrong repo or not at repo root)
+- A remote exists but does not match `gatyoukatyou/cli-commentator`
 
 ## Forbidden Directories
 - `~/actions-runner/_work/*` (CI/CD only)


### PR DESCRIPTION
## 背景
Codex Cloud に #280 の作業を依頼したところ、ガードレール確認で停止した。

- Codex Cloud はセキュリティ上、リポジトリを **git remote なし**でマウントする
- 現行ガードレールは `git remote -v | grep -q "gatyoukatyou/cli-commentator"` を必須としているため、正しいリポジトリでも必ず失敗する

## 変更内容
- リポジトリ同一性の確認を**マーカーチェック**（`pnpm-workspace.yaml` の存在 + `package.json` の `name: cli-commentator`）に変更。全環境で動作する
- remote チェックは「remote が設定されている場合のみ適用」に緩和：
  - remote があるのに `gatyoukatyou/cli-commentator` と不一致 → **従来どおり即停止**
  - remote が未設定（Codex Cloud / CIサンドボックス） → マーカーチェックのみで続行可
- 誤リポジトリ・誤ディレクトリ防止という本来の目的は維持

## 確認
- マージ後、Codex Cloud で #280 を再依頼して通過することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)