### PR TITLE
refactor(server): centralize style/source/provider normalization

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -41,6 +41,7 @@ import {
   type ServerRuntimeState,
   type ServerStateEventContextInput,
 } from "./runtime/state-event.js";
+import { isStyle, normalizeSource } from "./shared/validation.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -59,16 +60,6 @@ function parseInputMode(value?: string): InputMode {
 const INPUT_MODE: InputMode = parseInputMode(INPUT_MODE_RAW);
 const INPUT_FILE = process.env.INPUT_FILE ?? "";
 let runtimeInputMode: InputMode = INPUT_MODE;
-
-function isStyle(value: unknown): value is Style {
-  return value === "standard" || value === "kansai" || value === "zundamon";
-}
-
-function normalizeSource(value?: string): SourceMode {
-  const source = (value ?? "").trim().toLowerCase();
-  if (source === "claude" || source === "codex" || source === "generic") return source;
-  return "auto";
-}
 
 // --- Mutable state ---
 let currentStyle: Style = "kansai";

--- a/apps/server/src/profile/manager.ts
+++ b/apps/server/src/profile/manager.ts
@@ -15,6 +15,7 @@ import {
   normalizeArgs as normalizeSharedArgs,
   normalizeInputMode,
   normalizeOptionalArgs,
+  normalizeOptionalProvider,
   normalizeOptionalString,
   normalizeString,
   parseInputModeFromEnv,
@@ -23,12 +24,6 @@ import {
 
 // In-memory cache to avoid repeated disk reads
 let cachedStore: ProfileStore | null = null;
-
-function normalizeOptionalProvider(value?: ProviderName): ProviderName | undefined {
-  if (value === undefined) return undefined;
-  const trimmed = value.trim() as ProviderName;
-  return trimmed ? trimmed : undefined;
-}
 
 function normalizeCommand(value: string, inputMode?: InputMode): string {
   const trimmed = value.trim();

--- a/apps/server/src/shared/validation.ts
+++ b/apps/server/src/shared/validation.ts
@@ -1,4 +1,5 @@
-import type { InputMode } from "../types.js";
+import type { ProviderName } from "../llm/types.js";
+import type { InputMode, SourceMode, Style } from "../types.js";
 
 export function normalizeString(value: string): string {
   return value.trim();
@@ -53,4 +54,34 @@ export function parseTargetArgs(env: Record<string, string | undefined>): string
   }
 
   return [];
+}
+
+export function isStyle(value: unknown): value is Style {
+  return value === "standard" || value === "kansai" || value === "zundamon";
+}
+
+export function normalizeSource(value?: string): SourceMode {
+  const source = (value ?? "").trim().toLowerCase();
+  if (source === "claude" || source === "codex" || source === "generic") return source;
+  return "auto";
+}
+
+export function normalizeProviderName(value?: string): ProviderName | undefined {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (
+    normalized === "disabled" ||
+    normalized === "mock" ||
+    normalized === "openai" ||
+    normalized === "groq" ||
+    normalized === "local" ||
+    normalized === "anthropic" ||
+    normalized === "gemini"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+export function normalizeOptionalProvider(value?: ProviderName): ProviderName | undefined {
+  return normalizeProviderName(value);
 }

--- a/apps/server/src/styles/index.ts
+++ b/apps/server/src/styles/index.ts
@@ -1,5 +1,6 @@
 import type { CommentaryMode, CommentaryPayload, Event, Style } from "../types.js";
 import type { ProviderName } from "../llm/types.js";
+import { normalizeProviderName } from "../shared/validation.js";
 import { commentStandard } from "./standard.js";
 import { commentKansai } from "./kansai.js";
 import { commentZundamon } from "./zundamon.js";
@@ -587,22 +588,6 @@ function commentByRules(ev: Event, style: Style): CommentaryPayload {
       explanationProvider: "rules",
     },
   });
-}
-
-function normalizeProviderName(value?: string): ProviderName | undefined {
-  const normalized = (value ?? "").trim().toLowerCase();
-  if (
-    normalized === "disabled" ||
-    normalized === "mock" ||
-    normalized === "openai" ||
-    normalized === "groq" ||
-    normalized === "local" ||
-    normalized === "anthropic" ||
-    normalized === "gemini"
-  ) {
-    return normalized;
-  }
-  return undefined;
 }
 
 function resolveCommentaryProviders(providers: ProfileLLMProviders = {}): {


### PR DESCRIPTION
## 概要
Closes #280

#285 の follow-up（スタックPR: base = #285 のブランチ。**#285 を先にマージしてください**。base ブランチ削除時に自動で main に付け替わります）。

Codex 作のパッチをリレー公開（authorship 保持）。#280 の残スコープを回収：

- `isStyle` / `normalizeSource` を `src/index.ts` から `shared/validation.ts` へ移動
- `normalizeProviderName` を `src/styles/index.ts` から `shared/validation.ts` へ移動
- `profile/manager.ts` の `normalizeOptionalProvider` を共有版に差し替え（実体は `normalizeProviderName` に委譲）

## KUROレビューメモ
- ⚠️ 軽微な挙動差1点（許容と判断）: 旧 `normalizeOptionalProvider` は trim のみで任意文字列を通していたが、新実装はホワイトリスト検証＋小文字化を行う。プロファイル保存時に不正な provider 値が `undefined` に落ちるようになるが、下流の `resolveCommentaryProviders` は元々同じ検証をしていたため、実況動作としては同一。保存値が正規化される分だけ堅牢化
- ✅ その他は純粋な移動で、判定ロジックは1文字も変わっていない

## 検証
- [x] `pnpm -C apps/server test` 332件 全パス
- [x] `pnpm -C apps/server exec tsc --noEmit` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)