### PR TITLE
docs: aion-ops展開の残項目是正（CLAUDE.md導線 / .gitignore / handoff）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 .env
 .Turbo
 .pnpm-store/
+
+# aion-ops bootstrap clone (母艦の一時取得先・コミットしない)
+.aion-ops/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,40 @@
 
 CLIの出力を別ウィンドウで実況するMVP
 
+<!-- aion-ops bootstrap v2026-07-02 | 正本: gatyoukatyou/aion-ops | このブロックは編集せず雛形から再配布する -->
+
+## 共通運用ルール（正本 = aion-ops）
+
+このリポジトリの3AI運用（KURO / Gino / JEM ＋ HUMAN）の共通ルールは、
+**すべて `gatyoukatyou/aion-ops` を唯一の正本（canonical）とする**。
+ここには**ルール本体を書き写さない**。必ず正本を読むこと。矛盾時は aion-ops を優先し、迷えば停止してHUMAN確認。
+
+### 起動時にやること（環境別）
+
+- **ローカル版 Claude Code**：起動を `claude --add-dir ~/AION_Project/aion-ops` で行う。
+  （aion-ops をローカルに未cloneなら1回だけ
+  `git clone https://github.com/gatyoukatyou/aion-ops.git ~/AION_Project/aion-ops`）
+- **Web版 Claude Code**：セッション作成時に、作業repoと `gatyoukatyou/aion-ops` を**同時に選択**する。
+  単一repoセッションで aion-ops が見えない場合は、cloneで回避しようとせず、HUMANに複数repoセッションの作成を依頼する。
+
+### 最初に読む正本（順に）
+
+1. `aion-ops/docs/operations/minimal-operating-rules.md` — まず守る6項目（最上位サマリ）
+2. `aion-ops/docs/operations/todoist-operation-rules.md` — Todoist運用（ボード・ラベル・ライフサイクル・権限境界）
+3. `aion-ops/docs/operations/github-workflow.md` — GitHub運用
+4. `aion-ops/agents/kuro-claude.md` — KUROの役割・境界
+5. `aion-ops/templates/handoff-brief-template.md` — 節目ごとのhandoff書式（HUMAN判断待ちを最上段に置く）
+
+### GitHub / Todoist の更新について
+
+- 作業repoへの commit / PR / Issue は標準機能で行う。**main へ直接pushしない。mergeはHUMANのみ。**
+- 節目のhandoffは `repo/handoff/status-YYYY-MM-DD.md` を正本とし、要約をTodoist親カードのコメントに投稿する。
+  そのコメントは **Web版Claude と Gino（ChatGPT）が直接読む**（両者で実測済み。Gino向けの長文手動コピペは原則不要）。
+- Todoist更新は、Claude Code にユーザースコープで Todoist MCP を追加済みであれば全repoで可能。
+- 機微情報は GitHub・Todoist・handoff のいずれにも書かない。
+
+<!-- /aion-ops bootstrap -->
+
 ## Quick Start
 
 ```bash

--- a/handoff/status-2026-07-03.md
+++ b/handoff/status-2026-07-03.md
@@ -1,0 +1,28 @@
+# handoff 2026-07-03 — cli-commentator / aion-ops展開の残項目是正
+
+## 1. HUMAN判断待ち（最初に読む）
+- **判断事項**：本PR（aion-ops展開チェックリストの残項目是正）をmergeしてよいか
+  - 推奨：merge（PR #279 でAGENTS.mdに配布済みだが、Claude Codeが起動時に読むCLAUDE.md側に導線がなく、.gitignore / handoff/ も未整備だったため補完）
+  - 選択肢：merge / CLAUDE.mdへの追加は不要とし .gitignore・handoff のみ採用 / 差戻し
+  - 期限・緊急度：急ぎなし / 緊急度低
+  - 判断しない場合の影響：Claude CodeセッションがCLAUDE.md経由で正本参照導線を得られず、handoff正本の置き場もない
+
+## 2. 現在地
+- 作業状態：aion-ops展開の横断確認で検出したギャップの是正。AGENTS.mdの既存ブロック（PR #279）には触れていない
+- 最新PR：本ファイルを含むPR（ブランチ `ops-aion-bootstrap-gaps`）
+- ctx状態：ctx/review
+
+## 3. 今回やったこと
+- CLAUDE.md 冒頭付近に配布ブロック（雛形 v2026-07-02 完全版）を追加
+- .gitignore に `.aion-ops/` を追加
+- handoff/ を新設（本ファイルが初回）
+
+## 4. 重要な発見・リスク
+- AGENTS.md（Codex向け）とCLAUDE.md（Claude Code向け）の両方に配布ブロックが並存する。いずれもポインタのみでルール本体はないため、増殖リスクは低い
+
+## 5. 次の一手（AI別）
+- KURO：merge後、対応Todoistカードを更新し、aion-ops展開の横断確認を締める
+- Gino / JEM：なし
+
+## 6. 参照リンク
+- PR: 本ブランチのPR ／ 関連: PR #279（AGENTS.mdへの配布） ／ 対応Todoistカード: 「各repoへaion-opsブートストラップを展開する」配下


### PR DESCRIPTION
## 何をしたか

aion-ops 5repo展開の横断確認で検出した本repoの残項目（チェックリスト未充足分）を是正した。

## 変更点

- CLAUDE.md 冒頭付近に配布ブロック（雛形 v2026-07-02 完全版）を追加（PR #279 のAGENTS.md側ブロックは温存）
- .gitignore に `.aion-ops/` を追加
- handoff/ 新設（status-2026-07-03.md）。コードには触れていない

## 確認してほしいこと

- 判断: mergeしてよいか。AGENTS.md（Codex向け・短縮版）とCLAUDE.md（雛形完全版）の並存でよいか
- リスク: 低（ドキュメントのみの追加）
- Todoist/gate: 「各repoへaion-opsブートストラップを展開する」配下 / gate/human

🤖 Generated with [Claude Code](https://claude.com/claude-code)