### PR TITLE
docs: split local and release readiness guides

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,9 +21,16 @@ Public documentation is maintained in both Japanese and English.
 
 Set `TARGET_CMD` in `apps/server/.env`. Examples: `/bin/bash`, `/bin/zsh`, `powershell`, `claude`, `codex`
 
-## Onboarding and Distribution
+## Local Use and Development
+
+Start here first. Local startup and day-to-day readiness checks do not require signing, notarization, or updater distribution steps.
 
 - Getting Started: `docs/getting-started.en.md`
+
+## Distribution and Release Operations
+
+Use these docs for release builds, signing, notarization, updater wiring, and draft release validation.
+
 - Desktop Release Guide: `docs/desktop-release.en.md`
 - Latest release: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,9 +21,16 @@ CLIの出力を別ウィンドウで実況するMVP。
 
 `apps/server/.env` の `TARGET_CMD` に指定します。例: `/bin/bash`, `/bin/zsh`, `powershell`, `claude`, `codex`
 
-## 導入・配布導線
+## ローカルで使う・開発する
+
+まずはこちらを読んでください。ローカル起動や日常利用の確認では、署名・Notarization・Updater配布の手順は不要です。
 
 - Getting Started: `docs/getting-started.ja.md`
+
+## 配布・リリースを運用する
+
+配布版の作成、署名、Notarization、Updater、Draft Release確認はこちらです。
+
 - Desktop配布ガイド: `docs/desktop-release.ja.md`
 - 最新リリース: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 English: This repository is an MVP for streaming CLI commentary in a separate window. See `README.en.md` for details.
 
-## Getting Started
+## Local Use / ローカル利用
 - JA docs: `./docs/getting-started.ja.md`
 - EN docs: `./docs/getting-started.en.md`
 
-## Desktop Distribution
+## Desktop Distribution / Desktop配布
 - JA guide: `./docs/desktop-release.ja.md`
 - EN guide: `./docs/desktop-release.en.md`
 - Latest release: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -14,9 +14,13 @@ This folder will host public documentation in paired Japanese and English files.
 
 Each document should start with mutual links so readers can switch languages easily.
 
-- [Roadmap](ROADMAP.en.md)
-- [Roadmap Issue Drafts](roadmap-issues.en.md)
+## Local Use and Development Startup
+
 - [Getting Started](getting-started.en.md)
+- [Manual Test Checklist (Internal Validation)](manual-test-checklist.en.md)
+
+## Distribution and Release Operations
+
 - [Desktop Release Guide](desktop-release.en.md)
 - [Desktop Release Runbook](release-runbook.en.md)
 - [v0.2.0 RC Checklist](release-rc-checklist.en.md)
@@ -24,5 +28,9 @@ Each document should start with mutual links so readers can switch languages eas
 - [v0.2.0 RC Decision Evidence Log](release-evidence-log.en.md)
 - [Cross-Platform Smoke Matrix](cross-platform-smoke-matrix.en.md)
 - [Certificate & Secrets Operations](certificate-secrets.en.md)
-- [Manual Test Checklist (Internal Validation)](manual-test-checklist.en.md)
+
+## Planning and Operating Rules
+
+- [Roadmap](ROADMAP.en.md)
+- [Roadmap Issue Drafts](roadmap-issues.en.md)
 - [ROADMAP/LLM_ADAPTER Update Flow](docs-update-flow.en.md)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -14,9 +14,13 @@
 
 各ドキュメントの先頭に相互リンクの言語切替ボタンを置きます。
 
-- [ロードマップ](ROADMAP.ja.md)
-- [ロードマップIssue下書き](roadmap-issues.ja.md)
+## ローカル利用・開発起動
+
 - [Getting Started](getting-started.ja.md)
+- [手動テストチェックシート（内部検証）](manual-test-checklist.ja.md)
+
+## 配布・リリース運用
+
 - [Desktop配布ガイド](desktop-release.ja.md)
 - [Desktop Release Runbook](release-runbook.ja.md)
 - [v0.2.0 RCチェックリスト](release-rc-checklist.ja.md)
@@ -24,5 +28,9 @@
 - [v0.2.0 RC判定 証跡ログ](release-evidence-log.ja.md)
 - [Cross-Platform Smoke Matrix](cross-platform-smoke-matrix.ja.md)
 - [証明書・Secrets運用ガイド](certificate-secrets.ja.md)
-- [手動テストチェックシート（内部検証）](manual-test-checklist.ja.md)
+
+## 計画・運用ルール
+
+- [ロードマップ](ROADMAP.ja.md)
+- [ロードマップIssue下書き](roadmap-issues.ja.md)
 - [ROADMAP/LLM_ADAPTER更新フロー](docs-update-flow.ja.md)

--- a/docs/desktop-release.en.md
+++ b/docs/desktop-release.en.md
@@ -3,7 +3,7 @@
 
 # Desktop Release Guide (Tauri)
 
-This page is the practical checklist for desktop distribution.  
+This page is the practical checklist for **desktop distribution operators**. If you only want to run and use the app locally, start with `docs/getting-started.en.md`.  
 Current status: **Auto-start and in-app update checks are implemented**, and this repo now includes updater/release automation foundations.
 
 ## Current baseline
@@ -41,6 +41,7 @@ it does not change updater endpoint configuration, signing inputs, release
 artifact layout, or operator-facing release steps.
 
 Related docs:
+- Local use and development startup: `docs/getting-started.en.md`
 - Detailed operations (including recovery/rollback): `docs/release-runbook.en.md`
 - Certificate/secrets operations: `docs/certificate-secrets.en.md`
 

--- a/docs/desktop-release.ja.md
+++ b/docs/desktop-release.ja.md
@@ -3,7 +3,7 @@
 
 # Desktop配布ガイド（Tauri）
 
-このページは、デスクトップ版の配布導線を整えるための実務チェックリストです。  
+このページは、デスクトップ版の **配布運用者向け** 実務チェックリストです。ローカルで起動して使うだけなら、まず `docs/getting-started.ja.md` を参照してください。  
 現時点では **Auto-start と更新確認（Updater check）は実装済み** で、Updater/配布自動化の土台をこのリポジトリに追加済みです。
 
 ## 現在の到達点
@@ -40,6 +40,7 @@ updater endpoint 設定、署名入力、release artifact layout、operator-faci
 リリース手順は変更しません。
 
 関連ドキュメント:
+- ローカル利用・開発起動: `docs/getting-started.ja.md`
 - 詳細運用手順（復旧/ロールバック含む）: `docs/release-runbook.ja.md`
 - 証明書/Secrets運用: `docs/certificate-secrets.ja.md`
 

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -5,6 +5,8 @@
 
 CLI Commentator captures CLI output (PTY or file tail), extracts events, and streams commentary to the Web UI.
 
+This page is the entry point for **local use and development startup**. Signing, notarization, updater wiring, and draft release validation are not required for normal local use. If you are building or validating distribution artifacts, see `docs/desktop-release.en.md`.
+
 ## Prerequisites
 
 - Node.js (recommended: 20+)
@@ -22,13 +24,23 @@ Development flow (`pnpm dev*` / `tauri:build`) still requires local Node/pnpm.
 pnpm install
 ```
 
-## Use Desktop Release Builds
+## Run in Desktop Managed Mode (Tauri + web)
 
-- Latest release page: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
-- Desktop release guide: `docs/desktop-release.en.md`
+This is the primary path for checking the app locally as a desktop app.
 
-For normal usage, download `.dmg` (macOS) from Releases and launch it.  
-For signing/updater/release operations, use the desktop release guide and runbook docs.
+```bash
+pnpm dev:desktop:managed
+```
+
+`dev:desktop:managed` runs `pnpm ensure:desktop-sidecar` before startup. If `src-tauri/binaries`, `resources/server`, or `sidecar-manifest.json` is missing or incomplete, it regenerates the sidecar assets through `prepare:desktop-sidecar`. You can also run the same ensure command directly when you only want to validate the sidecar state.
+
+The Desktop Server panel controls server lifecycle (`Start` / `Stop`) and shows status (`stopped` / `starting` / `running` / `stopping` / `failed`).
+
+If status becomes `failed`, use the guidance shown in the panel and check logs from the same terminal.
+
+When startup fails, the Desktop Server panel shows a recovery card. It includes likely causes, checkpoints, diagnostic details, and copyable `commands to try`, so start with the commands shown there.
+
+Note: In desktop managed mode, if `8787` is occupied, desktop automatically falls back to `8788+` and the UI WebSocket target follows automatically.
 
 ## Run in Web Mode (server + web)
 
@@ -41,19 +53,15 @@ Expected URLs:
 - Server health: `http://localhost:8787/healthz` (`/health` is also supported)
 - Web UI: Vite URL (usually `http://localhost:5173`)
 
-## Run in Desktop Managed Mode (Tauri + web)
+## Use Desktop Release Builds
 
-```bash
-pnpm dev:desktop:managed
-```
+This path is for using already-published `.dmg` builds. It is not the procedure for creating releases, signing artifacts, or validating updater distribution.
 
-`dev:desktop:managed` runs `pnpm ensure:desktop-sidecar` before startup. If `src-tauri/binaries`, `resources/server`, or `sidecar-manifest.json` is missing or incomplete, it regenerates the sidecar assets through `prepare:desktop-sidecar`. You can also run the same ensure command directly when you only want to validate the sidecar state.
+- Latest release page: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
+- Distribution operations guide: `docs/desktop-release.en.md`
 
-The Desktop Server panel controls server lifecycle (`Start` / `Stop`) and shows status (`stopped` / `starting` / `running` / `stopping` / `failed`).
-
-If status becomes `failed`, use the guidance shown in the panel and check logs from the same terminal.
-
-Note: In desktop managed mode, if `8787` is occupied, desktop automatically falls back to `8788+` and the UI WebSocket target follows automatically.
+For normal usage, download `.dmg` (macOS) from Releases and launch it.  
+For signing/notarization/updater/release operations, use the distribution operations guide and runbook docs.
 
 ## Input Modes
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -5,6 +5,8 @@
 
 CLI Commentator は CLI 出力（PTY またはログファイル tail）を取り込み、イベント化して Web UI に実況を流します。
 
+このページは **ローカル利用・開発起動の入口**です。署名、Notarization、Updater、Draft Release などの配布運用は通常のローカル利用には不要です。配布版を作る・検証する場合は `docs/desktop-release.ja.md` を参照してください。
+
 ## 前提
 
 - Node.js（推奨: 20+）
@@ -22,26 +24,9 @@ CLI Commentator は CLI 出力（PTY またはログファイル tail）を取�
 pnpm install
 ```
 
-## 配布版（Desktop）を入手して使う
-
-- 最新配布ページ: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
-- 配布ガイド: `docs/desktop-release.ja.md`
-
-通常は Releases から `.dmg`（macOS）を取得して起動します。  
-運用や署名/更新まわりの詳細は配布ガイドと runbook を参照してください。
-
-## Web モードで起動（server + web）
-
-```bash
-pnpm dev
-```
-
-起動URLの目安:
-
-- Server health: `http://localhost:8787/healthz`（`/health` も互換で利用可能）
-- Web UI: Vite が表示する URL（通常 `http://localhost:5173`）
-
 ## Desktop managed モードで起動（Tauri + web）
+
+ローカルでデスクトップアプリとして確認する場合の主導線です。
 
 ```bash
 pnpm dev:desktop:managed
@@ -57,6 +42,27 @@ Desktop Server パネルで server の状態を操作します（`Start` / `Stop
 その場でコピーできる `試すコマンド` が出るので、まずは表示されたコマンドを順に確認してください。
 
 補足: Desktop managed モードでは、既定ポート `8787` が使用中なら `8788` 以降へ自動退避し、UI の接続先も自動追従します。
+
+## Web モードで起動（server + web）
+
+```bash
+pnpm dev
+```
+
+起動URLの目安:
+
+- Server health: `http://localhost:8787/healthz`（`/health` も互換で利用可能）
+- Web UI: Vite が表示する URL（通常 `http://localhost:5173`）
+
+## 配布版（Desktop）を入手して使う
+
+配布済みの `.dmg` を使う場合の導線です。配布版を作る・署名する・Updaterを検証する手順ではありません。
+
+- 最新配布ページ: <https://github.com/gatyoukatyou/cli-commentator/releases/latest>
+- 配布運用ガイド: `docs/desktop-release.ja.md`
+
+通常は Releases から `.dmg`（macOS）を取得して起動します。  
+署名/Notarization/Updater/リリース運用の詳細は配布運用ガイドと runbook を参照してください。
 
 ## 入力モード
 


### PR DESCRIPTION
## 概要

ローカル利用者向けの local readiness 導線と、配布運用者向けの release readiness 導線を分離します。

現在の焦点は release workflow smoke ではなく local desktop app polish / local readiness であるため、通常利用者が署名・Notarization・Updater 情報に早い段階で引っ張られないように、README / getting-started / desktop-release / docs index の導線を整理しました。

## 変更点

- `README.md` / `README.ja.md` / `README.en.md`
  - Local Use / ローカル利用 と Desktop Distribution / Desktop配布を分離
- `docs/getting-started.ja.md` / `docs/getting-started.en.md`
  - ローカル利用・開発起動の入口であることを明記
  - Desktop managed mode を主導線として前に移動
  - 配布版利用と配布運用を分けて説明
- `docs/desktop-release.ja.md` / `docs/desktop-release.en.md`
  - 配布運用者向け文書であることを冒頭に明記
  - local use は getting-started へ誘導
- `docs/README.ja.md` / `docs/README.en.md`
  - Local use / Distribution / Planning に分類

## 確認事項

- docs-only
- `.ja.md` / `.en.md` の日英ペアを同時更新
- 日英で見出し構造・リンク構造を揃えた
- 既存の `getting-started`, `desktop-release`, `release-runbook`, `certificate-secrets`, `releases/latest` 導線を維持
- workflow / package / 実装ファイルは未変更

## 注意

このPRは文書導線整理のみです。`pnpm dev:desktop:managed` の実機セルフ稼働確認や #278 release workflow smoke は別タスクとして扱います。