### PR TITLE
refactor(server): share validation and pty fallback handling

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -230,6 +230,59 @@ function logInputStartupFailure(
   console.error(formatPtyStartupFailureLog(payload));
 }
 
+
+function handlePtyUnavailableFailure(params: {
+  context: "startup" | "restart";
+  failure: Extract<PtyFailure, { kind: "ptyUnavailable" }>;
+  profileId?: string | null;
+  target: {
+    cmd?: string;
+    args?: string[];
+    cwd?: string;
+    inputFile?: string;
+  };
+  stateFailureTrigger: string;
+  fallbackSuccessTrigger?: string;
+  startupFallbackLogMessage: string;
+  unavailableLogMessage: string;
+}): FileFallbackResult {
+  markPtyUnavailable(params.failure.error);
+  broadcast(createPtyUnavailableMessage(params.failure.error));
+  const fallback = tryStartFileFallback(params.context);
+  logPtyStartupFailure(params.context, params.failure, fallback, params.target);
+
+  if (!fallback.activated) {
+    transitionServerState(params.stateFailureTrigger, "failed", {
+      level: "warn",
+      detail: `kind=${params.failure.kind}; fallback_reason=${fallback.reason}; error=${params.failure.error}`,
+      profileId: params.profileId,
+      context: {
+        failureKind: params.failure.kind,
+        fallbackReason: fallback.reason,
+        error: params.failure.error,
+        ...buildTargetContext(params.target),
+      },
+    });
+  } else if (params.fallbackSuccessTrigger) {
+    transitionServerState(params.fallbackSuccessTrigger, "file_running", {
+      level: "warn",
+      inputMode: "file",
+      detail: `fallback_reason=${fallback.reason}`,
+      profileId: params.profileId,
+      context: {
+        fallbackReason: fallback.reason,
+        inputFile: params.target.inputFile?.trim() || undefined,
+      },
+    });
+  }
+
+  if (fallback.activated) {
+    console.warn(params.startupFallbackLogMessage);
+  }
+  console.error(params.unavailableLogMessage, params.failure.error);
+  return fallback;
+}
+
 function createAdHocPTYConfig(input: LaunchSessionInput): PTYConfig {
   const cmd = (input.cmd ?? "").trim();
   if (!cmd) {
@@ -587,48 +640,21 @@ async function restartPTY(profileId: string | null, force = false): Promise<void
 
     const failure = classifyPtyFailure(err, getNodePtyError());
     if (failure.kind === "ptyUnavailable") {
-      markPtyUnavailable(failure.error);
-      broadcast(createPtyUnavailableMessage(failure.error));
-      const fallback = tryStartFileFallback("restart");
-      logPtyStartupFailure("restart", failure, fallback, {
-        cmd: config?.cmd,
-        args: config?.args,
-        cwd: config?.cwd,
-        inputFile: INPUT_FILE.trim() || undefined,
+      handlePtyUnavailableFailure({
+        context: "restart",
+        failure,
+        profileId,
+        target: {
+          cmd: config?.cmd,
+          args: config?.args,
+          cwd: config?.cwd,
+          inputFile: INPUT_FILE.trim() || undefined,
+        },
+        stateFailureTrigger: "restart_failed",
+        fallbackSuccessTrigger: "restart_fallback_file",
+        startupFallbackLogMessage: `[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY restart failure.`,
+        unavailableLogMessage: "[WARN] PTY restart failed because node-pty is unavailable:",
       });
-      if (!fallback.activated) {
-        transitionServerState("restart_failed", "failed", {
-          level: "warn",
-          detail: `kind=${failure.kind}; fallback_reason=${fallback.reason}; error=${failure.error}`,
-          profileId,
-          context: {
-            failureKind: failure.kind,
-            fallbackReason: fallback.reason,
-            error: failure.error,
-            ...buildTargetContext({
-              cmd: config?.cmd,
-              args: config?.args,
-              cwd: config?.cwd,
-              inputFile: INPUT_FILE,
-            }),
-          },
-        });
-      } else {
-        transitionServerState("restart_fallback_file", "file_running", {
-          level: "warn",
-          inputMode: "file",
-          detail: `fallback_reason=${fallback.reason}`,
-          profileId,
-          context: {
-            fallbackReason: fallback.reason,
-            inputFile: INPUT_FILE.trim() || undefined,
-          },
-        });
-      }
-      if (fallback.activated) {
-        console.warn(`[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY restart failure.`);
-      }
-      console.error("[WARN] PTY restart failed because node-pty is unavailable:", failure.error);
       return;
     }
 
@@ -1007,35 +1033,19 @@ if (INPUT_MODE === "pty") {
   } catch (err) {
     const failure = classifyPtyFailure(err, getNodePtyError());
     if (failure.kind === "ptyUnavailable") {
-      markPtyUnavailable(failure.error);
-      const fallback = tryStartFileFallback("startup");
-      logPtyStartupFailure("startup", failure, fallback, {
-        cmd: initialConfig.cmd,
-        args: initialConfig.args,
-        cwd: initialConfig.cwd,
-        inputFile: INPUT_FILE.trim() || undefined,
+      handlePtyUnavailableFailure({
+        context: "startup",
+        failure,
+        target: {
+          cmd: initialConfig.cmd,
+          args: initialConfig.args,
+          cwd: initialConfig.cwd,
+          inputFile: INPUT_FILE.trim() || undefined,
+        },
+        stateFailureTrigger: "startup_failed",
+        startupFallbackLogMessage: `[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY startup failure.`,
+        unavailableLogMessage: "[WARN] PTY initialization failed:",
       });
-      if (!fallback.activated) {
-        transitionServerState("startup_failed", "failed", {
-          level: "warn",
-          detail: `kind=${failure.kind}; fallback_reason=${fallback.reason}; error=${failure.error}`,
-          context: {
-            failureKind: failure.kind,
-            fallbackReason: fallback.reason,
-            error: failure.error,
-            ...buildTargetContext({
-              cmd: initialConfig.cmd,
-              args: initialConfig.args,
-              cwd: initialConfig.cwd,
-              inputFile: INPUT_FILE,
-            }),
-          },
-        });
-      }
-      if (fallback.activated) {
-        console.warn(`[INFO] Switched to file monitoring fallback (${INPUT_FILE}) after PTY startup failure.`);
-      }
-      console.error("[WARN] PTY initialization failed:", ptyInitError);
       console.error("[INFO] Server will continue without PTY. Use INPUT_MODE=file for file monitoring.");
     } else {
       logPtyStartupFailure("startup", failure, NO_FILE_FALLBACK, {

--- a/apps/server/src/profile/manager.ts
+++ b/apps/server/src/profile/manager.ts
@@ -10,29 +10,19 @@ import type {
 } from "./types.js";
 import type { Style, SourceMode, InputMode } from "../types.js";
 import type { ProviderName } from "../llm/types.js";
+import {
+  getDefaultShell,
+  normalizeArgs as normalizeSharedArgs,
+  normalizeInputMode,
+  normalizeOptionalArgs,
+  normalizeOptionalString,
+  normalizeString,
+  parseInputModeFromEnv,
+  parseTargetArgs,
+} from "../shared/validation.js";
 
 // In-memory cache to avoid repeated disk reads
 let cachedStore: ProfileStore | null = null;
-
-function normalizeString(value: string): string {
-  return value.trim();
-}
-
-function normalizeOptionalString(value?: string): string | undefined {
-  if (value === undefined) return undefined;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function normalizeArgs(args?: string[]): string[] | undefined {
-  if (args === undefined) return undefined;
-  return args.map((arg) => arg.trim()).filter(Boolean);
-}
-
-function normalizeInputMode(value?: InputMode): InputMode | undefined {
-  if (value === undefined) return undefined;
-  return value === "file" ? "file" : "pty";
-}
 
 function normalizeOptionalProvider(value?: ProviderName): ProviderName | undefined {
   if (value === undefined) return undefined;
@@ -52,7 +42,7 @@ function normalizeCreateInput(input: CreateProfileInput): CreateProfileInput {
     ...input,
     name: normalizeString(input.name),
     cmd: normalizeCommand(input.cmd, inputMode),
-    args: normalizeArgs(input.args),
+    args: normalizeOptionalArgs(input.args),
     cwd: normalizeOptionalString(input.cwd),
     inputMode,
     inputFile: normalizeOptionalString(input.inputFile),
@@ -68,7 +58,7 @@ function normalizeUpdateInput(input: UpdateProfileInput): UpdateProfileInput {
     ...input,
     ...(input.name !== undefined && { name: normalizeString(input.name) }),
     ...(input.cmd !== undefined && { cmd: normalizeCommand(input.cmd, inputMode) }),
-    ...(input.args !== undefined && { args: normalizeArgs(input.args) }),
+    ...(input.args !== undefined && { args: normalizeOptionalArgs(input.args) }),
     ...(input.cwd !== undefined && { cwd: normalizeOptionalString(input.cwd) }),
     ...(input.inputMode !== undefined && { inputMode }),
     ...(input.inputFile !== undefined && { inputFile: normalizeOptionalString(input.inputFile) }),
@@ -305,55 +295,15 @@ export async function remove(id: string): Promise<void> {
 }
 
 /**
- * Get the default shell for the current platform
- */
-function getDefaultShell(): string {
-  if (process.platform === "win32") {
-    return "powershell.exe";
-  }
-  return "bash";
-}
-
-function parseInputMode(env: Record<string, string | undefined>): InputMode {
-  return env.INPUT_MODE?.trim().toLowerCase() === "file" ? "file" : "pty";
-}
-
-/**
- * Parse command arguments from environment variables
- * TARGET_ARGS_JSON (JSON array) takes precedence over TARGET_ARGS (space-separated)
- */
-function parseArgs(env: Record<string, string | undefined>): string[] {
-  if (env.TARGET_ARGS_JSON) {
-    try {
-      const raw = JSON.parse(env.TARGET_ARGS_JSON);
-      if (!Array.isArray(raw) || !raw.every((x) => typeof x === "string")) {
-        throw new Error("must be array of strings");
-      }
-      return raw;
-    } catch {
-      throw new Error(
-        "Invalid TARGET_ARGS_JSON (must be JSON array of strings)"
-      );
-    }
-  }
-
-  if (env.TARGET_ARGS) {
-    return env.TARGET_ARGS.split(" ").filter(Boolean);
-  }
-
-  return [];
-}
-
-/**
  * Create a profile input from current environment variables
  * Useful for backwards compatibility / initial profile creation
  */
 export function createFromEnv(
   env: Record<string, string | undefined> = process.env
 ): CreateProfileInput {
-  const inputMode = parseInputMode(env);
+  const inputMode = parseInputModeFromEnv(env);
   const cmd = normalizeString(env.TARGET_CMD ?? getDefaultShell());
-  const args = parseArgs(env);
+  const args = normalizeSharedArgs(parseTargetArgs(env));
   const cwd = normalizeOptionalString(env.TARGET_CWD);
   const inputFile = normalizeOptionalString(env.INPUT_FILE);
 

--- a/apps/server/src/pty/manager.ts
+++ b/apps/server/src/pty/manager.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import type { Profile } from "../profile/types.js";
+import { getDefaultShell, normalizeArgs, parseTargetArgs } from "../shared/validation.js";
 
 // Local type definitions (to avoid runtime import of node-pty)
 type IPty = {
@@ -85,23 +86,9 @@ function normalizeCommand(value: string): string {
   return value.trim();
 }
 
-function normalizeArgs(args: string[]): string[] {
-  return args.map((arg) => arg.trim()).filter(Boolean);
-}
-
 function normalizeCwd(value?: string): string {
   const trimmed = value?.trim();
   return trimmed || process.cwd();
-}
-
-/**
- * Get the default shell for the current platform
- */
-function getDefaultShell(): string {
-  if (process.platform === "win32") {
-    return "powershell.exe";
-  }
-  return "bash";
 }
 
 /**
@@ -234,32 +221,6 @@ export function configFromProfile(profile: Profile): PTYConfig {
 }
 
 /**
- * Parse command arguments from environment variables
- * TARGET_ARGS_JSON (JSON array) takes precedence over TARGET_ARGS (space-separated)
- */
-function parseArgs(env: Record<string, string | undefined>): string[] {
-  if (env.TARGET_ARGS_JSON) {
-    try {
-      const raw = JSON.parse(env.TARGET_ARGS_JSON);
-      if (!Array.isArray(raw) || !raw.every((x) => typeof x === "string")) {
-        throw new Error("must be array of strings");
-      }
-      return raw;
-    } catch {
-      throw new Error(
-        "Invalid TARGET_ARGS_JSON (must be JSON array of strings)"
-      );
-    }
-  }
-
-  if (env.TARGET_ARGS) {
-    return env.TARGET_ARGS.split(" ").filter(Boolean);
-  }
-
-  return [];
-}
-
-/**
  * Create PTY config from environment variables
  */
 export function configFromEnv(
@@ -267,7 +228,7 @@ export function configFromEnv(
 ): PTYConfig {
   return {
     cmd: normalizeCommand(env.TARGET_CMD ?? getDefaultShell()),
-    args: normalizeArgs(parseArgs(env)),
+    args: normalizeArgs(parseTargetArgs(env)),
     cwd: normalizeCwd(env.TARGET_CWD),
   };
 }

--- a/apps/server/src/shared/validation.ts
+++ b/apps/server/src/shared/validation.ts
@@ -1,0 +1,56 @@
+import type { InputMode } from "../types.js";
+
+export function normalizeString(value: string): string {
+  return value.trim();
+}
+
+export function normalizeOptionalString(value?: string): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function normalizeArgs(args: string[]): string[] {
+  return args.map((arg) => arg.trim()).filter(Boolean);
+}
+
+export function normalizeOptionalArgs(args?: string[]): string[] | undefined {
+  if (args === undefined) return undefined;
+  return normalizeArgs(args);
+}
+
+export function normalizeInputMode(value?: InputMode): InputMode | undefined {
+  if (value === undefined) return undefined;
+  return value === "file" ? "file" : "pty";
+}
+
+export function parseInputModeFromEnv(env: Record<string, string | undefined>): InputMode {
+  return env.INPUT_MODE?.trim().toLowerCase() === "file" ? "file" : "pty";
+}
+
+export function getDefaultShell(platform: NodeJS.Platform = process.platform): string {
+  if (platform === "win32") {
+    return "powershell.exe";
+  }
+  return "bash";
+}
+
+export function parseTargetArgs(env: Record<string, string | undefined>): string[] {
+  if (env.TARGET_ARGS_JSON) {
+    try {
+      const raw = JSON.parse(env.TARGET_ARGS_JSON);
+      if (!Array.isArray(raw) || !raw.every((x) => typeof x === "string")) {
+        throw new Error("must be array of strings");
+      }
+      return raw;
+    } catch {
+      throw new Error("Invalid TARGET_ARGS_JSON (must be JSON array of strings)");
+    }
+  }
+
+  if (env.TARGET_ARGS) {
+    return env.TARGET_ARGS.split(" ").filter(Boolean);
+  }
+
+  return [];
+}


### PR DESCRIPTION
## 概要
Refs #280

Codex 作のパッチ（Codex Cloud のネットワーク制限で push 不可だったため、パッチ経由で KURO が代理公開。authorship はコミットに保持）。

- `src/shared/validation.ts` 新設: `normalizeString` / `normalizeOptionalString` / `normalizeArgs` / `normalizeOptionalArgs` / `normalizeInputMode` / `parseInputModeFromEnv` / `getDefaultShell` / `parseTargetArgs` を集約
- `profile/manager.ts` / `pty/manager.ts` の重複実装（`getDefaultShell`, `parseArgs`, `normalize*`）を削除し共有版へ差し替え
- `index.ts` の PTY unavailable 時の startup/restart フォールバック処理を `handlePtyUnavailableFailure` に一本化（ログ文言・構造化ログ・state遷移トリガー名は現状維持）

## KUROレビューメモ
- ✅ ログフォーマット・state遷移トリガー名・broadcastメッセージは統合前と一致することを差分レベルで確認
- ⚠️ 軽微な挙動差2点（許容と判断）:
  1. startup パスでも `ptyUnavailable` を broadcast するようになったが、起動時点では WS クライアントが存在しないため実質 no-op
  2. `profile/manager.ts` の `createFromEnv` が `TARGET_ARGS_JSON` 由来の引数にも trim/filter を適用するようになった（従来は raw）。`pty/manager.ts` 側は元々正規化しており、整合が取れる方向の変更
- 📝 #280 の残スコープ: `isStyle` / `normalizeSource`（index.ts）と `normalizeProviderName`（styles/index.ts）の shared への集約は未実施。#281 の前に小PRで回収するか、#281 に含めるかは要判断

## 検証
- [x] `pnpm -C apps/server test` 332件 全パス
- [x] `pnpm -C apps/server exec tsc --noEmit` クリーン
- [x] `pnpm -C apps/server build` （Codex環境で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)