### PR TITLE
feat: separate supervision explanation tone

### DIFF
--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -88,7 +88,9 @@ export function commentByRules(ev: Event, style: Style): CommentaryPayload {
     });
   }
 
-  const beginner = stripMemoPrefix(beginnerOneLine(ev, style));
+  // Keep the beginner explanation useful as a supervision layer regardless of
+  // the selected entertainment/narration style.
+  const beginner = stripMemoPrefix(beginnerOneLine(ev, "standard"));
   const glossaryNotes = getGlossaryNotes(ev.detail);
   const spotlight = detailSpotlight(ev, style);
 

--- a/apps/server/src/styles/prompt.ts
+++ b/apps/server/src/styles/prompt.ts
@@ -2,12 +2,20 @@ import type { Event, Style } from "../types.js";
 
 type CommentaryRole = "narration" | "explanation";
 
-function styleDescriptor(style: Style): string {
+function narrationStyleDescriptor(style: Style): string {
   return style === "kansai"
     ? "関西弁で"
     : style === "zundamon"
       ? "ずんだもん風（〜なのだ）で"
       : "標準的な日本語で";
+}
+
+function deliveryDescriptor(role: CommentaryRole, style: Style): string {
+  // The narration is the entertaining layer. The explanation is the stable
+  // supervision layer, so it must stay plain even when a character style is selected.
+  return role === "narration"
+    ? narrationStyleDescriptor(style)
+    : "口調プリセットに影響されない、平易で落ち着いた標準的な日本語で";
 }
 
 function isAmbiguousEvent(ev: Event): boolean {
@@ -132,6 +140,7 @@ function buildPrompt(
       : [
           "出力は1文だけ。",
           "初心者向けの補足にする。",
+          "イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。",
           "実況の言い換えだけで終わらせない。",
           "観測できる事実から外れる推測はしない。",
           "できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。",
@@ -145,7 +154,7 @@ function buildPrompt(
       : "回答は補足説明1文のみ。";
 
   return [
-    `${roleLine}${styleDescriptor(style)}話してください。`,
+    `${roleLine}${deliveryDescriptor(role, style)}話してください。`,
     "品質ルール:",
     ...qualityRules.map((rule) => `- ${rule}`),
     `イベント別の指示: ${eventGuidance}`,

--- a/apps/server/src/tests/__snapshots__/comment.prompt.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/comment.prompt.test.ts.snap
@@ -7,10 +7,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "高速進行イベントでは実況の即時性を強める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -34,10 +35,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -61,10 +63,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -94,10 +97,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "確認系イベントでは解説の意味づけを強める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -121,10 +125,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -148,10 +153,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -181,10 +187,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "曖昧なイベントでは断定を避ける指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -210,10 +217,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -239,10 +247,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -274,10 +283,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "失敗イベントでは次の確認点を補足する",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -301,10 +311,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -328,10 +339,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -361,10 +373,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "開始イベントでは始まった対象だけを先に言う指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -388,10 +401,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -415,10 +429,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -448,10 +463,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "stderr イベントでは問題発生を先に伝える指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -475,10 +491,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -502,10 +519,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -535,10 +553,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "test イベントでは実行中の確認名を先に言う指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -562,10 +581,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -589,10 +609,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -622,10 +643,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "lint イベントでは品質ルール確認の意味づけを補足する",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -649,10 +671,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -676,10 +699,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -709,10 +733,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "build イベントでは実行・配布向けにまとめる段階だと補足する",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -736,10 +761,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -763,10 +789,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -796,10 +823,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "server イベントではサーバー状態の変化を簡潔に述べる指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -823,10 +851,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -850,10 +879,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -883,10 +913,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "install イベントでは入れているものを短く述べる指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -910,10 +941,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -937,10 +969,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -970,10 +1003,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
     "intent": "done イベントではひと区切りついた事実だけを短く伝える指示を含める",
     "prompts": [
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。標準的な日本語で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -997,10 +1031,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "standard",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。関西弁で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。
@@ -1024,10 +1059,11 @@ exports[`commentary prompt fixtures > builds event-aware narration and explanati
         "style": "kansai",
       },
       {
-        "explanationPrompt": "あなたはCLI操作の解説者です。ずんだもん風（〜なのだ）で話してください。
+        "explanationPrompt": "あなたはCLI操作の解説者です。口調プリセットに影響されない、平易で落ち着いた標準的な日本語で話してください。
 品質ルール:
 - 出力は1文だけ。
 - 初心者向けの補足にする。
+- イベントの目的を1つに絞り、複数の推測や工程を詰め込まない。
 - 実況の言い換えだけで終わらせない。
 - 観測できる事実から外れる推測はしない。
 - できるだけ『何を見ていて』『それで何が分かるか』を一文にまとめる。

--- a/apps/server/src/tests/__snapshots__/commentary.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/commentary.test.ts.snap
@@ -24,7 +24,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係ある場所しぼってるで。",
+          "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
           "glossaryNotes": [
             "補足: rg はプロジェクト全体を高速検索するコマンド",
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
@@ -40,7 +40,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係ある場所をしぼってるのだ。",
+          "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
           "glossaryNotes": [
             "補足: rg はプロジェクト全体を高速検索するコマンド",
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
@@ -78,7 +78,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "問題直すために中身を更新してるで。",
+          "explanation": "問題を直すために内容を更新しています。",
           "glossaryNotes": [
             "補足: pty は CLI を仮想端末として包んで動かす仕組み",
             "補足: WebSocket は画面とサーバーをつなぐ常時接続",
@@ -94,7 +94,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "問題を直すために中身を更新してるのだ。",
+          "explanation": "問題を直すために内容を更新しています。",
           "glossaryNotes": [
             "補足: pty は CLI を仮想端末として包んで動かす仕組み",
             "補足: WebSocket は画面とサーバーをつなぐ常時接続",
@@ -132,7 +132,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "PRの自動チェック結果見て、公開前の安全確認してるで。",
+          "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしています。",
           "glossaryNotes": [
             "補足: gh は GitHub を操作する公式CLI",
             "補足: git は変更履歴を管理する仕組み",
@@ -148,7 +148,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしてるのだ。",
+          "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしています。",
           "glossaryNotes": [
             "補足: gh は GitHub を操作する公式CLI",
             "補足: git は変更履歴を管理する仕組み",
@@ -185,7 +185,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "TypeScript が『データや部品のつながり合ってへん』場所を知らせてるで。",
+          "explanation": "TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
           ],
@@ -200,7 +200,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "TypeScript が『データや部品のつながりが合ってない』場所を知らせてるのだ。",
+          "explanation": "TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
           ],
@@ -234,7 +234,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "README.md を読んで、手順や前提を確認してるで。",
+          "explanation": "README.md を読んで、手順や前提を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -247,7 +247,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "README.md を読んで、手順や前提を確認してるのだ。",
+          "explanation": "README.md を読んで、手順や前提を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -281,7 +281,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更されたファイル一覧を見て、今どこまで触ったか確認してるで。",
+          "explanation": "変更されたファイル一覧を見て、今どこまで触ったか確認しています。",
           "glossaryNotes": [
             "補足: git は変更履歴を管理する仕組み",
           ],
@@ -296,7 +296,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更されたファイル一覧を見て、今どこまで触ったか確認してるのだ。",
+          "explanation": "変更されたファイル一覧を見て、今どこまで触ったか確認しています。",
           "glossaryNotes": [
             "補足: git は変更履歴を管理する仕組み",
           ],
@@ -330,7 +330,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更差分まとめて当てて、複数箇所を一気に更新してるで。",
+          "explanation": "変更差分をまとめて当てて、複数箇所を一気に更新しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -343,7 +343,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更差分をまとめて当てて、複数箇所を一気に更新してるのだ。",
+          "explanation": "変更差分をまとめて当てて、複数箇所を一気に更新しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -375,7 +375,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "README.md を読んで、手順や前提を確認してるで。",
+          "explanation": "README.md を読んで、手順や前提を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -388,7 +388,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "README.md を読んで、手順や前提を確認してるのだ。",
+          "explanation": "README.md を読んで、手順や前提を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -420,7 +420,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "接続先が合ってるか確かめつつ、サーバー上で今どのサービス動いてるか棚卸ししてるで。",
+          "explanation": "接続先が正しいかを確かめつつ、サーバー上で今どのサービスが動いているか棚卸ししています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -433,7 +433,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "接続先が合ってるか確かめつつ、サーバー上で今どのサービスが動いてるか棚卸ししてるのだ。",
+          "explanation": "接続先が正しいかを確かめつつ、サーバー上で今どのサービスが動いているか棚卸ししています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -465,7 +465,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "ひと区切りついたから結果を確認してるで。",
+          "explanation": "作業がひと区切りで、結果を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -478,7 +478,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "ひと区切りついたので結果を確認してるのだ。",
+          "explanation": "作業がひと区切りで、結果を確認しています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -510,7 +510,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "これから作業の流れを順に追うで。",
+          "explanation": "これから作業の流れを順に追います。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -523,7 +523,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "これから作業の流れを順に追うのだ。",
+          "explanation": "これから作業の流れを順に追います。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -555,7 +555,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "エラー出力を見て原因しぼってるで。",
+          "explanation": "エラー出力を確認して原因を絞っています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -568,7 +568,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "エラー出力を見て原因をしぼってるのだ。",
+          "explanation": "エラー出力を確認して原因を絞っています。",
           "glossaryNotes": [],
           "meta": {
             "explanationProvider": "rules",
@@ -603,7 +603,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更の副作用ないか、自動テストで機械的に確認してるで。",
+          "explanation": "変更の副作用がないか、自動テストで機械的に確認しています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
             "補足: Vitest/Jest は自動テストを走らせる仕組み",
@@ -619,7 +619,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "変更の副作用がないか、自動テストで機械的に確認してるのだ。",
+          "explanation": "変更の副作用がないか、自動テストで機械的に確認しています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
             "補足: Vitest/Jest は自動テストを走らせる仕組み",
@@ -657,7 +657,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "プログラム同士のつながり合ってるか、型ルールで機械確認してるで。",
+          "explanation": "プログラム同士のつながりが噛み合っているか、型ルールで機械確認しています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
@@ -673,7 +673,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "プログラム同士のつながりが合ってるか、型ルールで機械確認してるのだ。",
+          "explanation": "プログラム同士のつながりが噛み合っているか、型ルールで機械確認しています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
@@ -710,7 +710,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "読みやすさと品質ルールを確認してるで。",
+          "explanation": "読みやすさと品質ルールを確認しています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -725,7 +725,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "読みやすさと品質ルールを確認してるのだ。",
+          "explanation": "読みやすさと品質ルールを確認しています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -761,7 +761,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "実行・配布できる形にまとめてるで。",
+          "explanation": "実行・配布できる形にまとめています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -776,7 +776,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "実行・配布できる形にまとめてるのだ。",
+          "explanation": "実行・配布できる形にまとめています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -812,7 +812,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "動作確認のため実行環境を立ち上げてるで。",
+          "explanation": "動作確認のため実行環境を立ち上げています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -827,7 +827,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "動作確認のため実行環境を立ち上げてるのだ。",
+          "explanation": "動作確認のため実行環境を立ち上げています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -863,7 +863,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "必要なツールや依存をそろえてるで。",
+          "explanation": "必要なツールや依存を揃えています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
@@ -878,7 +878,7 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
       },
       {
         "commentary": {
-          "explanation": "必要なツールや依存をそろえてるのだ。",
+          "explanation": "必要なツールや依存を揃えています。",
           "glossaryNotes": [
             "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],

--- a/apps/server/src/tests/comment.prompt.test.ts
+++ b/apps/server/src/tests/comment.prompt.test.ts
@@ -59,6 +59,45 @@ describe("commentary prompt fixtures", () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  it("keeps supervision explanations in plain Japanese across narration styles", () => {
+    const event: Event = {
+      ts: 1,
+      type: "search",
+      summary: "該当箇所を検索している",
+      detail: "rg commentary apps/server/src",
+    };
+
+    const prompts = styles.map((style) => buildExplanationPrompt(event, style));
+
+    expect(new Set(prompts).size).toBe(1);
+    expect(prompts[0]).toContain("口調プリセットに影響されない");
+    expect(prompts[0]).toContain("イベントの目的を1つに絞り");
+    expect(prompts[0]).not.toContain("関西弁");
+    expect(prompts[0]).not.toContain("ずんだもん");
+  });
+});
+
+describe("rule-based supervision layer", () => {
+  it("keeps explanations in standard Japanese while narration follows the selected style", async () => {
+    const { comment } = await import("../styles/index.js");
+    const event: Event = {
+      ts: 1,
+      type: "test",
+      summary: "テストを実行している",
+      detail: "pnpm vitest",
+    };
+
+    const standard = await comment(event, "standard");
+    const kansai = await comment(event, "kansai");
+    const zundamon = await comment(event, "zundamon");
+
+    expect(kansai.narration).not.toBe(standard.narration);
+    expect(zundamon.narration).not.toBe(standard.narration);
+    expect(kansai.explanation).toBe(standard.explanation);
+    expect(zundamon.explanation).toBe(standard.explanation);
+    expect(kansai.explanation).not.toMatch(/やで|や。|へん|なのだ/u);
+  });
 });
 
 describe("normalizeGeneratedCommentaryText", () => {


### PR DESCRIPTION
## Summary
実況のキャラクター口調と、監督向けの平易な解説を分離します。

## Changes
- 解説プロンプトを口調プリセットに依存しない標準語へ固定
- ルールベース解説も標準語へ固定
- 1イベント1意図の品質ルールと回帰テストを追加

## Verification
- pnpm -C apps/server test
- pnpm -C apps/server build
- pnpm -C apps/web test
- pnpm -C apps/web lint
- pnpm -C apps/web build
- pnpm check:doc-sync

## Review focus
関西弁・ずんだもん風の実況を維持しつつ、やさしい説明だけが落ち着いた標準語になる点を確認してください。