### PR TITLE
feat: Claude TUIの監督イベント4分類を検知

### DIFF
--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,6 +1,7 @@
 import type { Event } from "./types.js";
 import { rulesForLine } from "./rulesets/index.js";
 import { isCodexProgressNoise } from "./progress-noise.js";
+import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
 
 // Remove ANSI/VT control sequences so TUI apps like Claude Code still match rules.
 const ANSI_ESCAPE_RE =
@@ -165,6 +166,11 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
 
 export function extractEvents(chunk: string, sourceEnv: string | undefined = process.env.LOG_SOURCE): Event[] {
   const ts = Date.now();
+
+  if ((sourceEnv ?? "").trim().toLowerCase() === "claude") {
+    const supervisionEvents = extractClaudeSupervisionEvents(chunk, ts);
+    if (supervisionEvents.length > 0) return supervisionEvents;
+  }
 
   const events: Event[] = [];
   for (const rawLine of chunk.split(/\r?\n/)) {

--- a/apps/server/src/rulesets/claude-supervision.ts
+++ b/apps/server/src/rulesets/claude-supervision.ts
@@ -1,0 +1,51 @@
+import type { Event } from "../types.js";
+
+const ANSI_ESCAPE_RE =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
+
+function normalizeTuiChunk(chunk: string): { readable: string; compact: string } {
+  const readable = chunk
+    .replace(ANSI_ESCAPE_RE, " ")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return {
+    readable,
+    compact: readable.replace(/\s+/g, "").toLowerCase(),
+  };
+}
+
+export function extractClaudeSupervisionEvents(chunk: string, ts = Date.now()): Event[] {
+  const { readable, compact } = normalizeTuiChunk(chunk);
+  if (!compact) return [];
+
+  const events: Event[] = [];
+  const detail = readable.slice(0, 1000);
+
+  if (
+    (compact.includes("quicksafetycheck:") && compact.includes("trustthisfolder")) ||
+    (compact.includes("requiresapproval") && compact.includes("doyouwanttoproceed?"))
+  ) {
+    events.push({ ts, type: "stdout", summary: "許可を待っている", detail });
+  }
+
+  if (compact.includes("entertoselect") && /(?:1\.|2\.).*(?:3\.|typesomething)/i.test(readable)) {
+    events.push({ ts, type: "stdout", summary: "質問への回答を待っている", detail });
+  }
+
+  if (
+    compact.includes("failedwithexitcode") ||
+    compact.includes("commandnotfound") ||
+    compact.includes("executionerror")
+  ) {
+    events.push({ ts, type: "error", summary: "エラーが発生している", detail });
+  }
+
+  if (/(?:the )?(?:task|work) is complete\.?$/i.test(readable)) {
+    events.push({ ts, type: "done", summary: "作業が完了した", detail });
+  }
+
+  return events;
+}

--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -5,6 +5,10 @@ export const claudeRuleset: RuleSet = {
   label: "Claude Code",
   detect: (line) => /^(⏺|•)\s*(Read|Update|Write|Bash)\(/.test(line),
   rules: [
+    { id: "claude.permission", priority: 130, re: /requires approval|do you want to proceed\?|trust this folder/i, type: "stdout", summary: "許可を待っている" },
+    { id: "claude.question", priority: 125, re: /enter to select|which .* do you (?:choose|prefer)/i, type: "stdout", summary: "質問への回答を待っている" },
+    { id: "claude.completion", priority: 120, re: /(?:^|[.!?]\s+)(?:the )?(?:task|work) is complete\.?$/i, type: "done", summary: "作業が完了した" },
+    { id: "claude.exit-error", priority: 115, re: /failed with exit code|command not found/i, type: "error", summary: "エラーが発生している" },
     { id: "claude.read", priority: 100, re: /^[⏺•]\s*Read\(/, type: "read", summary: "ファイルを読み込んでいる" },
     { id: "claude.glob", priority: 95, re: /^[⏺•]\s*Glob\(/, type: "search", summary: "ファイル一覧を検索している" },
     { id: "claude.grep", priority: 92, re: /^[⏺•]\s*Grep\(/, type: "search", summary: "該当箇所を検索している" },

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractEvents } from "../extract.js";
+
+const fixtureDir = path.resolve(process.cwd(), "test/fixtures/claude-tui");
+
+function loadChunks(name: string): string {
+  const fixture = JSON.parse(fs.readFileSync(path.join(fixtureDir, name), "utf8")) as {
+    chunks: string[];
+  };
+  return fixture.chunks.join("");
+}
+
+describe("Claude TUI supervision detection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-12T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(["trust-prompt.json", "tool-approval.json"])("detects permission wait from %s", (name) => {
+    expect(extractEvents(loadChunks(name), "claude")).toEqual([
+      expect.objectContaining({ type: "stdout", summary: "許可を待っている" }),
+    ]);
+  });
+
+  it("detects a multiple-choice question", () => {
+    expect(extractEvents(loadChunks("question.json"), "claude")).toEqual([
+      expect.objectContaining({ type: "stdout", summary: "質問への回答を待っている" }),
+    ]);
+  });
+
+  it("detects error and completion from the same redraw", () => {
+    expect(extractEvents(loadChunks("error-completion.json"), "claude")).toEqual([
+      expect.objectContaining({ type: "error", summary: "エラーが発生している" }),
+      expect.objectContaining({ type: "done", summary: "作業が完了した" }),
+    ]);
+  });
+
+  it.each([
+    "The documentation explains when approval is required.",
+    "The task is complete only after a reviewer approves it.",
+    "Choose a color in the settings page.",
+    "The previous command exited successfully with code 0.",
+  ])("does not promote normal prose: %s", (chunk) => {
+    const events = extractEvents(chunk, "claude");
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ summary: expect.stringMatching(/許可を待っている|質問への回答を待っている|エラーが発生している|作業が完了した/) }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

#305で採取した実Claude Code TUI fixtureを使い、#306の監督イベント4分類を検知します。

- ANSI制御シーケンスとTUI再描画由来の空白を正規化
- workspace信頼確認・Bash実行許可を「許可待ち」として検知
- 選択式プロンプトを「質問」として検知
- exit code / command not foundを「エラー」として検知
- 明示的な完了文を「作業完了」として検知
- 通常の説明文を緊急イベントへ昇格しない誤検知ガードを追加

## Scope

優先度とWSプロトコルは#308で追加するため、本PRでは既存EventTypeを維持します。

- 許可待ち / 質問: `stdout`
- エラー: `error`
- 完了: `done`

エラー膠着（同じ失敗の繰り返し判定）とCodex rulesetへの横展開は対象外です。

## Validation

- `pnpm -C apps/server test -- --run`: 346 tests passed
- `pnpm -C apps/server build`: PASS
- `git diff --check`: clean

HUMAN実機テストは本PRの必須条件ではありません。実fixtureによる自動テストで固定し、TTS/UIを含む実機受け入れは#309で行います。

Refs #304
Closes #306