### PR TITLE
fix: support current Codex exec tool-call logs

### DIFF
--- a/apps/server/src/__tests__/detect.test.ts
+++ b/apps/server/src/__tests__/detect.test.ts
@@ -13,6 +13,7 @@ const cases = [
   { name: "claude.readonly.log", expected: "claude" },
   { name: "codex.approval.log", expected: "codex" },
   { name: "codex.toolcall.log", expected: "codex" },
+  { name: "codex-current-toolcall.log", expected: "codex" },
   { name: "codex.lifecycle-error.log", expected: "generic" },
   { name: "generic.shell.log", expected: "generic" },
   { name: "lock-does-not-flip-after-initial-detect.log", expected: "claude" },

--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -67,4 +67,66 @@ describe("extractEvents fixtures", () => {
     const events = extractEvents("10;?\n•2", "codex");
     expect(events).toEqual([]);
   });
+
+  it("extracts current Codex exec tool calls without surfacing routine plugin logs", async () => {
+    const content = await fs.readFile(path.join(fixturesDir, "codex-current-toolcall.log"), "utf8");
+    const events = extractEvents(content, "codex");
+
+    expect(events.map(({ type, summary, detail }) => ({ type, summary, detail }))).toEqual([
+      { type: "search", summary: "該当箇所を検索している", detail: "⏺ Grep(rg -n 'TODO' src)" },
+      { type: "read", summary: "ファイルを読み込んでいる", detail: "⏺ Read(sed -n '1,80p' src/index.ts)" },
+      { type: "git", summary: "Git操作をしている", detail: "⏺ Bash(git status -sb)" },
+      { type: "test", summary: "テスト/型チェックを実行している", detail: "⏺ Bash(pnpm -C apps/server test)" },
+      {
+        type: "search",
+        summary: "ファイル一覧を検索している",
+        detail: "⏺ Glob(rg --files src ; sed -n '1,40p' src/app.ts)",
+      },
+      { type: "search", summary: "該当箇所を検索している", detail: "⏺ Grep(grep -R 'legacy' src)" },
+      { type: "error", summary: "終了コードで失敗している", detail: "Command failed with exit code 1" },
+      {
+        type: "error",
+        summary: "エラーが出ている",
+        detail:
+          '2026-07-19T01:00:09.000000Z ERROR codex_core_plugins::remote::remote_installed_plugin_sync: plugin sync failed failed_remote_plugin_ids=["plugin-demo"]',
+      },
+    ]);
+    expect(events.every((event) => !event.detail?.includes("ToolCall: exec"))).toBe(true);
+  });
+
+  it("uses a bounded, redacted preview for multiple exec commands", () => {
+    const chunk =
+      'ToolCall: exec await Promise.all([tools.exec_command({cmd:"curl --token secret-value https://example.invalid"}), tools.exec_command({cmd:"git status"}), tools.exec_command({cmd:"pnpm test"})]);';
+    const events = extractEvents(chunk, "codex");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "git", summary: "Git操作をしている" });
+    expect(events[0]?.detail).toBe(
+      "⏺ Bash(curl --token=[REDACTED] https://example.invalid ; git status ... (+1 commands))"
+    );
+    expect(events[0]?.detail).not.toContain("secret-value");
+    expect(events[0]?.detail).not.toContain("pnpm test");
+  });
+
+  it("safely drops current exec calls whose cmd is not a static string", () => {
+    const events = extractEvents(
+      'ToolCall: exec const buildCommand = getCommand(); const r = await tools.exec_command({cmd:buildCommand}); text(r.output);',
+      "codex"
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("suppresses write_stdin in the current exec wrapper", () => {
+    const events = extractEvents(
+      'ToolCall: exec const r = await tools.write_stdin({session_id:42,chars:"",yield_time_ms:1000}); text(r.output);',
+      "codex"
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("does not treat an empty failed-id field as an error", () => {
+    expect(extractEvents("failed_remote_plugin_ids=[]", "codex")).toEqual([]);
+  });
 });

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -69,6 +69,235 @@ function parseToolPayload(text: string): Record<string, unknown> | null {
   }
 }
 
+type QuotedString = {
+  value: string;
+  end: number;
+};
+
+function readQuotedString(text: string, start: number): QuotedString | null {
+  const quote = text[start];
+  if (quote !== "\"" && quote !== "'" && quote !== "`") return null;
+
+  let escaped = false;
+  for (let index = start + 1; index < text.length; index += 1) {
+    const ch = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    // Template interpolation would require evaluating JavaScript. Only static
+    // template literals are accepted as command values.
+    if (quote === "`" && ch === "$" && text[index + 1] === "{") return null;
+    if (ch !== quote) continue;
+
+    const raw = text.slice(start + 1, index);
+    if (quote === "\"") {
+      try {
+        return { value: JSON.parse(text.slice(start, index + 1)), end: index + 1 };
+      } catch {
+        return null;
+      }
+    }
+
+    // Decode only the escapes needed to identify ordinary shell commands.
+    // Unknown escapes are preserved, avoiding eval or a full JavaScript parser.
+    const value = raw.replace(/\\([\\'`nrt])/g, (_match, escapedChar: string) => {
+      if (escapedChar === "n") return "\n";
+      if (escapedChar === "r") return "\r";
+      if (escapedChar === "t") return "\t";
+      return escapedChar;
+    });
+    return { value, end: index + 1 };
+  }
+  return null;
+}
+
+function skipJsSpaceAndComments(text: string, start: number): number {
+  let index = start;
+  while (index < text.length) {
+    if (/\s/.test(text[index])) {
+      index += 1;
+      continue;
+    }
+    if (text.startsWith("//", index)) {
+      const newline = text.indexOf("\n", index + 2);
+      return newline < 0 ? text.length : skipJsSpaceAndComments(text, newline + 1);
+    }
+    if (text.startsWith("/*", index)) {
+      const end = text.indexOf("*/", index + 2);
+      return end < 0 ? text.length : skipJsSpaceAndComments(text, end + 2);
+    }
+    break;
+  }
+  return index;
+}
+
+function findJsToken(text: string, token: string, start: number): number {
+  for (let index = start; index < text.length; index += 1) {
+    const ch = text[index];
+    if (ch === "\"" || ch === "'" || ch === "`") {
+      let escaped = false;
+      for (index += 1; index < text.length; index += 1) {
+        if (escaped) {
+          escaped = false;
+        } else if (text[index] === "\\") {
+          escaped = true;
+        } else if (text[index] === ch) {
+          break;
+        }
+      }
+      continue;
+    }
+    if (text.startsWith("//", index) || text.startsWith("/*", index)) {
+      const next = skipJsSpaceAndComments(text, index);
+      if (next <= index || next >= text.length) return -1;
+      index = next - 1;
+      continue;
+    }
+    if (text.startsWith(token, index)) return index;
+  }
+  return -1;
+}
+
+function findMatchingDelimiter(text: string, start: number): number | null {
+  const opener = text[start];
+  const closer = opener === "(" ? ")" : opener === "{" ? "}" : opener === "[" ? "]" : null;
+  if (!closer) return null;
+
+  const stack = [closer];
+  for (let index = start + 1; index < text.length; index += 1) {
+    const ch = text[index];
+    if (ch === "\"" || ch === "'" || ch === "`") {
+      const quoted = readQuotedString(text, index);
+      if (!quoted) return null;
+      index = quoted.end - 1;
+      continue;
+    }
+    if (text.startsWith("//", index) || text.startsWith("/*", index)) {
+      const next = skipJsSpaceAndComments(text, index);
+      if (next <= index || next >= text.length) return null;
+      index = next - 1;
+      continue;
+    }
+    if (ch === "(" || ch === "{" || ch === "[") {
+      stack.push(ch === "(" ? ")" : ch === "{" ? "}" : "]");
+      continue;
+    }
+    if (ch === stack.at(-1)) {
+      stack.pop();
+      if (stack.length === 0) return index;
+    }
+  }
+  return null;
+}
+
+function extractStaticCmdProperty(objectText: string): string | null {
+  let index = 1;
+  while (index < objectText.length - 1) {
+    index = skipJsSpaceAndComments(objectText, index);
+    if (index >= objectText.length - 1) break;
+
+    let key: string | null = null;
+    let keyEnd = index;
+    if (objectText[index] === "\"" || objectText[index] === "'") {
+      const quoted = readQuotedString(objectText, index);
+      if (!quoted) return null;
+      key = quoted.value;
+      keyEnd = quoted.end;
+    } else {
+      const identifier = objectText.slice(index).match(/^[A-Za-z_$][A-Za-z0-9_$]*/)?.[0];
+      if (identifier) {
+        key = identifier;
+        keyEnd = index + identifier.length;
+      }
+    }
+
+    if (key !== null) {
+      const colon = skipJsSpaceAndComments(objectText, keyEnd);
+      if (objectText[colon] === ":") {
+        const valueStart = skipJsSpaceAndComments(objectText, colon + 1);
+        if (key === "cmd") {
+          return readQuotedString(objectText, valueStart)?.value ?? null;
+        }
+      }
+    }
+
+    const ch = objectText[index];
+    if (ch === "\"" || ch === "'" || ch === "`") {
+      const quoted = readQuotedString(objectText, index);
+      if (!quoted) return null;
+      index = quoted.end;
+      continue;
+    }
+    if (ch === "(" || ch === "{" || ch === "[") {
+      const end = findMatchingDelimiter(objectText, index);
+      if (end === null) return null;
+      index = end + 1;
+      continue;
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function extractCurrentExecCommands(payload: string): string[] {
+  const marker = "tools.exec_command";
+  const commands: string[] = [];
+  let index = 0;
+
+  while (index < payload.length) {
+    const found = findJsToken(payload, marker, index);
+    if (found < 0) break;
+
+    const before = payload[found - 1];
+    const after = payload[found + marker.length];
+    if ((before && /[A-Za-z0-9_$]/.test(before)) || (after && /[A-Za-z0-9_$]/.test(after))) {
+      index = found + marker.length;
+      continue;
+    }
+
+    const openParen = skipJsSpaceAndComments(payload, found + marker.length);
+    if (payload[openParen] !== "(") {
+      index = found + marker.length;
+      continue;
+    }
+    const closeParen = findMatchingDelimiter(payload, openParen);
+    if (closeParen === null) break;
+
+    const objectStart = skipJsSpaceAndComments(payload, openParen + 1);
+    if (payload[objectStart] === "{") {
+      const objectEnd = findMatchingDelimiter(payload, objectStart);
+      if (objectEnd !== null && objectEnd < closeParen) {
+        const cmd = extractStaticCmdProperty(payload.slice(objectStart, objectEnd + 1));
+        if (cmd) commands.push(cmd);
+      }
+    }
+    index = closeParen + 1;
+  }
+
+  return commands;
+}
+
+function safeCommandPreview(cmd: string): string {
+  const compact = cmd.replace(/\s+/g, " ").trim();
+  const redacted = compact
+    .replace(/\b([A-Za-z_][A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Za-z0-9_]*)=([^\s]+)/gi, "$1=[REDACTED]")
+    .replace(/(--?(?:token|secret|password|api[-_]?key))(?:=|\s+)('[^']*'|\"[^\"]*\"|[^\s]+)/gi, "$1=[REDACTED]");
+  return redacted.length <= 240 ? redacted : `${redacted.slice(0, 237)}...`;
+}
+
+function classifyExecCommands(commands: string[]): string | null {
+  if (commands.length === 0) return null;
+  const visible = commands.slice(0, 2).map(safeCommandPreview);
+  const omitted = commands.length - visible.length;
+  const combined = visible.join(" ; ") + (omitted > 0 ? ` ... (+${omitted} commands)` : "");
+  return classifyExecCommand(combined);
+}
+
 function classifyExecCommand(cmd: string): string {
   const compact = cmd.trim();
   if (!compact) return "⏺ Bash(exec_command)";
@@ -97,15 +326,17 @@ function canonicalizeCodexToolCall(rawLine: string): string | null {
   const payload = toolMatch[2] ?? "";
 
   switch (toolName) {
+    case "exec":
+      return classifyExecCommands(extractCurrentExecCommands(payload)) ?? "";
     case "exec_command": {
       const parsed = parseToolPayload(payload);
       const cmd = typeof parsed?.cmd === "string" ? parsed.cmd : "";
-      return classifyExecCommand(cmd);
+      return classifyExecCommands(cmd ? [cmd] : []) ?? "";
     }
     case "apply_patch":
       return "apply_patch";
     case "write_stdin":
-      return null;
+      return "";
     case "list_mcp_resources":
     case "list_mcp_resource_templates":
     case "search_query":
@@ -120,6 +351,21 @@ function canonicalizeCodexToolCall(rawLine: string): string | null {
     default:
       return `ToolCall: ${fullToolName}`;
   }
+}
+
+function isRoutineCodexInternalLog(line: string): boolean {
+  if (!/\bcodex_core_[A-Za-z0-9_]+::/i.test(line)) return false;
+  if (/(?:^|\s)ERROR(?:\s|$)/.test(line)) return false;
+  if (/\bfailed_[A-Za-z0-9_]*=\[\]/i.test(line)) return true;
+  return /(?:^|\s)(TRACE|DEBUG|INFO)(?:\s|$)/.test(line);
+}
+
+function hasOnlyEmptyFailureMarkers(line: string): boolean {
+  const withoutEmptyMarkers = line.replace(/\bfailed_[A-Za-z0-9_]*=\[\]/gi, "");
+  return (
+    withoutEmptyMarkers !== line &&
+    !/\b(?:execution error|error|failed|exception|panic|ELIFECYCLE|exit code)\b/i.test(withoutEmptyMarkers)
+  );
 }
 
 function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
@@ -142,7 +388,11 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
 
   const codexToolCall = canonicalizeCodexToolCall(normalized);
   if (codexToolCall !== null) {
-    return codexToolCall;
+    return codexToolCall || null;
+  }
+
+  if (isRoutineCodexInternalLog(normalized) || hasOnlyEmptyFailureMarkers(normalized)) {
+    return null;
   }
 
   if (/\bcodex_core::/i.test(normalized)) {

--- a/apps/server/src/rulesets/detect.ts
+++ b/apps/server/src/rulesets/detect.ts
@@ -22,8 +22,8 @@ const CODEX_STRONG = [
   /would you like to run the following command\?/i,
   /you approved .* to run/i,
   /^(apply_patch|apply patch|\*\*\* Begin Patch\b)/i,
-  /(?:^|\s)codex_core::.*\bToolCall:\s*(?:exec_command|write_stdin|apply_patch|read_mcp_resource|update_plan)\b/i,
-  /^ToolCall:\s*(?:exec_command|write_stdin|apply_patch|read_mcp_resource|update_plan)\b/i
+  /(?:^|\s)codex_core::.*\bToolCall:\s*(?:exec|exec_command|write_stdin|apply_patch|read_mcp_resource|update_plan)\b/i,
+  /^ToolCall:\s*(?:exec|exec_command|write_stdin|apply_patch|read_mcp_resource|update_plan)\b/i
 ];
 const CODEX_MEDIUM = [/^codex$/i, /\bcodex_core::/i];
 const CODEX_WEAK = [/\bELIFECYCLE\b/i, /exit code/i];

--- a/apps/server/test/fixtures/codex-current-toolcall.log
+++ b/apps/server/test/fixtures/codex-current-toolcall.log
@@ -1,0 +1,11 @@
+2026-07-19T01:00:00.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({cmd:"rg -n 'TODO' src",workdir:"/Users/demo/project",yield_time_ms:10000,max_output_tokens:2000}); text(r.output); thread_id=demo
+2026-07-19T01:00:01.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({cmd:"sed -n '1,80p' src/index.ts",workdir:"/Users/demo/project"}); text(r.output); thread_id=demo
+2026-07-19T01:00:02.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({cmd:"git status -sb",workdir:"/Users/demo/project"}); text(r.output); thread_id=demo
+2026-07-19T01:00:03.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({cmd:"pnpm -C apps/server test",workdir:"/Users/demo/project"}); text(r.output); thread_id=demo
+2026-07-19T01:00:04.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec const [files, source] = await Promise.all([tools.exec_command({cmd:"rg --files src",workdir:"/Users/demo/project"}), tools.exec_command({cmd:"sed -n '1,40p' src/app.ts",workdir:"/Users/demo/project"})]); text(files.output); text(source.output); thread_id=demo
+2026-07-19T01:00:05.000000Z  INFO codex_core::stream_events_utils: ToolCall: exec_command {"cmd":"grep -R 'legacy' src","workdir":"/Users/demo/project"} thread_id=demo
+2026-07-19T01:00:06.000000Z  INFO codex_core::stream_events_utils: ToolCall: write_stdin {"session_id":42,"chars":"","yield_time_ms":1000} thread_id=demo
+2026-07-19T01:00:07.000000Z  INFO codex_core_plugins::remote::remote_installed_plugin_sync: completed remote installed plugin bundle sync installed_plugin_ids=[] removed_cache_plugin_ids=[] failed_remote_plugin_ids=[]
+2026-07-19T01:00:08.000000Z  WARN codex_core_plugins::remote::remote_installed_plugin_sync: completed with failed_remote_plugin_ids=[]
+Command failed with exit code 1
+2026-07-19T01:00:09.000000Z ERROR codex_core_plugins::remote::remote_installed_plugin_sync: plugin sync failed failed_remote_plugin_ids=["plugin-demo"]


### PR DESCRIPTION
## Summary

- Support the Codex CLI 0.144.5 `ToolCall: exec ... tools.exec_command(...)` log format.
- Preserve backward compatibility with the legacy `ToolCall: exec_command {...}` format.
- Prevent routine `codex_core_plugins` logs and empty `failed_remote_plugin_ids=[]` fields from being treated as errors.
- Extract only static `cmd` string values with a bounded scanner that does not evaluate JavaScript.
- Limit multiple-command previews to the first two commands plus a remaining-count indicator, and redact token, secret, password, and API-key arguments.
- Suppress dynamic commands instead of guessing or exposing their contents.

## Why

A real-device `dev:codex:file` trial with Codex CLI 0.144.5 repeatedly narrated only `ToolCall: exec` because the extractor recognized the outer wrapper but not the nested `tools.exec_command` call. Routine plugin synchronization logs were also incorrectly surfaced as actionable errors.

## Validation

- `pnpm -C apps/server test`: PASS (38 files / 366 tests)
- `pnpm -C apps/server build`: PASS
- `git diff --check`: PASS

## Out of scope

The Managed Terminal English input and paste issue in the browser is a separate issue and is not addressed by this PR.