### PR TITLE
docs: handoff status-2026-07-19 (Gino→KURO takeover)

### DIFF
--- a/handoff/status-2026-07-19.md
+++ b/handoff/status-2026-07-19.md
@@ -1,0 +1,144 @@
+# handoff 2026-07-19 — cli-commentator / Phase A-1 継続を KURO へ移管
+
+## 1. HUMAN判断待ち（最初に読む）
+
+- **判断事項**：Draft PR #317 をマージして Issue #309 へ進むか
+  - 推奨：PR #317 の差分を KURO が最終レビューし、問題がなければ HUMAN 権限境界に従ってマージして #309 へ進む
+  - 選択肢：A. #317をマージして#309へ進む / B. #317へ修正を加える / C. 保留する
+  - 期限・緊急度：本日の Phase A-1 作業を継続する前。緊急度は高
+  - 判断しない場合の影響：#309 が依存する `urgent / notice / progress` のプロトコルと優先度パイプラインが main に入らず、TTS/UI実装へ安全に進めない
+
+> 2026-07-19 の HUMAN 指示：当初は「本日のプランを完遂。細かな判断は事前承認」と指示された。その後、実装主体を KURO（Claude Code）へ変更し、調査情報と指示の引き継ぎを求められた。Gino は #317 をマージしていない。merge は aion-ops の権限境界に従って扱うこと。
+
+## 2. 現在地
+
+- 作業状態：Gino の調査と計画作成まで完了。実装・マージ・GitHub書き込みは未実施
+- 最新PR：Draft PR #317 `feat: add priority-aware event pipeline`
+  - <https://github.com/gatyoukatyou/cli-commentator/pull/317>
+- ctx状態：`ctx/review` 相当（#317がHUMAN判断待ち）
+- ローカルブランチ：`handoff/status-2026-07-19`（最新 `origin/main` = `210f1d3` 基点）
+- 作業ツリー：このhandoffファイル以外に変更なし
+- 直前まで使われていた `feat/claude-supervision-detection` は PR #311 として squash merge済み。継続作業には使わない
+
+## 3. HUMANから受けた指示
+
+1. アプリの開発状況を確認し、本日の作業計画を作る
+2. 当初の実行指示：Fableをオーケストレータ、Opusをサブエージェントとして本日の計画を完遂し、細かな判断は事前承認とする
+3. 実行環境では Fable / Opus のモデル固定はできない旨を説明し、3つのサブエージェントへ読取専用監査を分担した
+4. HUMANの最新指示により作業を止め、KURO（Claude Code）へ移管する
+5. 進行中だったサブエージェント3体は停止済み。成果を確定情報として採用していない
+
+## 4. 確認済みの開発状況
+
+### Phase A-1
+
+- #305 PTY fixture採取：PR #310で完了
+- #306 許可待ち・質問・エラー・完了検知：PR #311で完了
+- #307 長考・沈黙検知：PR #316で完了、main commit `04ce38d`
+- #308 優先度付きイベントパイプライン：Draft PR #317で実装・CI完了、未マージ
+- #309 TTS割り込み読み上げ + Web UI要対応表示：未着手
+- 親Issue：#304
+  - <https://github.com/gatyoukatyou/cli-commentator/issues/304>
+- 次Issue：#309
+  - <https://github.com/gatyoukatyou/cli-commentator/issues/309>
+
+### リポジトリと検証
+
+- 調査時の最新 `origin/main`：`210f1d3`
+- mainへ入った依存更新 PR #318 / #319 は全CI・CodeQL成功
+- `feat/claude-supervision-detection` 上で以下を実行し成功
+  - `pnpm -C apps/server test`：34 suites / 346 tests PASS
+  - `pnpm -C apps/server build`：PASS
+- テスト後も作業ツリーはクリーンだった
+- `git diff --check origin/main...origin/feat/priority-event-pipeline`：問題なし
+- `git merge-tree` による最新mainとの確認：競合マーカーなし
+
+### PR #317 の状態
+
+- Draft / OPEN / GitHub表示 `mergeStateStatus: CLEAN`
+- head：`2d9e0fa`
+- PR作成時base：`04ce38d`
+- CI：test / test_windows / desktop_check / desktop_distribution_smoke / docs_drift_guard / failure_regression / actionlint / CodeQL がすべて成功
+- 主な内容
+  - shared protocolに `EventPriority = urgent | notice | progress`
+  - priorityはoptionalとして旧メッセージとの後方互換を維持
+  - 許可待ち・質問・エラーをurgent、完了・沈黙をnotice、通常実況をprogressに分類
+  - progressのみ既存2秒ゲートを適用
+  - ルールベースeventを即時broadcastし、LLM commentaryは非同期配信
+  - Webのcommentary itemへpriorityを保持
+  - UI/TTS挙動は意図的に#309へ分離
+- Ginoの独立差分確認では、マージを止める明白なブロッカーは発見していない。ただしKUROによる最終レビューは必要
+
+## 5. Issue #309 実装前に判明した重要点
+
+1. **現在のTTSは全発話が割り込み式**
+   - `apps/web/src/lib/tts.ts` の `speak()` は毎回 `speechSynthesis.cancel()` を呼ぶ
+   - 要件は urgent のみ割り込み、notice は現在の発話を止めずキュー末尾、progress は従来の間引き/まとめ読み
+   - 単なるpriority分岐では足りず、cancelする発話とqueueする発話を分離する必要がある
+
+2. **Webは即時eventを現在無視している**
+   - `apps/web/src/hooks/useCommentatorSocket.ts` の `case "event": break;`
+   - PR #317はルールベースeventをLLM commentaryより先に送る設計
+   - 「すぐ気づける」要対応UIは `kind: "event"` を直接処理するのが自然
+
+3. **二重通知を防ぐ必要がある**
+   - 同一eventについて即時eventと後続commentaryが届く
+   - 即時eventで定型TTSし、commentaryでも読むと二重読み上げになる
+   - `ev.ts` 等による相関・既読記録、またはUIだけ即時event/TTSはcommentaryなど、明示的な方針を決めてテストする
+
+4. **スキンの受け入れ条件が実装と不一致**
+   - Issue #309は standard / brutalism / paper の3スキン確認を要求
+   - 現行 `AppHeader.tsx` / `App.tsx` で利用可能なのは standard / cli の2スキン
+   - 推奨：#309では現行2スキンで検証し、廃止済みスキンの復活を混ぜない。Issue/ROADMAPの文言を実態へ同期する
+
+5. **エラー膠着の完全性**
+   - 明示的なエラー文字列検知は実装済み
+   - 「同じ失敗を繰り返している」の反復検知は確認できていない
+   - #309を膨らませず、Phase A-1受け入れ時に不足ならフォローアップIssueへ切り出すのが妥当
+
+## 6. KUROの次の一手
+
+1. aion-opsの開始時ルールを再確認する
+2. `git fetch origin --prune` で最新main・並行PRを再確認する
+3. PR #317を最終レビューし、HUMAN権限境界に従ってmerge可否を確定する
+4. #317 merge後、最新mainから #309 専用ブランチを作る
+5. #309を次の順で実装する
+   - `kind: "event"` の即時要対応状態
+   - urgent割り込み / noticeキュー / progress従来動作のTTS制御
+   - event/commentaryの二重通知防止
+   - 優先度バッジ/ハイライト（design token使用）
+   - standard / cli の2スキンとアクセシビリティ確認
+6. 自動検証
+   - TTS queue/cancel順序の単体テスト
+   - WebSocket event処理テスト
+   - 二重通知防止テスト
+   - web test / lint / build
+   - server/shared回帰
+   - doc sync
+7. 実機で5分類を疑似発生させ、urgentのみ割り込むことを確認する
+8. ROADMAP、#304、#309を更新し、Draft PRを作成してHUMAN reviewで止める
+
+## 7. 重要なリスク・運用メモ
+
+- GitHub CLI `gh auth status` は保存済みアカウントのtokenをinvalidと表示した一方、`gh pr view` / `gh pr checks` / `gh issue view` は実行できた。KUROの実行環境でwrite権限を改めて確認すること
+- Apple署名 #138、tauri-action更新 #278 / 親 #292 は長期方針どおりDeferred。今日のPhase A-1作業へ混ぜない
+- mainへ直接pushしない。mergeはHUMAN権限境界に従う
+- このhandoff作成時点で #317のmerge、Issueコメント、Todoist更新、commit、push、PR作成は行っていない
+
+## 8. KURO引き継ぎ追記（2026-07-19 同日）
+
+- KURO（Claude Code ローカル）が本handoffを受領し、記載内容を再検証した。進捗・PR状態・ローカルブランチ状態はすべて記載どおりだった
+- PR #317 をKUROが最終レビュー。urgent分類のsummary文字列が `claude.ts` / `claude-supervision.ts` / 沈黙タイマーの実際の出力と完全一致することを現物確認。ブロッカーなし
+- 最新main（`210f1d3`）+ #317 の合流ツリーをworktreeで検証：server 353 tests / web 58 tests / tsc build / vite build / eslint すべてPASS
+- HUMAN明示承認を得て #317 をsquash merge（main `f52b234`）
+- §7のGitHub CLI懸念：KURO環境では `gh auth status` 正常・write可
+- 次アクション：#309（TTS割り込み + 要対応UI）を最新mainから実装し、Draft PRでctx/review停止する
+
+## 9. 参照リンク
+
+- PR #317: <https://github.com/gatyoukatyou/cli-commentator/pull/317>
+- Phase A-1親 #304: <https://github.com/gatyoukatyou/cli-commentator/issues/304>
+- 次タスク #309: <https://github.com/gatyoukatyou/cli-commentator/issues/309>
+- 長期方針 #300: <https://github.com/gatyoukatyou/cli-commentator/issues/300>
+- Deferred依存整理 #292: <https://github.com/gatyoukatyou/cli-commentator/issues/292>
+- Apple署名 #138: <https://github.com/gatyoukatyou/cli-commentator/issues/138>


### PR DESCRIPTION
## 概要
Phase A-1 継続作業の Gino→KURO 引き継ぎhandoff（正本）。

- Codex(Gino)作成のhandoff本文 + KURO再検証・#317 merge記録の同日追記（§8）
- PR #317 は HUMAN承認のもと squash merge済み（main f52b234）

## HUMANに見てほしい点
- §1 の判断事項は解決済み（#317 merge実行）。記録としての正確性のみ確認ください

🤖 Generated with [Claude Code](https://claude.com/claude-code)