### PR TITLE
refactor: share websocket protocol types

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@cli-commentator/shared": "workspace:*",
     "dotenv": "^17.4.2",
     "ws": "^8.20.1"
   },

--- a/apps/server/src/llm/types.ts
+++ b/apps/server/src/llm/types.ts
@@ -1,4 +1,4 @@
-export type ProviderName = "disabled" | "mock" | "openai" | "groq" | "local" | "anthropic" | "gemini";
+export type { ProviderName } from "@cli-commentator/shared";
 
 export type ChatMessage = {
   role: "system" | "user" | "assistant";

--- a/apps/server/src/profile/types.ts
+++ b/apps/server/src/profile/types.ts
@@ -1,58 +1,15 @@
-import type { Style, SourceMode, InputMode } from "../types.js";
-import type { ProviderName } from "../llm/types.js";
+import type { Profile } from "@cli-commentator/shared";
 
-export type ProfileLLMProviders = {
-  llmProvider?: ProviderName;
-  narrationProvider?: ProviderName;
-  explanationProvider?: ProviderName;
-};
+export type {
+  CreateProfileInput,
+  Profile,
+  ProfileLLMProviders,
+  ProfileSummary,
+  UpdateProfileInput,
+} from "@cli-commentator/shared";
 
-/**
- * Full profile definition with all settings
- */
-export type Profile = ProfileLLMProviders & {
-  id: string;
-  name: string;
-  cmd: string;
-  args: string[];
-  cwd?: string;
-  style: Style;
-  logSource: SourceMode;
-  inputMode?: InputMode;
-  inputFile?: string;
-  createdAt: number;
-  updatedAt: number;
-};
-
-/**
- * Minimal profile info for list display
- */
-export type ProfileSummary = Pick<Profile, "id" | "name" | "cmd">;
-
-/**
- * Persisted store format
- */
 export type ProfileStore = {
   version: 1;
   activeId: string | null;
   profiles: Profile[];
 };
-
-/**
- * Input for creating a new profile (id/timestamps auto-generated)
- */
-export type CreateProfileInput = ProfileLLMProviders & {
-  name: string;
-  cmd: string;
-  args?: string[];
-  cwd?: string;
-  style?: Style;
-  logSource?: SourceMode;
-  inputMode?: InputMode;
-  inputFile?: string;
-};
-
-/**
- * Input for updating an existing profile
- */
-export type UpdateProfileInput = Partial<CreateProfileInput>;

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,84 +1,21 @@
-import type { Profile, ProfileSummary, CreateProfileInput, UpdateProfileInput } from "./profile/types.js";
-
-export type Style = "standard" | "kansai" | "zundamon";
-export type DetectedSource = "claude" | "codex" | "generic";
-export type SourceMode = "auto" | DetectedSource;
-export type InputMode = "pty" | "file";
-export type SourceState = { mode: SourceMode; detected: DetectedSource | null };
-
-export type EventType =
-  | "start"
-  | "stdout"
-  | "stderr"
-  | "read"
-  | "write"
-  | "search"
-  | "test"
-  | "git"
-  | "github"
-  | "install"
-  | "build"
-  | "lint"
-  | "server"
-  | "error"
-  | "done";
-
-export type Event = {
-  ts: number;
-  type: EventType;
-  summary: string;
-  detail?: string;
-};
-
-export type CommentaryMode = "narration" | "explanation" | "both";
-
-export type CommentaryMeta = {
-  narrationProvider?: string;
-  explanationProvider?: string;
-  mode?: CommentaryMode;
-};
-
-export type CommentaryPayload = {
-  narration?: string;
-  explanation?: string;
-  glossaryNotes?: string[];
-  meta?: CommentaryMeta;
-};
-
-export type LaunchSessionInput = {
-  name?: string;
-  cmd: string;
-  args?: string[];
-  cwd?: string;
-  style?: Style;
-  logSource?: SourceMode;
-};
-
-export type WsOutgoing =
-  | { kind: "hello"; style: Style; source: SourceState }
-  | { kind: "style"; style: Style }
-  | { kind: "source"; source: SourceState }
-  | { kind: "raw"; data: string }
-  | { kind: "event"; ev: Event }
-  | ({ kind: "commentary"; ts: number; ev: Event } & CommentaryPayload)
-  // Profile messages
-  | { kind: "profiles"; profiles: ProfileSummary[]; activeId: string | null }
-  | { kind: "profileSaved"; profile: ProfileSummary; activeId: string | null }
-  | { kind: "profileDeleted"; id: string; activeId: string | null }
-  | { kind: "profileDetail"; profile: Profile }
-  | { kind: "profileError"; error: string }
-  // PTY messages
-  | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
-  | { kind: "ptyError"; error: string }
-  | { kind: "ptyUnavailable"; error: string; suggestion: string };
-
-export type WsIncoming =
-  | { kind: "setStyle"; style: Style }
-  | { kind: "launchSession"; session: LaunchSessionInput }
-  | { kind: "writeInput"; data: string }
-  // Profile messages
-  | { kind: "getProfiles" }
-  | { kind: "getProfile"; id: string }
-  | { kind: "saveProfile"; profile: CreateProfileInput & { id?: string } }
-  | { kind: "deleteProfile"; id: string }
-  | { kind: "setActiveProfile"; id: string | null };
+export type {
+  CommentaryMeta,
+  CommentaryMode,
+  CommentaryPayload,
+  CreateProfileInput,
+  DetectedSource,
+  Event,
+  EventType,
+  InputMode,
+  LaunchSessionInput,
+  Profile,
+  ProfileLLMProviders,
+  ProfileSummary,
+  ProviderName,
+  SourceMode,
+  SourceState,
+  Style,
+  UpdateProfileInput,
+  WsIncoming,
+  WsOutgoing,
+} from "@cli-commentator/shared";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@cli-commentator/shared": "workspace:*",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "xterm": "^5.3.0",

--- a/apps/web/src/hooks/useCommentatorSocket.ts
+++ b/apps/web/src/hooks/useCommentatorSocket.ts
@@ -1,19 +1,16 @@
 import { useEffect, useRef, useState, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react";
 import type { TerminalPaneHandle } from "../components/TerminalPane";
 import { getCommentaryTextParts } from "../lib/glossary-note";
-import { isEventType, type CommentaryItem } from "../lib/log-filter";
+import type { CommentaryItem } from "../lib/log-filter";
 import { normalizeSuggestion } from "../lib/text";
+import { parseServerMessage } from "@cli-commentator/shared";
 import type {
   Profile,
   ProfileSummary,
-  PtyUnavailablePayload,
-  ServerToClientMessage,
   SourceState,
   Style,
 } from "../types";
 
-type LegacyHello = { type: "hello"; style: Style };
-type PayloadMessage = { type?: string; payload?: PtyUnavailablePayload | Record<string, unknown> };
 export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "reconnecting";
 type EditingProfile = Profile | null | "new" | "loading";
 type CopyState = "idle" | "copied" | "failed";
@@ -45,27 +42,6 @@ type UseCommentatorSocketOptions = {
   queueSpeech: (item: CommentaryItem) => void;
   clearPendingSpeech: () => void;
   stopAndClearSpeech: () => void;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const getPayloadRecord = (msg: unknown): Record<string, unknown> | null => {
-  if (!isRecord(msg) || !("payload" in msg)) return null;
-  const payload = (msg as { payload?: unknown }).payload;
-  return isRecord(payload) ? payload : null;
-};
-
-const getStringField = (obj: Record<string, unknown> | null, key: string): string | undefined => {
-  if (!obj) return undefined;
-  const value = obj[key];
-  return typeof value === "string" ? value : undefined;
-};
-
-const getStringArrayField = (obj: Record<string, unknown> | null, key: string): string[] | undefined => {
-  if (!obj) return undefined;
-  const value = obj[key];
-  return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : undefined;
 };
 
 function stubProfileFromSummary(summary: ProfileSummary): Profile {
@@ -145,142 +121,104 @@ export function useCommentatorSocket({
       ws.onmessage = (e) => {
         if (cancelled || wsRef.current !== ws) return;
         try {
-          const msg = JSON.parse(e.data) as ServerToClientMessage | LegacyHello | PayloadMessage;
-          const kind = "kind" in msg ? msg.kind : msg.type;
-          const payload = getPayloadRecord(msg);
-          const data = (payload ?? msg) as Record<string, unknown>;
-          switch (kind) {
+          const message = parseServerMessage(JSON.parse(e.data));
+          if (!message) return;
+
+          switch (message.kind) {
             case "hello":
-              if (typeof data.style === "string") setStyle(data.style as Style);
-              if (data.source) setSource(data.source as SourceState);
+              setStyle(message.style);
+              setSource(message.source);
               break;
             case "style":
-              if (typeof data.style === "string") setStyle(data.style as Style);
+              setStyle(message.style);
               break;
             case "source":
-              if (data.source) setSource(data.source as SourceState);
+              setSource(message.source);
               break;
             case "raw":
-              if (typeof data.data === "string") {
-                writeToTerminal(data.data);
-              }
+              writeToTerminal(message.data);
               break;
-            case "commentary":
-              if (typeof data.ts === "number") {
-                const ev = isRecord(data.ev) ? data.ev : null;
-                const eventTypeCandidate = ev?.type;
-                const eventType = isEventType(eventTypeCandidate) ? eventTypeCandidate : "stdout";
-                const summary = typeof ev?.summary === "string" ? ev.summary : undefined;
-                const detail = typeof ev?.detail === "string" ? ev.detail : undefined;
-                const parts = getCommentaryTextParts({
-                  narration: getStringField(data, "narration"),
-                  explanation: getStringField(data, "explanation"),
-                  glossaryNotes: getStringArrayField(data, "glossaryNotes"),
-                  text: getStringField(data, "text"),
-                });
-                if (!parts.narrationText && !parts.explanationText && parts.glossaryNotes.length === 0) {
-                  break;
-                }
-                const nextItem: CommentaryItem = {
-                  ts: data.ts as number,
-                  narration: parts.narrationText ?? undefined,
-                  explanation: parts.explanationText ?? undefined,
-                  glossaryNotes: parts.glossaryNotes,
-                  eventType,
-                  summary,
-                  detail,
-                };
-                setItems((prev) => [...prev, nextItem].slice(-200));
-                queueSpeech(nextItem);
+            case "commentary": {
+              const parts = getCommentaryTextParts({
+                narration: message.narration,
+                explanation: message.explanation,
+                glossaryNotes: message.glossaryNotes,
+              });
+              if (!parts.narrationText && !parts.explanationText && parts.glossaryNotes.length === 0) {
+                break;
               }
+              const nextItem: CommentaryItem = {
+                ts: message.ts,
+                narration: parts.narrationText ?? undefined,
+                explanation: parts.explanationText ?? undefined,
+                glossaryNotes: parts.glossaryNotes,
+                eventType: message.ev.type,
+                summary: message.ev.summary,
+                detail: message.ev.detail,
+              };
+              setItems((prev) => [...prev, nextItem].slice(-200));
+              queueSpeech(nextItem);
               break;
+            }
             case "profiles":
-              if (Array.isArray(data.profiles)) {
-                setProfiles(data.profiles as ProfileSummary[]);
-                if ("activeId" in data) {
-                  setActiveProfileId((data.activeId as string | null) ?? null);
-                }
-              }
+              setProfiles(message.profiles);
+              setActiveProfileId(message.activeId);
               break;
-            case "profileSaved":
-              if (data.profile) {
-                const profile = data.profile as ProfileSummary;
-                setProfiles((prev) => {
-                  const exists = prev.some((p) => p.id === profile.id);
-                  if (exists) {
-                    return prev.map((p) => (p.id === profile.id ? profile : p));
-                  }
-                  return [...prev, profile];
-                });
-                if ("activeId" in data) {
-                  setActiveProfileId((data.activeId as string | null) ?? null);
+            case "profileSaved": {
+              const profile = message.profile;
+              setProfiles((prev) => {
+                const exists = prev.some((entry) => entry.id === profile.id);
+                if (exists) {
+                  return prev.map((entry) => (entry.id === profile.id ? profile : entry));
                 }
-                setEditingProfile(null);
-                setProfileError(null);
-              }
+                return [...prev, profile];
+              });
+              setActiveProfileId(message.activeId);
+              setEditingProfile(null);
+              setProfileError(null);
               break;
+            }
             case "profileDeleted":
-              if (typeof data.id === "string") {
-                setProfiles((prev) => prev.filter((p) => p.id !== data.id));
-                if ("activeId" in data) {
-                  setActiveProfileId((data.activeId as string | null) ?? null);
-                }
-              }
+              setProfiles((prev) => prev.filter((profile) => profile.id !== message.id));
+              setActiveProfileId(message.activeId);
               break;
             case "profileDetail":
-              if (data.profile) {
-                const profile = data.profile as Profile;
-                // Verify this is the response for the pending edit request
-                if (pendingEditIdRef.current === profile.id) {
-                  setEditingProfile(profile);
-                  pendingEditIdRef.current = null;
-                }
+              if (pendingEditIdRef.current === message.profile.id) {
+                setEditingProfile(message.profile);
+                pendingEditIdRef.current = null;
               }
               break;
-            case "profileError":
-              if (typeof data.error === "string") {
-                setProfileError(data.error);
-                // If a profile detail fetch was pending, fall back to summary data
-                const pid = pendingEditIdRef.current;
-                if (pid) {
-                  pendingEditIdRef.current = null;
-                  const summary = profilesRef.current.find((p) => p.id === pid);
-                  if (summary) {
-                    setEditingProfile(stubProfileFromSummary(summary));
-                  } else {
-                    setEditingProfile(null);
-                  }
-                }
+            case "profileError": {
+              setProfileError(message.error);
+              const pendingId = pendingEditIdRef.current;
+              if (pendingId) {
+                pendingEditIdRef.current = null;
+                const summary = profilesRef.current.find((profile) => profile.id === pendingId);
+                setEditingProfile(summary ? stubProfileFromSummary(summary) : null);
               }
               break;
+            }
             case "ptyRestart":
-              // Clear commentary items when PTY restarts
               setItems([]);
               clearTerminal();
               terminalPaneRef.current?.resetInputGate();
               stopAndClearSpeech();
               setProfileError(null);
               setPtyError(null);
-              setCurrentSessionLabel(
-                [typeof data.cmd === "string" ? data.cmd : "", ...(Array.isArray(data.args) ? (data.args as string[]) : [])]
-                  .filter(Boolean)
-                  .join(" ") || "session"
-              );
+              setCurrentSessionLabel([message.cmd, ...message.args].filter(Boolean).join(" ") || "session");
               break;
             case "ptyError":
-              if (typeof data.error === "string") {
-                setPtyError(data.error);
-              }
+              setPtyError(message.error);
               break;
             case "ptyUnavailable":
               setCopyState("idle");
               setPtyUnavailable({
-                error: normalizeSuggestion(getStringField(data, "error")),
-                suggestion: normalizeSuggestion(getStringField(data, "suggestion")),
+                error: normalizeSuggestion(message.error),
+                suggestion: normalizeSuggestion(message.suggestion),
                 receivedAt: Date.now(),
               });
               break;
-            default:
+            case "event":
               break;
           }
         } catch (err) {

--- a/apps/web/src/lib/server-message.test.ts
+++ b/apps/web/src/lib/server-message.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parseServerMessage } from "@cli-commentator/shared";
+
+describe("parseServerMessage", () => {
+  it("parses canonical commentary messages", () => {
+    const message = parseServerMessage({
+      kind: "commentary",
+      ts: 123,
+      ev: {
+        ts: 123,
+        type: "stdout",
+        summary: "ログ更新",
+        detail: "done",
+      },
+      narration: "処理中です。",
+      glossaryNotes: ["補足"],
+    });
+
+    expect(message).toMatchObject({
+      kind: "commentary",
+      ts: 123,
+      narration: "処理中です。",
+      ev: { type: "stdout", summary: "ログ更新" },
+    });
+  });
+
+  it("normalizes legacy type/payload envelopes", () => {
+    expect(
+      parseServerMessage({
+        type: "ptyUnavailable",
+        payload: {
+          error: "PTY unavailable",
+          suggestion: "INPUT_MODE=file",
+        },
+      })
+    ).toEqual({
+      kind: "ptyUnavailable",
+      error: "PTY unavailable",
+      suggestion: "INPUT_MODE=file",
+    });
+  });
+
+  it("rejects malformed messages", () => {
+    expect(parseServerMessage({ kind: "style", style: "unknown" })).toBeNull();
+    expect(parseServerMessage({ kind: "commentary", ts: 123 })).toBeNull();
+    expect(parseServerMessage("not an object")).toBeNull();
+  });
+});

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,106 +1,22 @@
-export type Style = "standard" | "kansai" | "zundamon";
-export type DetectedSource = "claude" | "codex" | "generic";
-export type SourceMode = "auto" | DetectedSource;
-export type InputMode = "pty" | "file";
-export type SourceState = { mode: SourceMode; detected: DetectedSource | null };
-export type EventType =
-  | "start"
-  | "stdout"
-  | "stderr"
-  | "read"
-  | "write"
-  | "search"
-  | "test"
-  | "git"
-  | "github"
-  | "install"
-  | "build"
-  | "lint"
-  | "server"
-  | "error"
-  | "done";
-
-export type Event = {
-  type: EventType;
-  summary: string;
-  detail?: string;
-};
-
-export type ProviderName = "disabled" | "mock" | "openai" | "groq" | "local" | "anthropic" | "gemini";
+export type {
+  CommentaryMeta,
+  CommentaryPayload,
+  CreateProfileInput,
+  DetectedSource,
+  Event,
+  EventType,
+  InputMode,
+  LaunchSessionInput,
+  Profile,
+  ProfileLLMProviders,
+  ProfileSummary,
+  ProviderName,
+  SourceMode,
+  SourceState,
+  Style,
+  UpdateProfileInput,
+  WsIncoming,
+  WsOutgoing,
+} from "@cli-commentator/shared";
 
 export type CommentaryDisplayMode = "narration" | "explanation" | "both";
-
-export type CommentaryMeta = {
-  narrationProvider?: string;
-  explanationProvider?: string;
-  mode?: CommentaryDisplayMode;
-};
-
-export type CommentaryPayload = {
-  narration?: string;
-  explanation?: string;
-  glossaryNotes?: string[];
-  meta?: CommentaryMeta;
-};
-
-export type LaunchSessionInput = {
-  name?: string;
-  cmd: string;
-  args?: string[];
-  cwd?: string;
-  style?: Style;
-  logSource?: SourceMode;
-};
-
-export type Profile = {
-  id: string;
-  name: string;
-  cmd: string;
-  args: string[];
-  cwd?: string;
-  style: Style;
-  logSource: SourceMode;
-  inputMode?: InputMode;
-  inputFile?: string;
-  llmProvider?: ProviderName;
-  narrationProvider?: ProviderName;
-  explanationProvider?: ProviderName;
-  createdAt: number;
-  updatedAt: number;
-};
-
-export type ProfileSummary = Pick<Profile, "id" | "name" | "cmd">;
-
-export type CreateProfileInput = {
-  name: string;
-  cmd: string;
-  args?: string[];
-  cwd?: string;
-  style?: Style;
-  logSource?: SourceMode;
-  inputMode?: InputMode;
-  inputFile?: string;
-  llmProvider?: ProviderName;
-  narrationProvider?: ProviderName;
-  explanationProvider?: ProviderName;
-};
-
-export type PtyUnavailablePayload = {
-  error?: string;
-  suggestion?: string;
-};
-
-export type ServerToClientMessage =
-  | { kind: "hello"; style: Style; source: SourceState }
-  | { kind: "style"; style: Style }
-  | { kind: "source"; source: SourceState }
-  | { kind: "raw"; data: string }
-  | ({ kind: "commentary"; ts: number; ev?: Event; text?: string } & CommentaryPayload)
-  | { kind: "profiles"; profiles: ProfileSummary[]; activeId: string | null }
-  | { kind: "profileSaved"; profile: ProfileSummary; activeId: string | null }
-  | { kind: "profileDeleted"; id: string; activeId: string | null }
-  | { kind: "profileDetail"; profile: Profile }
-  | { kind: "profileError"; error: string }
-  | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
-  | { kind: "ptyError"; error: string }
-  | { kind: "ptyUnavailable"; error?: string; suggestion?: string };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@cli-commentator/shared",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./protocol.js";
+export * from "./parse-server-message.js";

--- a/packages/shared/src/parse-server-message.ts
+++ b/packages/shared/src/parse-server-message.ts
@@ -1,0 +1,183 @@
+import type {
+  CommentaryMeta,
+  Event,
+  EventType,
+  Profile,
+  ProfileSummary,
+  ProviderName,
+  SourceMode,
+  SourceState,
+  Style,
+  WsOutgoing,
+} from "./protocol.js";
+
+const EVENT_TYPES = new Set<EventType>([
+  "start",
+  "stdout",
+  "stderr",
+  "read",
+  "write",
+  "search",
+  "test",
+  "git",
+  "github",
+  "install",
+  "build",
+  "lint",
+  "server",
+  "error",
+  "done",
+]);
+
+const PROVIDERS = new Set<ProviderName>([
+  "disabled",
+  "mock",
+  "openai",
+  "groq",
+  "local",
+  "anthropic",
+  "gemini",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
+
+const isNullableString = (value: unknown): value is string | null =>
+  value === null || typeof value === "string";
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const isProviderName = (value: unknown): value is ProviderName =>
+  typeof value === "string" && PROVIDERS.has(value as ProviderName);
+
+const isOptionalProviderName = (value: unknown): value is ProviderName | undefined =>
+  value === undefined || isProviderName(value);
+
+export const isStyle = (value: unknown): value is Style =>
+  value === "standard" || value === "kansai" || value === "zundamon";
+
+export const isSourceMode = (value: unknown): value is SourceMode =>
+  value === "auto" || value === "claude" || value === "codex" || value === "generic";
+
+export const isEventType = (value: unknown): value is EventType =>
+  typeof value === "string" && EVENT_TYPES.has(value as EventType);
+
+export const isSourceState = (value: unknown): value is SourceState =>
+  isRecord(value) &&
+  isSourceMode(value.mode) &&
+  (value.detected === null ||
+    value.detected === "claude" ||
+    value.detected === "codex" ||
+    value.detected === "generic");
+
+export const isEvent = (value: unknown): value is Event =>
+  isRecord(value) &&
+  typeof value.ts === "number" &&
+  isEventType(value.type) &&
+  typeof value.summary === "string" &&
+  isOptionalString(value.detail);
+
+const isCommentaryMeta = (value: unknown): value is CommentaryMeta =>
+  isRecord(value) &&
+  isOptionalString(value.narrationProvider) &&
+  isOptionalString(value.explanationProvider) &&
+  (value.mode === undefined ||
+    value.mode === "narration" ||
+    value.mode === "explanation" ||
+    value.mode === "both");
+
+const hasCommentaryPayload = (value: Record<string, unknown>): boolean =>
+  isOptionalString(value.narration) &&
+  isOptionalString(value.explanation) &&
+  (value.glossaryNotes === undefined || isStringArray(value.glossaryNotes)) &&
+  (value.meta === undefined || isCommentaryMeta(value.meta));
+
+const isProfileSummary = (value: unknown): value is ProfileSummary =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  typeof value.name === "string" &&
+  typeof value.cmd === "string";
+
+const isProfile = (value: unknown): value is Profile =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  typeof value.name === "string" &&
+  typeof value.cmd === "string" &&
+  isStringArray(value.args) &&
+  isOptionalString(value.cwd) &&
+  isStyle(value.style) &&
+  isSourceMode(value.logSource) &&
+  (value.inputMode === undefined || value.inputMode === "pty" || value.inputMode === "file") &&
+  isOptionalString(value.inputFile) &&
+  isOptionalProviderName(value.llmProvider) &&
+  isOptionalProviderName(value.narrationProvider) &&
+  isOptionalProviderName(value.explanationProvider) &&
+  typeof value.createdAt === "number" &&
+  typeof value.updatedAt === "number";
+
+const normalizeEnvelope = (value: unknown): Record<string, unknown> | null => {
+  if (!isRecord(value)) return null;
+  if (typeof value.kind === "string") return value;
+  if (typeof value.type !== "string") return null;
+  if (isRecord(value.payload)) return { ...value.payload, kind: value.type };
+  return { ...value, kind: value.type };
+};
+
+export function parseServerMessage(value: unknown): WsOutgoing | null {
+  const message = normalizeEnvelope(value);
+  if (!message) return null;
+
+  switch (message.kind) {
+    case "hello":
+      return isStyle(message.style) && isSourceState(message.source)
+        ? (message as WsOutgoing)
+        : null;
+    case "style":
+      return isStyle(message.style) ? (message as WsOutgoing) : null;
+    case "source":
+      return isSourceState(message.source) ? (message as WsOutgoing) : null;
+    case "raw":
+      return typeof message.data === "string" ? (message as WsOutgoing) : null;
+    case "event":
+      return isEvent(message.ev) ? (message as WsOutgoing) : null;
+    case "commentary":
+      return typeof message.ts === "number" && isEvent(message.ev) && hasCommentaryPayload(message)
+        ? (message as WsOutgoing)
+        : null;
+    case "profiles":
+      return Array.isArray(message.profiles) &&
+        message.profiles.every(isProfileSummary) &&
+        isNullableString(message.activeId)
+        ? (message as WsOutgoing)
+        : null;
+    case "profileSaved":
+      return isProfileSummary(message.profile) && isNullableString(message.activeId)
+        ? (message as WsOutgoing)
+        : null;
+    case "profileDeleted":
+      return typeof message.id === "string" && isNullableString(message.activeId)
+        ? (message as WsOutgoing)
+        : null;
+    case "profileDetail":
+      return isProfile(message.profile) ? (message as WsOutgoing) : null;
+    case "profileError":
+    case "ptyError":
+      return typeof message.error === "string" ? (message as WsOutgoing) : null;
+    case "ptyRestart":
+      return typeof message.cmd === "string" &&
+        isStringArray(message.args) &&
+        isNullableString(message.profileId)
+        ? (message as WsOutgoing)
+        : null;
+    case "ptyUnavailable":
+      return typeof message.error === "string" && typeof message.suggestion === "string"
+        ? (message as WsOutgoing)
+        : null;
+    default:
+      return null;
+  }
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,0 +1,123 @@
+export type Style = "standard" | "kansai" | "zundamon";
+export type DetectedSource = "claude" | "codex" | "generic";
+export type SourceMode = "auto" | DetectedSource;
+export type InputMode = "pty" | "file";
+export type SourceState = { mode: SourceMode; detected: DetectedSource | null };
+
+export type EventType =
+  | "start"
+  | "stdout"
+  | "stderr"
+  | "read"
+  | "write"
+  | "search"
+  | "test"
+  | "git"
+  | "github"
+  | "install"
+  | "build"
+  | "lint"
+  | "server"
+  | "error"
+  | "done";
+
+export type Event = {
+  ts: number;
+  type: EventType;
+  summary: string;
+  detail?: string;
+};
+
+export type CommentaryMode = "narration" | "explanation" | "both";
+
+export type CommentaryMeta = {
+  narrationProvider?: string;
+  explanationProvider?: string;
+  mode?: CommentaryMode;
+};
+
+export type CommentaryPayload = {
+  narration?: string;
+  explanation?: string;
+  glossaryNotes?: string[];
+  meta?: CommentaryMeta;
+};
+
+export type ProviderName =
+  | "disabled"
+  | "mock"
+  | "openai"
+  | "groq"
+  | "local"
+  | "anthropic"
+  | "gemini";
+
+export type ProfileLLMProviders = {
+  llmProvider?: ProviderName;
+  narrationProvider?: ProviderName;
+  explanationProvider?: ProviderName;
+};
+
+export type Profile = ProfileLLMProviders & {
+  id: string;
+  name: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  style: Style;
+  logSource: SourceMode;
+  inputMode?: InputMode;
+  inputFile?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ProfileSummary = Pick<Profile, "id" | "name" | "cmd">;
+
+export type CreateProfileInput = ProfileLLMProviders & {
+  name: string;
+  cmd: string;
+  args?: string[];
+  cwd?: string;
+  style?: Style;
+  logSource?: SourceMode;
+  inputMode?: InputMode;
+  inputFile?: string;
+};
+
+export type UpdateProfileInput = Partial<CreateProfileInput>;
+
+export type LaunchSessionInput = {
+  name?: string;
+  cmd: string;
+  args?: string[];
+  cwd?: string;
+  style?: Style;
+  logSource?: SourceMode;
+};
+
+export type WsOutgoing =
+  | { kind: "hello"; style: Style; source: SourceState }
+  | { kind: "style"; style: Style }
+  | { kind: "source"; source: SourceState }
+  | { kind: "raw"; data: string }
+  | { kind: "event"; ev: Event }
+  | ({ kind: "commentary"; ts: number; ev: Event } & CommentaryPayload)
+  | { kind: "profiles"; profiles: ProfileSummary[]; activeId: string | null }
+  | { kind: "profileSaved"; profile: ProfileSummary; activeId: string | null }
+  | { kind: "profileDeleted"; id: string; activeId: string | null }
+  | { kind: "profileDetail"; profile: Profile }
+  | { kind: "profileError"; error: string }
+  | { kind: "ptyRestart"; cmd: string; args: string[]; profileId: string | null }
+  | { kind: "ptyError"; error: string }
+  | { kind: "ptyUnavailable"; error: string; suggestion: string };
+
+export type WsIncoming =
+  | { kind: "setStyle"; style: Style }
+  | { kind: "launchSession"; session: LaunchSessionInput }
+  | { kind: "writeInput"; data: string }
+  | { kind: "getProfiles" }
+  | { kind: "getProfile"; id: string }
+  | { kind: "saveProfile"; profile: CreateProfileInput & { id?: string } }
+  | { kind: "deleteProfile"; id: string }
+  | { kind: "setActiveProfile"; id: string | null };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@cli-commentator/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -61,6 +64,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@cli-commentator/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -113,6 +119,8 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  packages/shared: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary

- add `@cli-commentator/shared` as a minimal workspace package for WS protocol, event, commentary, provider, launch, and profile types
- replace server/web duplicate definitions with compatibility re-exports from the shared package
- add `parseServerMessage` and use its discriminated union in `useCommentatorSocket`
- remove the web hook's manual `Record<string, unknown>` field extraction
- include the workspace links in `pnpm-lock.yaml`

## Behavior

No protocol fields or message kinds were changed. Legacy `type` / `payload` envelopes remain accepted by the shared parser.

## Validation

- `pnpm -C apps/server test` — 332 passed
- `pnpm -C apps/server exec tsc --noEmit` — passed
- `pnpm -C apps/server build` — passed
- `pnpm -C apps/web test` — 57 passed
- `pnpm -C apps/web build` — passed
- `pnpm -C apps/web lint` — passed
- `pnpm dev` — server, PTY, and Vite startup passed
- duplicate protocol type definitions — zero

## Documentation

[skip-doc-sync-check] `apps/server/src/llm/types.ts` only became a compatibility re-export of unchanged shared protocol types. LLM behavior, providers, configuration, and public usage did not change, so the LLM adapter documentation remains accurate.

## Manual verification

Before merge, please verify commentary display, profile operations, and style switching in Chrome as required by #283.

Refs #283
