### PR TITLE
feat: detect prolonged CLI silence

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -31,3 +31,4 @@ LOG_SOURCE=auto
 # Timeout settings (ms)
 # COMMENT_TIMEOUT_MS=3000        # Timeout for individual comment() calls
 # COMMENT_EXIT_TIMEOUT_MS=1500   # Hard timeout for exit event cleanup
+# SILENCE_TIMEOUT_MS=60000       # Emit one silence event after this period without PTY/file output

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -43,9 +43,11 @@ import {
 } from "./runtime/state-event.js";
 import { isStyle, normalizeSource } from "./shared/validation.js";
 import { createPtyCapture } from "./pty/capture.js";
+import { createSilenceTimer, parseSilenceTimeoutMs } from "./silence-timer.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
+const SILENCE_TIMEOUT_MS = parseSilenceTimeoutMs(process.env.SILENCE_TIMEOUT_MS);
 
 const INPUT_MODE_RAW = process.env.INPUT_MODE; // For debugging
 
@@ -308,6 +310,7 @@ async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
   });
 
   try {
+    silenceTimer.stop();
     ptyManager.kill();
     stopFileTail(true);
     disableStdinPassthrough();
@@ -368,6 +371,8 @@ async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
  * This is the common data processing pipeline.
  */
 function processInputData(data: string, writeToStdout: boolean = true): void {
+  silenceTimer.activity();
+
   // Write raw data to local terminal (only for PTY mode or when requested)
   if (writeToStdout) {
     process.stdout.write(data);
@@ -386,17 +391,33 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
   broadcast({ kind: "raw", data: clean });
 
   for (const ev of evs) {
-    broadcast({ kind: "event", ev });
-    if (ev.type === "error" || shouldEmitNow()) {
-      // comment() is async - fire and forget, errors are handled inside
-      void comment(ev, currentStyle, currentCommentaryProviders)
-        .then((payload) => {
-          broadcastCommentary(ev.ts, ev, payload);
-        })
-        .catch(() => {});
-    }
+    emitEvent(ev);
   }
 }
+
+function emitEvent(ev: Event): void {
+  broadcast({ kind: "event", ev });
+  if (ev.type === "error" || shouldEmitNow()) {
+    // comment() is async - fire and forget, errors are handled inside
+    void comment(ev, currentStyle, currentCommentaryProviders)
+      .then((payload) => {
+        broadcastCommentary(ev.ts, ev, payload);
+      })
+      .catch(() => {});
+  }
+}
+
+const silenceTimer = createSilenceTimer({
+  thresholdMs: SILENCE_TIMEOUT_MS,
+  onSilence: () => {
+    emitEvent({
+      ts: Date.now(),
+      type: "stdout",
+      summary: "長考・沈黙が続いている",
+      detail: `${SILENCE_TIMEOUT_MS}ms outputなし`,
+    });
+  },
+});
 
 function broadcast(msg: WsOutgoing) {
   const data = JSON.stringify(msg);
@@ -421,6 +442,7 @@ function broadcastSource(nextDetected: SourceState["detected"]) {
  */
 function setupPTY(config: PTYConfig, profileId: string | null): void {
   const term = ptyManager.spawn(config);
+  silenceTimer.start();
   transitionServerState("setup_pty_success", "pty_running", {
     inputMode: "pty",
     profileId,
@@ -450,6 +472,8 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
     if (ptyManager.current !== term) {
       return;
     }
+    silenceTimer.stop();
+
     // If we're restarting, don't broadcast done or trigger cleanup
     if (restartInFlight || queuedProfileId !== undefined) {
       return;
@@ -579,6 +603,7 @@ async function restartPTY(profileId: string | null, force = false): Promise<void
     }
 
     // Kill existing PTY / file tail fallback
+    silenceTimer.stop();
     ptyManager.kill();
     stopFileTail(true);
     disableStdinPassthrough();
@@ -874,6 +899,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
 
   // Handle exit
   tail.on("exit", (code) => {
+    silenceTimer.stop();
     if (fileTail === tail) {
       fileTail = null;
     }
@@ -902,6 +928,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
   // Start tailing
   try {
     tail.start();
+    silenceTimer.start();
     transitionServerState("file_tail_started", "file_running", {
       inputMode: "file",
       detail: filePath,
@@ -1143,6 +1170,7 @@ function cleanup(exitCode: number = 0): void {
   disableStdinPassthrough();
 
   // 2. PTY kill / FileTail stop
+  silenceTimer.stop();
   ptyManager.kill();
   stopFileTail(true);
   ptyCapture?.close();

--- a/apps/server/src/silence-timer.test.ts
+++ b/apps/server/src/silence-timer.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SILENCE_TIMEOUT_MS,
+  createSilenceTimer,
+  parseSilenceTimeoutMs,
+} from "./silence-timer.js";
+
+describe("silence timer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses a positive env threshold and falls back for invalid values", () => {
+    expect(parseSilenceTimeoutMs("2500")).toBe(2500);
+    expect(parseSilenceTimeoutMs("0")).toBe(DEFAULT_SILENCE_TIMEOUT_MS);
+    expect(parseSilenceTimeoutMs("invalid")).toBe(DEFAULT_SILENCE_TIMEOUT_MS);
+  });
+
+  it("fires after the configured interval without output", () => {
+    const onSilence = vi.fn();
+    const timer = createSilenceTimer({ thresholdMs: 1000, onSilence });
+
+    timer.start();
+    vi.advanceTimersByTime(999);
+    expect(onSilence).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onSilence).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the interval when output resumes", () => {
+    const onSilence = vi.fn();
+    const timer = createSilenceTimer({ thresholdMs: 1000, onSilence });
+
+    timer.start();
+    vi.advanceTimersByTime(800);
+    timer.activity();
+    vi.advanceTimersByTime(800);
+    expect(onSilence).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(200);
+    expect(onSilence).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not repeat until new output activity and stops with the input source", () => {
+    const onSilence = vi.fn();
+    const timer = createSilenceTimer({ thresholdMs: 1000, onSilence });
+
+    timer.start();
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(5000);
+    expect(onSilence).toHaveBeenCalledTimes(1);
+
+    timer.activity();
+    vi.advanceTimersByTime(1000);
+    expect(onSilence).toHaveBeenCalledTimes(2);
+
+    timer.activity();
+    timer.stop();
+    vi.advanceTimersByTime(1000);
+    expect(onSilence).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/silence-timer.ts
+++ b/apps/server/src/silence-timer.ts
@@ -1,0 +1,56 @@
+export const DEFAULT_SILENCE_TIMEOUT_MS = 60_000;
+
+export function parseSilenceTimeoutMs(
+  value: string | undefined,
+  fallback = DEFAULT_SILENCE_TIMEOUT_MS
+): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export interface SilenceTimer {
+  start(): void;
+  activity(): void;
+  stop(): void;
+}
+
+export function createSilenceTimer(options: {
+  thresholdMs: number;
+  onSilence: () => void;
+}): SilenceTimer {
+  let active = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clear = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = () => {
+    clear();
+    if (!active) return;
+
+    timer = setTimeout(() => {
+      timer = null;
+      if (!active) return;
+      options.onSilence();
+    }, options.thresholdMs);
+  };
+
+  return {
+    start() {
+      active = true;
+      schedule();
+    },
+    activity() {
+      if (!active) return;
+      schedule();
+    },
+    stop() {
+      active = false;
+      clear();
+    },
+  };
+}

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -151,15 +151,15 @@ CLI Commentator は、非エンジニアで英語に不慣れな人が、CLI上�
 - PR #259：Desktop sidecar prepare を冪等化し、`dev:desktop:managed` 起動前に同梱sidecarを安全に確認・再生成できるようにした
 
 **Now**
-- Issue #300 で長期改良方針を正本化。最優先は「監督イベント検知」とし、Phase A-0 のドッグフーディング観察から開始する
-- Phase A-0 では1週間の実作業セッションを通じて「監督に必要だったのに拾えなかった瞬間」を記録し、5分類の検知仕様へつなげる
+- Issue #300 で長期改良方針を正本化。HUMAN判断で Phase A-0 の観察をスキップし、Issue #304 の Phase A-1（監督イベント5分類）を進行中
+- #305 fixture採取は PR #310、#306 Claude TUI監督イベント4分類は PR #311 で完了
+- #307 長考・沈黙検知は Draft PR #316 で、無出力タイマー・環境変数・テストを実装しCI確認中
 - Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
-- local desktop app polish / local readiness は、Phase A-0 の観察を開始できる起動導線として維持する
-- main は PR #259 反映後の状態で最新化済み。GitHub CI は `test` / `test_windows` / `desktop_check` / `desktop_distribution_smoke` / CodeQL が green
+- local desktop app polish / local readiness は、監督イベントの実機確認へ入るための起動導線として維持する
 
 **Next**
-- Phase A-0 の観察項目、記録形式、完了条件をIssueへ分解する
-- 観察結果から許可待ち、質問、エラー、完了、長考・沈黙の検知仕様と優先度付きTTSを設計する（Phase A-1）
+- PR #316 をHUMAN判断でmerge後、#308 優先度付きイベントパイプラインとWSプロトコル拡張へ進む
+- #309 で優先度付きTTSとWeb UI要対応表示を追加し、実機でPhase A-1の受け入れ確認を行う
 - 日本語解説・要約と、真面目トーン／実況トーンを分けた提示層を改善する（Phase B）
 
 **Later**

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -171,6 +171,7 @@ Main keys:
 - `INPUT_FILE` (required for `INPUT_MODE=file`)
 - `TARGET_CMD`, `TARGET_ARGS`, `TARGET_ARGS_JSON`, `TARGET_CWD`
 - `LOG_SOURCE` (`auto|claude|codex|generic`)
+- `SILENCE_TIMEOUT_MS` (milliseconds without PTY/file output before emitting a silence event; default: `60000`)
 
 Web dev key (must match server port, mainly for web mode):
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -172,6 +172,7 @@ codex --no-alt-screen -C /Users/home/AION_Project/repos/n8n-workflows -c log_dir
 - `INPUT_FILE`（`INPUT_MODE=file` で必須）
 - `TARGET_CMD`, `TARGET_ARGS`, `TARGET_ARGS_JSON`, `TARGET_CWD`
 - `LOG_SOURCE`（`auto|claude|codex|generic`）
+- `SILENCE_TIMEOUT_MS`（無出力を長考・沈黙として通知するまでの時間。ミリ秒、既定: `60000`）
 
 Web 側（server port と合わせる、主にWebモードで利用）:
 


### PR DESCRIPTION
## Summary

- add a configurable inactivity timer for PTY and file-tail input
- emit one `長考・沈黙が続いている` event after 60 seconds without output
- reset the timer when output resumes and stop it during exit, restart, or cleanup
- document `SILENCE_TIMEOUT_MS` in the server env example and bilingual getting-started guides
- add timer unit tests for threshold, reset, single-fire, and stop behavior

## Design notes

- The event currently uses the existing `stdout` event type so this PR does not pre-empt the priority/protocol work in #308.
- A separate recovery notification is intentionally deferred. New output simply rearms the timer, avoiding extra notifications before the priority pipeline is available.

## Validation

The branch was created through the GitHub connector in a cloud workspace without a local checkout or `gh`, so local commands were not run before push.

GitHub Actions completed successfully on commit `a5935b0`:

- server tests and TypeScript build
- Windows test/build/lint
- desktop cargo check/test
- desktop distribution build and runtime smoke
- documentation drift guard
- failure regression and actionlint
- CodeQL

## Documentation drift guard

[skip-doc-sync-check] `apps/server/.env.example` changed only to document the server-side silence timer. No LLM adapter, provider, prompt, or commentary behavior changed. The new key is documented in both Getting Started languages.

## Notes for Next Agent

1. HUMAN reviews this draft and decides whether to merge.
2. After merge, continue with #308; do not add priority fields or Web UI/TTS behavior to this PR.
3. Stop before merge; HUMAN makes the final decision.

Closes #307
Refs #304
