### PR TITLE
docs: ROADMAPにIssue #300の長期改良方針を反映（ja/en）

### DIFF
--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -4,24 +4,37 @@
 # CLI Commentator Roadmap (v1)
 
 ## What is this?
-CLI Commentator is an app that reads terminal work logs and streams beginner-friendly commentary in a separate window.  
+CLI Commentator helps non-engineers who are not comfortable with English supervise CLI-based AI work through understandable Japanese text and speech.
+
 This page summarizes the **Goal**, the **phases**, and the **current status** in a simple, non-technical way.
 
 ---
 
 ## Goal
-- Use your terminal as usual (Claude Code / Codex / bash / git, etc.)
-- The app reads logs and generates “what’s happening now?” commentary automatically
-- Commentary flows in a **separate window** (doesn’t interrupt work)
+- Launch Claude Code and explain its activity and requests in real time through Japanese text and speech
+- Make it possible to understand **what the AI is doing and whether human judgment is required** without continuously reading English CLI output
+- Detect permission requests, questions, errors, completion, and prolonged thinking or silence so intervention is not missed
+- Generate explanations with rules and lightweight APIs instead of asking Claude Code itself
 - Tone presets (Standard / Kansai, etc.) + 1-line beginner hint + glossary notes (parentheses)
 - Mask secret-looking strings to reduce leakage risk
-- MVP works without an LLM (rule-based), with an option to add LLM adapters later
+- Ultimately supervise Claude Code and Codex CLI working in parallel, including their interactions
 
 ---
 
 ## Principle
-We prioritize a **stable foundation** over flashy features.  
-Build a minimal MVP that reliably works, then expand once value is proven.
+We prioritize **delivering the information needed for supervision, without omission or noise**.
+
+Entertaining commentary can help adoption, but interruption priority and immediate error alerts remain consistent across all tones.
+
+## Long-term priorities
+
+1. **Supervision event detection**: detect permission requests, questions, errors, completion, and prolonged thinking or silence, then notify by importance
+2. **Japanese explanation quality**: summarize English output in plain Japanese by intent and add necessary terminology notes
+3. **Remove startup friction**: let users reach live Claude Code commentary without relying on a manual
+4. **Parallel AI supervision**: supervise multiple Claude Code and Codex CLI sessions
+5. **Distribution and sharing**: improve external distribution and commentary-sharing paths
+
+Supervision and entertaining commentary share one event-detection result; only the presentation layer is separated into serious and play-by-play tones.
 
 ---
 
@@ -84,7 +97,7 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 
 ---
 
-## Current status (as of 2026-05-08)
+## Current status (as of 2026-07-12)
 **Done**
 - PR #1: detect boundary tests (mixed => generic, 50-line limit, exported constants)
 - PR #2: add roadmap docs (JA/EN + links from docs/README)
@@ -133,17 +146,20 @@ Build a minimal MVP that reliably works, then expand once value is proven.
 - PR #259 made Desktop sidecar preparation idempotent, so `dev:desktop:managed` can safely verify and regenerate bundled sidecar assets before startup
 
 **Now**
+- Issue #300 establishes the long-term direction. Supervision event detection is the top priority, beginning with a Phase A-0 dogfooding observation period
+- During Phase A-0, record moments that mattered for supervision but were missed during one week of real work sessions, then use them to specify the five event classes
 - Because we are not issuing an Apple Developer ID certificate for now, `#138` is treated as Deferred. Signed distribution readiness remains important, but we will return to it when certificate issuance and external distribution preparation resume
-- The near-term focus is local desktop app polish / local readiness instead of release readiness. The priority is a desktop app that starts reliably on a local machine and makes the next step obvious
+- Keep local desktop app polish / local readiness sufficient to start Phase A-0 observations reliably
 - Main is current after PR #259, with GitHub CI green across `test`, `test_windows`, `desktop_check`, `desktop_distribution_smoke`, and CodeQL
 
 **Next**
-- Make the local `pnpm dev:desktop:managed` startup path easier to follow, especially first setup, sidecar/server startup waiting, and recovery guidance when startup fails
-- Consider a local readiness check script that can validate a clean checkout path, for example by running `ensure:desktop-sidecar`, web lint/build, server tests, and desktop cargo tests in order
-- Improve the standalone Web UI disconnected state and the Desktop managed flow that asks users to press Start before commentary can begin
-- Separate release readiness from local readiness so signing/notarization details do not dominate the local-use experience
+- Break Phase A-0 into an issue with observation fields, recording format, and completion criteria
+- Use the observations to specify permission requests, questions, errors, completion, and prolonged thinking or silence, with priority-aware TTS (Phase A-1)
+- Improve Japanese explanations and summarization, with separate serious and play-by-play presentation layers (Phase B)
 
 **Later**
+- Complete a manual-free path from launch to live commentary (Phase C)
+- Extend the architecture to supervise Claude Code and Codex CLI in parallel with multiple sessions
 - Continue dependency and desktop runtime maintenance through the docs drift guard path
 - Keep improving failure-regression summaries and recovery evidence as new concrete failure cases appear
 - Return to `#138` when Apple Developer ID certificate issuance and distribution preparation resume, then run the signed/notarized `release-desktop` smoke and record evidence

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -4,24 +4,37 @@
 # CLI Commentator ロードマップ（v1）
 
 ## これは何？
-CLI Commentator は「ターミナルの作業ログを見て、別ウィンドウで初心者向け実況（解説）を流す」アプリです。  
+CLI Commentator は、非エンジニアで英語に不慣れな人が、CLI上で動くAIの作業を理解できる日本語のテキストと音声で監督するためのアプリです。
+
 このページは **Goal（完成形）** と **そこに行く道（フェーズ）** と **現在地（いま何をやっているか）** を、非エンジニア向けに整理したものです。
 
 ---
 
 ## Goal（完成形）
-- ふだん通りにターミナルで作業（Claude Code / Codex / bash / git など）
-- アプリがログを読み取り、**「いま何してる？」を自動実況**
-- 実況は **別ウィンドウ**に流れ、作業の邪魔をしない
+- Claude Codeを起動し、その動作や指示をリアルタイムに日本語で解説・読み上げる
+- 英語のCLI出力を読み続けなくても、**「いま何をしているか」「HUMANの判断が必要か」**を把握できる
+- 許可待ち、質問、エラー、完了、長考・沈黙を検知し、介入すべき瞬間を逃さない
+- 解説はClaude Code自身ではなく、ルールと軽量APIで生成する
 - 口調プリセット（標準/関西弁など）＋「初心者向け1行説明」＋「用語注釈（括弧）」
 - **秘密っぽい文字列をマスク**して漏えい事故を防ぐ
-- 最初は **ルールベースで成立**（後でLLM差し替え可能）
+- 最終的にはClaude CodeとCodex CLIを並列で動かし、相互のやり取りを含めて監督する
 
 ---
 
 ## いまの方針（大事）
-このプロジェクトは、派手な機能よりも **「壊れない土台」**を優先します。  
-まずは “確実に動く最小構成（MVP）” を作り、価値が見えたら拡張します。
+このプロジェクトは **「監督に必要な情報が過不足なく届くこと」**を最優先します。
+
+実況の面白さは利用のフックとして活かしますが、口調が変わっても割り込み優先度とエラーの即時通知は共通にします。
+
+## 長期改良の優先順位
+
+1. **監督イベント検知**：許可待ち、質問、エラー、完了、長考・沈黙を検知し、重要度に応じて通知する
+2. **日本語解説の質**：英語出力を平易な日本語で意図単位に要約し、必要な用語注釈を付ける
+3. **起動フリクション排除**：説明書なしでClaude Codeの実況開始まで辿り着ける導線を作る
+4. **並列AI監督**：Claude CodeとCodex CLIの複数セッションを監督する
+5. **配布・共有**：外部配布と実況を共有しやすい導線を整える
+
+監督と実況の面白さは同じイベント検知結果を使い、真面目トーン／実況トーンの提示層だけを分離します。
 
 ---
 
@@ -89,7 +102,7 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 
 ---
 
-## 現在地（2026-05-08 時点）
+## 現在地（2026-07-12 時点）
 **Done**
 - PR #1：detect 境界テスト（混在→generic、50行制限、重要定数export）
 - PR #2：ロードマップ docs 追加（日英＋docs/READMEからリンク）
@@ -138,17 +151,20 @@ CLI Commentator は「ターミナルの作業ログを見て、別ウィンド�
 - PR #259：Desktop sidecar prepare を冪等化し、`dev:desktop:managed` 起動前に同梱sidecarを安全に確認・再生成できるようにした
 
 **Now**
+- Issue #300 で長期改良方針を正本化。最優先は「監督イベント検知」とし、Phase A-0 のドッグフーディング観察から開始する
+- Phase A-0 では1週間の実作業セッションを通じて「監督に必要だったのに拾えなかった瞬間」を記録し、5分類の検知仕様へつなげる
 - Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
-- 直近の焦点は release readiness ではなく local desktop app polish / local readiness。ローカルで安定して起動し、迷わず使えるデスクトップアプリとしての完成度を優先する
+- local desktop app polish / local readiness は、Phase A-0 の観察を開始できる起動導線として維持する
 - main は PR #259 反映後の状態で最新化済み。GitHub CI は `test` / `test_windows` / `desktop_check` / `desktop_distribution_smoke` / CodeQL が green
 
 **Next**
-- `pnpm dev:desktop:managed` のローカル起動導線をさらに分かりやすくする。初回セットアップ、sidecar/server 起動待ち、失敗時の復旧案内を local 利用者目線で磨く
-- clean checkout から local readiness を確認できるスクリプトを検討する。例: `ensure:desktop-sidecar`、web lint/build、server test、desktop cargo test を順に実行する小さな検証入口
-- Web UI 単体起動時の「切断」表示と、Desktop managed 起動時の「まず Start する」導線を整理する
-- release readiness と local readiness の情報を分け、ローカル利用時に署名・notarization 関連情報が前面に出すぎないようにする
+- Phase A-0 の観察項目、記録形式、完了条件をIssueへ分解する
+- 観察結果から許可待ち、質問、エラー、完了、長考・沈黙の検知仕様と優先度付きTTSを設計する（Phase A-1）
+- 日本語解説・要約と、真面目トーン／実況トーンを分けた提示層を改善する（Phase B）
 
 **Later**
+- 説明書なしで実況開始まで辿り着ける起動導線を完成させる（Phase C）
+- 複数セッション前提でClaude CodeとCodex CLIの並列監督へ拡張する
 - dependency / desktop runtime maintenance は docs drift guard 経由で継続運用する
 - 新しい具体的な失敗例が出たら、failure regression summary と recovery evidence を継続強化する
 - Apple Developer ID 証明書の発行・配布準備を再開する段階で `#138` に戻り、signed/notarized `release-desktop` smoke と証跡記録を実施する


### PR DESCRIPTION
## Summary

Issue #300 で正本化した長期改良方針をROADMAP日英に反映する。

- 「これは何？」「Goal」を目的定義（非エンジニアが日本語テキスト+音声でAI作業を監督するツール）に書き換え
- 「いまの方針」を「監督に必要な情報が過不足なく届くこと」最優先に更新し、長期優先順位（監督イベント検知 → 日本語解説 → 起動導線 → 並列監督 → 配布）を追加
- 現在地の Now / Next / Later を Phase A-0（1週間ドッグフーディング観察）起点に更新
- 実況の面白さは、監督とイベント検知エンジンを共有する提示層として位置づけ（割り込み優先度・エラー即時通知は全トーン共通）

## Related Issues

Refs #300

**⚠️ Gino方針確認が完了するまでDraftのまま維持し、mergeしないこと（merge判断はHUMAN）**

## Type of Change

- [x] Documentation

## Checklist

### General
- [x] docsのみの変更（コード変更なし）
- [x] `pnpm check:doc-sync`: PASS
- [x] `git diff --check`: clean
- [x] 最新 `origin/main`（380bd4f）基点

🤖 Generated with [Claude Code](https://claude.com/claude-code)