### PR TITLE
test: Claude PTY監督イベントの採取経路とfixtureを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 
 # aion-ops bootstrap clone (母艦の一時取得先・コミットしない)
 .aion-ops/
+
+# Raw PTY diagnostic captures can contain secrets and local paths.
+*.pty-capture.jsonl

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -17,6 +17,9 @@ TARGET_CWD=
 # PTY_USE_CONPTY=1
 # Force-disable PTY to test file fallback behavior (optional)
 # CLI_COMMENTATOR_FORCE_NO_PTY=1
+# Diagnostic only: records unredacted PTY chunks as timestamped Base64 JSONL.
+# The file can contain secrets and local paths; keep it outside the repository and sanitize before sharing.
+# PTY_CAPTURE_FILE=/tmp/session.pty-capture.jsonl
 
 # Which ruleset to use: auto|claude|codex|generic
 LOG_SOURCE=auto

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,6 +42,7 @@ import {
   type ServerStateEventContextInput,
 } from "./runtime/state-event.js";
 import { isStyle, normalizeSource } from "./shared/validation.js";
+import { createPtyCapture } from "./pty/capture.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -59,6 +60,7 @@ function parseInputMode(value?: string): InputMode {
 
 const INPUT_MODE: InputMode = parseInputMode(INPUT_MODE_RAW);
 const INPUT_FILE = process.env.INPUT_FILE ?? "";
+const ptyCapture = createPtyCapture(process.env.PTY_CAPTURE_FILE);
 let runtimeInputMode: InputMode = INPUT_MODE;
 
 // --- Mutable state ---
@@ -439,6 +441,7 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
   // Process and broadcast data using common pipeline
   term.onData((data) => {
     if (ptyManager.current !== term) return;
+    ptyCapture?.write(data);
     processInputData(data, true);
   });
 
@@ -1142,6 +1145,7 @@ function cleanup(exitCode: number = 0): void {
   // 2. PTY kill / FileTail stop
   ptyManager.kill();
   stopFileTail(true);
+  ptyCapture?.close();
 
   // 3. WebSocket clients close
   for (const client of wss.clients) {

--- a/apps/server/src/pty/capture.ts
+++ b/apps/server/src/pty/capture.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type PtyCapture = {
+  write: (data: string, ts?: number) => void;
+  close: () => void;
+};
+
+type CaptureRecord =
+  | { kind: "meta"; version: 1; startedAt: number }
+  | { kind: "data"; ts: number; dataBase64: string };
+
+export function createPtyCapture(filePath?: string): PtyCapture | null {
+  const resolved = filePath?.trim();
+  if (!resolved) return null;
+
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  const fd = fs.openSync(resolved, "a", 0o600);
+  fs.chmodSync(resolved, 0o600);
+  let closed = false;
+
+  const append = (record: CaptureRecord): void => {
+    if (closed) return;
+    fs.writeSync(fd, `${JSON.stringify(record)}\n`, undefined, "utf8");
+  };
+
+  append({ kind: "meta", version: 1, startedAt: Date.now() });
+
+  return {
+    write(data, ts = Date.now()) {
+      append({
+        kind: "data",
+        ts,
+        dataBase64: Buffer.from(data, "utf8").toString("base64"),
+      });
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      fs.closeSync(fd);
+    },
+  };
+}

--- a/apps/server/src/tests/pty.capture.test.ts
+++ b/apps/server/src/tests/pty.capture.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPtyCapture } from "../pty/capture.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createPtyCapture", () => {
+  it("stays disabled without an explicit path", () => {
+    expect(createPtyCapture()).toBeNull();
+    expect(createPtyCapture("   ")).toBeNull();
+  });
+
+  it("records exact PTY chunks with timestamps as base64 JSONL", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-commentator-pty-capture-"));
+    tempDirs.push(dir);
+    const capturePath = path.join(dir, "nested", "session.pty-capture.jsonl");
+    const capture = createPtyCapture(capturePath);
+
+    capture?.write("\u001b[2J許可しますか？\r\n", 1234);
+    capture?.close();
+
+    const records = fs
+      .readFileSync(capturePath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(records[0]).toMatchObject({ kind: "meta", version: 1 });
+    expect(records[1]).toEqual({
+      kind: "data",
+      ts: 1234,
+      dataBase64: Buffer.from("\u001b[2J許可しますか？\r\n", "utf8").toString("base64"),
+    });
+    expect(fs.statSync(capturePath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/apps/server/src/tests/pty.capture.test.ts
+++ b/apps/server/src/tests/pty.capture.test.ts
@@ -39,6 +39,8 @@ describe("createPtyCapture", () => {
       ts: 1234,
       dataBase64: Buffer.from("\u001b[2J許可しますか？\r\n", "utf8").toString("base64"),
     });
-    expect(fs.statSync(capturePath).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(capturePath).mode & 0o777).toBe(0o600);
+    }
   });
 });

--- a/apps/server/src/tests/pty.fixtures.test.ts
+++ b/apps/server/src/tests/pty.fixtures.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const fixtureDir = path.resolve(process.cwd(), "test/fixtures/claude-tui");
+
+describe("Claude TUI PTY fixtures", () => {
+  const fixtureNames = [
+    "trust-prompt.json",
+    "question.json",
+    "tool-approval.json",
+    "error-completion.json",
+  ];
+
+  it.each(fixtureNames)("keeps %s sanitized and parseable", (fixtureName) => {
+    const raw = fs.readFileSync(path.join(fixtureDir, fixtureName), "utf8");
+    const fixture = JSON.parse(raw) as { sanitized: boolean; chunks: string[] };
+
+    expect(fixture.sanitized).toBe(true);
+    expect(fixture.chunks.length).toBeGreaterThan(0);
+    expect(fixture.chunks.join("")).toContain("\u001b[");
+    expect(raw).not.toMatch(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+    expect(raw).not.toContain("/private/tmp/");
+  });
+});

--- a/apps/server/test/fixtures/claude-tui/error-completion.json
+++ b/apps/server/test/fixtures/claude-tui/error-completion.json
@@ -1,0 +1,8 @@
+{
+  "classification": ["error", "completion"],
+  "source": "Claude Code 2.1.207 PTY capture",
+  "sanitized": true,
+  "chunks": [
+    "\u001b[1B⏺\u001b[3GYou chose red. The command cli_commentator_fixture_missing\u001b[62Gfailed\u001b[69Gwith\u001b[74Gexit\u001b[79Gcode\u001b[84G127\u001b[88Gand\u001b[92Gthe\u001b[96Gmessage\u001b[104Gcommand\u001b[112Gnot\u001b[116Gfound\r\n\u001b[2C\u001b[1B— this is the shell's standard way of saying no executable with that name exists in your PATH\r\n\u001b[1B\u001b[K\r\n\u001b[2C\u001b[1BThe task is complete.\u001b[K"
+  ]
+}

--- a/apps/server/test/fixtures/claude-tui/question.json
+++ b/apps/server/test/fixtures/claude-tui/question.json
@@ -1,0 +1,8 @@
+{
+  "classification": "question",
+  "source": "Claude Code 2.1.207 PTY capture",
+  "sanitized": true,
+  "chunks": [
+    "\u001b[1C\u001b[1B☐\u001b[4GColor pick\u001b[K\r\n\u001b[1C\u001b[1B\u001b[K\r\n\u001b[1BWhich\u001b[7Gcolor do you choose:\u001b[28Gred\u001b[32Gor\u001b[35Gblue?\r\n\u001b[2C\u001b[2B1. Red\u001b[K\r\n\u001b[2C\u001b[1B2. Blue\r\n\u001b[2B  3. Type something.\r\n\u001b[2B  4. Chat about this\r\n\u001b[1B\u001b[K\r\n\u001b[1BEnter to select · ↑/↓ to navigate · Esc to cancel\u001b[K"
+  ]
+}

--- a/apps/server/test/fixtures/claude-tui/tool-approval.json
+++ b/apps/server/test/fixtures/claude-tui/tool-approval.json
@@ -1,0 +1,8 @@
+{
+  "classification": "permission",
+  "source": "Claude Code 2.1.207 PTY capture",
+  "sanitized": true,
+  "chunks": [
+    "\u001b[1B Bash command\u001b[K\r\n\u001b[2C\u001b[1B\u001b[K\r\n\u001b[3C\u001b[1Bcli_commentator_fixture_missing\r\n\u001b[1B  Run nonexistent command to demonstrate error\u001b[K\r\n\u001b[1C\u001b[2BThis command requires approval\r\n\u001b[2B Do you want to proceed?\u001b[K\r\n\u001b[1C\u001b[1B❯\u001b[4G1.\u001b[7GYes\u001b[K\r\n   2. Yes, and don’t ask again for: cli_commentator_fixture_missing\u001b[K\r\n  3. No\r\n\u001b[1BEsc to cancel · Tab to amend · ctrl+e to explain\u001b[K"
+  ]
+}

--- a/apps/server/test/fixtures/claude-tui/trust-prompt.json
+++ b/apps/server/test/fixtures/claude-tui/trust-prompt.json
@@ -1,0 +1,8 @@
+{
+  "classification": "permission",
+  "source": "Claude Code 2.1.207 PTY capture",
+  "sanitized": true,
+  "chunks": [
+    "\u001b[2GAccessing\u001b[12Gworkspace:\r\n\r\n\u001b[2G/tmp/<WORKSPACE>\r\n\r\n\u001b[2GQuick\u001b[8Gsafety\u001b[15Gcheck:\u001b[22GIs\u001b[25Gthis\u001b[30Ga\u001b[32Gproject\u001b[40Gyou\u001b[44Gcreated\u001b[52Gor\u001b[55Gone\u001b[59Gyou\u001b[63Gtrust?\r\n\r\n\u001b[2GClaude\u001b[9GCode'll\u001b[17Gbe\u001b[20Gable\u001b[25Gto\u001b[28Gread,\u001b[34Gedit,\u001b[40Gand\u001b[44Gexecute\u001b[52Gfiles\u001b[58Ghere.\r\n\r\n\u001b[2G❯\u001b[4G1.\u001b[7GYes,\u001b[12GI\u001b[14Gtrust\u001b[20Gthis\u001b[25Gfolder\r\n\u001b[4G2.\u001b[7GNo,\u001b[11Gexit\r\n\r\n\u001b[2GEnter\u001b[8Gto\u001b[11Gconfirm\u001b[19G·\u001b[21GEsc\u001b[25Gto\u001b[28Gcancel"
+  ]
+}


### PR DESCRIPTION
## Summary

Phase A-1 の最初の調査タスク #305 として、Claude Code TUIの監督イベントを実PTYから採取し、マスク済みfixtureへ固定します。

- `PTY_CAPTURE_FILE` 指定時だけ、生PTYチャンクを時刻付きBase64 JSONLとして権限`600`で保存
- 生captureをGit除外し、機微情報を含む原本を誤ってcommitしないガードを追加
- Claude Code 2.1.207の実セッションから、workspace信頼確認・選択式質問・ツール許可待ち・command not found・完了を採取
- ANSI/TUI再描画を保持したマスク済みfixtureと安全性テストを追加

## Findings

Claude Code TUIは一行ログではなく、画面全体の再描画とカーソル移動を頻繁に出力します。そのため単純な行分割だけでは不安定です。一方、質問・許可待ち・エラー・完了の核となる文言は生チャンクに残るため、ANSI除去後の短時間チャンク窓を正規化する設計で検知可能と判断しました。

## Validation

- `pnpm -C apps/server test -- --run`: 338 tests passed
- `pnpm -C apps/server build`: PASS
- `git diff --check`: clean
- 実Claude Code PTY smoke: capture生成、Base64復元、権限`600`を確認
- 機微情報を含む一時原本はfixture作成後に削除済み

## Docs sync

[skip-doc-sync-check]

`apps/server/.env.example`の変更はLLM Adapter設定ではなく、一時診断用のPTY capture変数を安全上の注意とともに記載するものです。LLM Adapter文書への変更は不要です。

Refs #304
Closes #305