### PR TITLE
feat: add priority-aware event pipeline

### DIFF
--- a/apps/server/src/event-priority.test.ts
+++ b/apps/server/src/event-priority.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createCommentaryGate, getEventPriority, withEventPriority } from "./event-priority.js";
+
+describe("event priority", () => {
+  it("classifies supervision events", () => {
+    expect(getEventPriority({ ts: 1, type: "stdout", summary: "許可を待っている" })).toBe("urgent");
+    expect(getEventPriority({ ts: 1, type: "stdout", summary: "質問への回答を待っている" })).toBe("urgent");
+    expect(getEventPriority({ ts: 1, type: "error", summary: "失敗" })).toBe("urgent");
+    expect(getEventPriority({ ts: 1, type: "done", summary: "完了" })).toBe("notice");
+    expect(getEventPriority({ ts: 1, type: "stdout", summary: "長考・沈黙が続いている" })).toBe("notice");
+    expect(getEventPriority({ ts: 1, type: "read", summary: "読取" })).toBe("progress");
+  });
+
+  it("preserves an explicit priority", () => {
+    expect(
+      withEventPriority({ ts: 1, type: "stdout", summary: "custom", priority: "notice" })
+    ).toMatchObject({ priority: "notice" });
+  });
+
+  it("throttles only progress commentary", () => {
+    let current = 0;
+    const gate = createCommentaryGate({ intervalMs: 2000, now: () => current });
+
+    expect(gate.shouldEmit("progress")).toBe(true);
+    current = 1000;
+    expect(gate.shouldEmit("progress")).toBe(false);
+    expect(gate.shouldEmit("urgent")).toBe(true);
+    expect(gate.shouldEmit("notice")).toBe(true);
+    current = 1999;
+    expect(gate.shouldEmit("progress")).toBe(false);
+    current = 2000;
+    expect(gate.shouldEmit("progress")).toBe(true);
+  });
+});

--- a/apps/server/src/event-priority.ts
+++ b/apps/server/src/event-priority.ts
@@ -1,0 +1,45 @@
+import type { Event, EventPriority } from "./types.js";
+
+const URGENT_SUMMARIES = new Set([
+  "許可を待っている",
+  "質問への回答を待っている",
+  "エラーが発生している",
+]);
+
+export function getEventPriority(event: Event): EventPriority {
+  if (event.priority) return event.priority;
+  if (event.type === "error" || URGENT_SUMMARIES.has(event.summary)) return "urgent";
+  if (event.type === "done" || event.summary === "長考・沈黙が続いている") return "notice";
+  return "progress";
+}
+
+export function withEventPriority(event: Event): Event & { priority: EventPriority } {
+  return {
+    ...event,
+    priority: getEventPriority(event),
+  };
+}
+
+export interface CommentaryGate {
+  shouldEmit(priority: EventPriority): boolean;
+}
+
+export function createCommentaryGate(options?: {
+  intervalMs?: number;
+  now?: () => number;
+}): CommentaryGate {
+  const intervalMs = options?.intervalMs ?? 2000;
+  const now = options?.now ?? Date.now;
+  let lastProgressEmit = Number.NEGATIVE_INFINITY;
+
+  return {
+    shouldEmit(priority) {
+      if (priority !== "progress") return true;
+
+      const current = now();
+      if (current - lastProgressEmit < intervalMs) return false;
+      lastProgressEmit = current;
+      return true;
+    },
+  };
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -44,6 +44,7 @@ import {
 import { isStyle, normalizeSource } from "./shared/validation.js";
 import { createPtyCapture } from "./pty/capture.js";
 import { createSilenceTimer, parseSilenceTimeoutMs } from "./silence-timer.js";
+import { createCommentaryGate, withEventPriority } from "./event-priority.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -91,16 +92,8 @@ function markPtyUnavailable(error: string): void {
   ptyInitError = error;
 }
 
-// rate limit: max once per 2s (error is always allowed)
-let lastEmit = 0;
-function shouldEmitNow(): boolean {
-  const now = Date.now();
-  if (now - lastEmit >= 2000) {
-    lastEmit = now;
-    return true;
-  }
-  return false;
-}
+// Progress commentary remains rate-limited; urgent and notice events bypass the gate.
+const commentaryGate = createCommentaryGate({ intervalMs: 2000 });
 
 // --- HTTP + WS ---
 const server = http.createServer((req, res) => {
@@ -396,12 +389,13 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
 }
 
 function emitEvent(ev: Event): void {
-  broadcast({ kind: "event", ev });
-  if (ev.type === "error" || shouldEmitNow()) {
-    // comment() is async - fire and forget, errors are handled inside
-    void comment(ev, currentStyle, currentCommentaryProviders)
+  const prioritizedEvent = withEventPriority(ev);
+  // The rule-based event reaches clients immediately; LLM commentary follows asynchronously.
+  broadcast({ kind: "event", ev: prioritizedEvent });
+  if (commentaryGate.shouldEmit(prioritizedEvent.priority)) {
+    void comment(prioritizedEvent, currentStyle, currentCommentaryProviders)
       .then((payload) => {
-        broadcastCommentary(ev.ts, ev, payload);
+        broadcastCommentary(prioritizedEvent.ts, prioritizedEvent, payload);
       })
       .catch(() => {});
   }
@@ -479,7 +473,7 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
       return;
     }
 
-    const ev: Event = { ts: Date.now(), type: "done", summary: `終了 code=${exitCode}` };
+    const ev = withEventPriority({ ts: Date.now(), type: "done", summary: `終了 code=${exitCode}` });
     broadcast({ kind: "event", ev });
 
     // 安全タイマー付き二重化（comment()がsettleしなくてもcleanup確実実行）
@@ -506,12 +500,12 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
   });
 
   // Broadcast start event (ptyRestart is sent separately in restartPTY for correct ordering)
-  const startEvent: Event = {
+  const startEvent = withEventPriority({
     ts: Date.now(),
     type: "start",
     summary: "開始",
     detail: `${config.cmd} ${config.args.join(" ")}`,
-  };
+  });
   broadcast({ kind: "event", ev: startEvent });
 
   // Send commentary for start event
@@ -893,7 +887,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
   // Handle errors
   tail.on("error", (err) => {
     console.error("File tail error:", err.message);
-    const ev: Event = { ts: Date.now(), type: "error", summary: "ファイル監視エラー", detail: err.message };
+    const ev = withEventPriority({ ts: Date.now(), type: "error", summary: "ファイル監視エラー", detail: err.message });
     broadcast({ kind: "event", ev });
   });
 
@@ -912,7 +906,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
     }
 
     console.log(`File tail exited with code: ${code}`);
-    const ev: Event = { ts: Date.now(), type: "done", summary: `ファイル監視終了 code=${code}` };
+    const ev = withEventPriority({ ts: Date.now(), type: "done", summary: `ファイル監視終了 code=${code}` });
     broadcast({ kind: "event", ev });
 
     void comment(ev, currentStyle, currentCommentaryProviders)
@@ -938,12 +932,12 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
     });
 
     // Broadcast start event
-    const startEvent: Event = {
+    const startEvent = withEventPriority({
       ts: Date.now(),
       type: "start",
       summary: "ファイル監視開始",
       detail: `tail -f ${filePath}`,
-    };
+    });
     broadcast({ kind: "event", ev: startEvent });
 
     void comment(startEvent, currentStyle, currentCommentaryProviders)

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -5,6 +5,7 @@ export type {
   CreateProfileInput,
   DetectedSource,
   Event,
+  EventPriority,
   EventType,
   InputMode,
   LaunchSessionInput,

--- a/apps/web/src/hooks/useCommentatorSocket.ts
+++ b/apps/web/src/hooks/useCommentatorSocket.ts
@@ -153,6 +153,7 @@ export function useCommentatorSocket({
                 explanation: parts.explanationText ?? undefined,
                 glossaryNotes: parts.glossaryNotes,
                 eventType: message.ev.type,
+                priority: message.ev.priority ?? "progress",
                 summary: message.ev.summary,
                 detail: message.ev.detail,
               };

--- a/apps/web/src/lib/log-filter.ts
+++ b/apps/web/src/lib/log-filter.ts
@@ -1,4 +1,4 @@
-import type { EventType } from "../types";
+import type { EventPriority, EventType } from "../types";
 import { buildCombinedCommentaryText } from "./glossary-note";
 
 export type LogEventTypeFilter = "all" | EventType;
@@ -9,6 +9,7 @@ export type CommentaryItem = {
   explanation?: string;
   glossaryNotes?: string[];
   eventType: EventType;
+  priority?: EventPriority;
   summary?: string;
   detail?: string;
 };

--- a/apps/web/src/lib/server-message.test.ts
+++ b/apps/web/src/lib/server-message.test.ts
@@ -11,6 +11,7 @@ describe("parseServerMessage", () => {
         type: "stdout",
         summary: "ログ更新",
         detail: "done",
+        priority: "urgent",
       },
       narration: "処理中です。",
       glossaryNotes: ["補足"],
@@ -20,7 +21,29 @@ describe("parseServerMessage", () => {
       kind: "commentary",
       ts: 123,
       narration: "処理中です。",
-      ev: { type: "stdout", summary: "ログ更新" },
+      ev: { type: "stdout", summary: "ログ更新", priority: "urgent" },
+    });
+  });
+
+  it("accepts priority on event messages and legacy events without it", () => {
+    expect(
+      parseServerMessage({
+        kind: "event",
+        ev: { ts: 456, type: "done", summary: "完了", priority: "notice" },
+      })
+    ).toMatchObject({
+      kind: "event",
+      ev: { priority: "notice" },
+    });
+
+    expect(
+      parseServerMessage({
+        kind: "event",
+        ev: { ts: 789, type: "stdout", summary: "legacy" },
+      })
+    ).toMatchObject({
+      kind: "event",
+      ev: { summary: "legacy" },
     });
   });
 
@@ -43,6 +66,12 @@ describe("parseServerMessage", () => {
   it("rejects malformed messages", () => {
     expect(parseServerMessage({ kind: "style", style: "unknown" })).toBeNull();
     expect(parseServerMessage({ kind: "commentary", ts: 123 })).toBeNull();
+    expect(
+      parseServerMessage({
+        kind: "event",
+        ev: { ts: 123, type: "stdout", summary: "bad", priority: "immediate" },
+      })
+    ).toBeNull();
     expect(parseServerMessage("not an object")).toBeNull();
   });
 });

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -4,6 +4,7 @@ export type {
   CreateProfileInput,
   DetectedSource,
   Event,
+  EventPriority,
   EventType,
   InputMode,
   LaunchSessionInput,

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -153,13 +153,13 @@ CLI Commentator は、非エンジニアで英語に不慣れな人が、CLI上�
 **Now**
 - Issue #300 で長期改良方針を正本化。HUMAN判断で Phase A-0 の観察をスキップし、Issue #304 の Phase A-1（監督イベント5分類）を進行中
 - #305 fixture採取は PR #310、#306 Claude TUI監督イベント4分類は PR #311 で完了
-- #307 長考・沈黙検知は Draft PR #316 で、無出力タイマー・環境変数・テストを実装しCI確認中
+- #307 長考・沈黙検知は PR #316 で完了。#308 優先度付きイベントパイプラインは Draft PR #317 で実装しCI確認中
 - Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
 - local desktop app polish / local readiness は、監督イベントの実機確認へ入るための起動導線として維持する
 
 **Next**
-- PR #316 をHUMAN判断でmerge後、#308 優先度付きイベントパイプラインとWSプロトコル拡張へ進む
-- #309 で優先度付きTTSとWeb UI要対応表示を追加し、実機でPhase A-1の受け入れ確認を行う
+- PR #317 をHUMAN判断でmerge後、#309 優先度付きTTSとWeb UI要対応表示へ進む
+- #309 で実機受け入れ確認を行い、Phase A-1を完了する
 - 日本語解説・要約と、真面目トーン／実況トーンを分けた提示層を改善する（Phase B）
 
 **Later**

--- a/packages/shared/src/parse-server-message.ts
+++ b/packages/shared/src/parse-server-message.ts
@@ -1,6 +1,7 @@
 import type {
   CommentaryMeta,
   Event,
+  EventPriority,
   EventType,
   Profile,
   ProfileSummary,
@@ -28,6 +29,8 @@ const EVENT_TYPES = new Set<EventType>([
   "error",
   "done",
 ]);
+
+const EVENT_PRIORITIES = new Set<EventPriority>(["urgent", "notice", "progress"]);
 
 const PROVIDERS = new Set<ProviderName>([
   "disabled",
@@ -66,6 +69,9 @@ export const isSourceMode = (value: unknown): value is SourceMode =>
 export const isEventType = (value: unknown): value is EventType =>
   typeof value === "string" && EVENT_TYPES.has(value as EventType);
 
+export const isEventPriority = (value: unknown): value is EventPriority =>
+  typeof value === "string" && EVENT_PRIORITIES.has(value as EventPriority);
+
 export const isSourceState = (value: unknown): value is SourceState =>
   isRecord(value) &&
   isSourceMode(value.mode) &&
@@ -79,7 +85,8 @@ export const isEvent = (value: unknown): value is Event =>
   typeof value.ts === "number" &&
   isEventType(value.type) &&
   typeof value.summary === "string" &&
-  isOptionalString(value.detail);
+  isOptionalString(value.detail) &&
+  (value.priority === undefined || isEventPriority(value.priority));
 
 const isCommentaryMeta = (value: unknown): value is CommentaryMeta =>
   isRecord(value) &&

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -21,11 +21,14 @@ export type EventType =
   | "error"
   | "done";
 
+export type EventPriority = "urgent" | "notice" | "progress";
+
 export type Event = {
   ts: number;
   type: EventType;
   summary: string;
   detail?: string;
+  priority?: EventPriority;
 };
 
 export type CommentaryMode = "narration" | "explanation" | "both";


### PR DESCRIPTION
## Summary

- add shared `EventPriority` values: `urgent`, `notice`, and `progress`
- validate optional priority fields while preserving legacy messages without priority
- classify permission waits, questions, and errors as urgent
- classify completion and prolonged silence as notice
- keep normal progress commentary on the existing 2-second gate
- broadcast the rule-based event immediately, then generate commentary asynchronously
- retain priority in the Web commentary item model without adding UI/TTS behavior yet
- add priority classification, gate, and protocol parser tests

## Compatibility

- `Event.priority` is optional in the shared protocol so older stored/test messages remain valid.
- The server adds priority to newly emitted event and commentary messages.
- Existing error immediacy is preserved; urgent and notice events bypass progress throttling.

## Scope boundary

Web UI attention styling and interrupting TTS are intentionally deferred to #309.

## Validation

The branch was created through the GitHub connector without a local checkout, so checks were run by GitHub Actions on commit `2d9e0fa`.

All checks passed:

- server tests and TypeScript build
- web tests, build, and lint
- Windows test/build/lint
- desktop cargo check/test
- desktop distribution build and runtime smoke
- documentation drift guard
- failure regression and actionlint
- CodeQL

## Notes for Next Agent

1. HUMAN reviews this draft and decides whether to merge.
2. After merge, continue with #309.
3. Do not add UI attention styling or TTS interruption to this PR.
4. Stop before merge; HUMAN decides.

Closes #308
Refs #304
