### PR TITLE
[codex] fix doc drift guard for Cargo.lock updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Test documentation drift guard
+        run: node --test ./scripts/check-doc-sync.test.mjs
+
       - name: Check documentation drift guard
         run: node ./scripts/check-doc-sync.mjs
 

--- a/docs/docs-update-flow.en.md
+++ b/docs/docs-update-flow.en.md
@@ -58,6 +58,7 @@ Use the Doc Freshness checklist in `.github/pull_request_template.md` and enforc
 - On pull requests, `docs_drift_guard` runs `scripts/check-doc-sync.mjs`.
 - Local runs include committed, staged, unstaged, and untracked file changes.
 - If LLM/desktop-distribution implementation changes without matching docs updates, CI fails.
+- Dependency-only changes to `apps/desktop/src-tauri/Cargo.lock` do not alter operating procedures and are excluded from desktop-distribution doc sync. Desktop code, configuration, CI, and release workflow changes remain covered.
 - Use `[skip-doc-sync-check]` in the PR body only for explicit exceptions, and include the reason.
 
 ### CI action maintenance

--- a/docs/docs-update-flow.ja.md
+++ b/docs/docs-update-flow.ja.md
@@ -58,6 +58,7 @@
 - PR では `docs_drift_guard` ジョブが `scripts/check-doc-sync.mjs` を実行する。
 - ローカル実行では commit 済み、stage 済み、未stage、untracked の差分を対象にする。
 - 対象実装（LLM/desktop配布系）が変わったのに主要docsが未更新の場合、CI は失敗する。
+- `apps/desktop/src-tauri/Cargo.lock` のみの依存更新は、運用手順を変更しないため desktop 配布docsの同期対象外とする。desktopコード・設定・CI・release workflowは引き続き対象とする。
 - 例外運用が必要な場合のみ、PR本文に `[skip-doc-sync-check]` を明記し、理由を添える。
 
 ### CI action maintenance

--- a/scripts/check-doc-sync.mjs
+++ b/scripts/check-doc-sync.mjs
@@ -2,10 +2,11 @@
 
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const SKIP_TOKEN = "[skip-doc-sync-check]";
 
-const RULES = [
+export const RULES = [
   {
     id: "llm-adapter-doc-sync",
     description: "LLM implementation changes should update LLM adapter docs",
@@ -27,6 +28,9 @@ const RULES = [
       /^scripts\/prepare-desktop-sidecar\.mjs$/,
       /^\.github\/workflows\/ci\.yml$/,
       /^\.github\/workflows\/release-desktop\.yml$/,
+    ],
+    ignoredFiles: [
+      /^apps\/desktop\/src-tauri\/Cargo\.lock$/,
     ],
     requiredDocs: [
       "docs/ROADMAP.ja.md",
@@ -149,29 +153,13 @@ function getChangedFiles(baseRef, headRef) {
   return [...new Set([...committedFiles, ...localFiles])].sort();
 }
 
-function main() {
-  const args = parseArgs(process.argv.slice(2));
-  const changedFiles = getChangedFiles(args.baseRef, args.headRef);
-
-  console.log(`[doc-sync] Comparing ${args.baseRef}...${args.headRef}`);
-  console.log(`[doc-sync] Changed files: ${changedFiles.length}`);
-
-  if (changedFiles.length === 0) {
-    console.log("[doc-sync] No changed files. PASS");
-    return;
-  }
-
-  const prBody = readPullRequestBody();
-  if (prBody.includes(SKIP_TOKEN)) {
-    console.log(`[doc-sync] Skip token '${SKIP_TOKEN}' found in PR body. PASS`);
-    return;
-  }
-
+export function findViolations(changedFiles, rules = RULES) {
   const violations = [];
 
-  for (const rule of RULES) {
+  for (const rule of rules) {
     const matchedFiles = changedFiles.filter((file) =>
-      rule.triggers.some((pattern) => pattern.test(file))
+      rule.triggers.some((pattern) => pattern.test(file)) &&
+      !rule.ignoredFiles?.some((pattern) => pattern.test(file))
     );
 
     if (matchedFiles.length === 0) {
@@ -191,6 +179,29 @@ function main() {
       });
     }
   }
+
+  return violations;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const changedFiles = getChangedFiles(args.baseRef, args.headRef);
+
+  console.log(`[doc-sync] Comparing ${args.baseRef}...${args.headRef}`);
+  console.log(`[doc-sync] Changed files: ${changedFiles.length}`);
+
+  if (changedFiles.length === 0) {
+    console.log("[doc-sync] No changed files. PASS");
+    return;
+  }
+
+  const prBody = readPullRequestBody();
+  if (prBody.includes(SKIP_TOKEN)) {
+    console.log(`[doc-sync] Skip token '${SKIP_TOKEN}' found in PR body. PASS`);
+    return;
+  }
+
+  const violations = findViolations(changedFiles);
 
   if (violations.length === 0) {
     console.log("[doc-sync] All triggered rules satisfied. PASS");
@@ -213,4 +224,6 @@ function main() {
   process.exit(1);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-doc-sync.test.mjs
+++ b/scripts/check-doc-sync.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findViolations } from "./check-doc-sync.mjs";
+
+test("ignores Cargo.lock-only desktop dependency updates", () => {
+  assert.deepEqual(
+    findViolations(["apps/desktop/src-tauri/Cargo.lock"]),
+    []
+  );
+});
+
+test("still requires docs for desktop release workflow changes", () => {
+  const violations = findViolations([".github/workflows/release-desktop.yml"]);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].ruleId, "desktop-distribution-doc-sync");
+  assert.deepEqual(violations[0].matchedFiles, [
+    ".github/workflows/release-desktop.yml",
+  ]);
+});
+
+test("accepts desktop release workflow changes with an operations doc", () => {
+  assert.deepEqual(
+    findViolations([
+      ".github/workflows/release-desktop.yml",
+      "docs/release-runbook.en.md",
+    ]),
+    []
+  );
+});
+
+test("still requires docs for desktop runtime source changes", () => {
+  const violations = findViolations([
+    "apps/desktop/src-tauri/src/main.rs",
+  ]);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].ruleId, "desktop-distribution-doc-sync");
+});


### PR DESCRIPTION
## What changed

- exclude dependency-only `apps/desktop/src-tauri/Cargo.lock` changes from `desktop-distribution-doc-sync`
- keep desktop source, configuration, CI, and release workflow changes covered
- add four regression tests and run them in the `docs_drift_guard` job
- document the narrow Cargo.lock exception in Japanese and English

## Root cause

The desktop rule matched every file under `apps/desktop/`, so Dependabot PR #271 was required to update operator documentation even though it only changed the resolved Rust dependency lockfile. Release workflow changes such as #278 remain intentionally covered.

## Validation

- `node --test ./scripts/check-doc-sync.test.mjs` — 4 passed
- `pnpm check:doc-sync` — passed
- `actionlint -color` — passed
- `git diff --check` — passed

Closes #293
Refs #292
