### PR TITLE
feat: detect repeated error loops

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -45,6 +45,7 @@ import { isStyle, normalizeSource } from "./shared/validation.js";
 import { createPtyCapture } from "./pty/capture.js";
 import { createSilenceTimer, parseSilenceTimeoutMs } from "./silence-timer.js";
 import { createCommentaryGate, withEventPriority } from "./event-priority.js";
+import { createRepeatedErrorDetector } from "./repeated-error-detector.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -94,6 +95,7 @@ function markPtyUnavailable(error: string): void {
 
 // Progress commentary remains rate-limited; urgent and notice events bypass the gate.
 const commentaryGate = createCommentaryGate({ intervalMs: 2000 });
+const repeatedErrorDetector = createRepeatedErrorDetector();
 
 // --- HTTP + WS ---
 const server = http.createServer((req, res) => {
@@ -389,7 +391,7 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
 }
 
 function emitEvent(ev: Event): void {
-  const prioritizedEvent = withEventPriority(ev);
+  const prioritizedEvent = withEventPriority(repeatedErrorDetector.observe(ev));
   // The rule-based event reaches clients immediately; LLM commentary follows asynchronously.
   broadcast({ kind: "event", ev: prioritizedEvent });
   if (commentaryGate.shouldEmit(prioritizedEvent.priority)) {

--- a/apps/server/src/repeated-error-detector.test.ts
+++ b/apps/server/src/repeated-error-detector.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "./types.js";
+import { createRepeatedErrorDetector } from "./repeated-error-detector.js";
+
+const errorEvent = (detail: string, ts = 1): Event => ({
+  ts,
+  type: "error",
+  summary: "エラーが発生している",
+  detail,
+});
+
+describe("repeated error detector", () => {
+  it("promotes the third matching error to an urgent loop warning", () => {
+    const detector = createRepeatedErrorDetector({ threshold: 3 });
+
+    expect(detector.observe(errorEvent("Command failed with exit code 1"))).toMatchObject({
+      summary: "エラーが発生している",
+    });
+    expect(detector.observe(errorEvent("  command FAILED with exit code 1  "))).toMatchObject({
+      summary: "エラーが発生している",
+    });
+    expect(detector.observe(errorEvent("Command failed with exit code 1"))).toMatchObject({
+      summary: "同じエラーが繰り返されている",
+      detail: "3回検出: Command failed with exit code 1",
+      priority: "urgent",
+    });
+  });
+
+  it("does not combine different errors or ordinary progress events", () => {
+    const detector = createRepeatedErrorDetector({ threshold: 3 });
+
+    detector.observe(errorEvent("first failure"));
+    detector.observe({ ts: 2, type: "search", summary: "原因を検索している" });
+    detector.observe(errorEvent("second failure"));
+    expect(detector.observe(errorEvent("first failure"))).toMatchObject({
+      summary: "エラーが発生している",
+    });
+  });
+
+  it("expires old repetitions and resets at session boundaries", () => {
+    let current = 0;
+    const detector = createRepeatedErrorDetector({ threshold: 3, windowMs: 1000, now: () => current });
+
+    detector.observe(errorEvent("same failure"));
+    current = 1001;
+    detector.observe(errorEvent("same failure"));
+    current = 1100;
+    detector.observe({ ts: 3, type: "done", summary: "完了" });
+    detector.observe(errorEvent("same failure"));
+    expect(detector.observe(errorEvent("same failure"))).toMatchObject({
+      summary: "エラーが発生している",
+    });
+  });
+
+  it("emits only one loop warning until the error changes", () => {
+    const detector = createRepeatedErrorDetector({ threshold: 3 });
+
+    detector.observe(errorEvent("same failure"));
+    detector.observe(errorEvent("same failure"));
+    expect(detector.observe(errorEvent("same failure")).summary).toBe("同じエラーが繰り返されている");
+    expect(detector.observe(errorEvent("same failure")).summary).toBe("エラーが発生している");
+  });
+});

--- a/apps/server/src/repeated-error-detector.ts
+++ b/apps/server/src/repeated-error-detector.ts
@@ -1,0 +1,69 @@
+import type { Event } from "./types.js";
+
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_WINDOW_MS = 2 * 60 * 1000;
+
+const normalizeErrorSignature = (event: Event): string =>
+  `${event.summary}\n${event.detail ?? ""}`
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLocaleLowerCase("en-US");
+
+export interface RepeatedErrorDetector {
+  observe(event: Event): Event;
+  reset(): void;
+}
+
+export function createRepeatedErrorDetector(options?: {
+  threshold?: number;
+  windowMs?: number;
+  now?: () => number;
+}): RepeatedErrorDetector {
+  const threshold = Math.max(2, options?.threshold ?? DEFAULT_THRESHOLD);
+  const windowMs = Math.max(1, options?.windowMs ?? DEFAULT_WINDOW_MS);
+  const now = options?.now ?? Date.now;
+  let signature: string | null = null;
+  let count = 0;
+  let lastSeenAt = Number.NEGATIVE_INFINITY;
+  let alerted = false;
+
+  const reset = () => {
+    signature = null;
+    count = 0;
+    lastSeenAt = Number.NEGATIVE_INFINITY;
+    alerted = false;
+  };
+
+  return {
+    observe(event) {
+      if (event.type === "start" || event.type === "done") {
+        reset();
+        return event;
+      }
+
+      if (event.type !== "error") return event;
+
+      const currentTime = now();
+      const nextSignature = normalizeErrorSignature(event);
+      if (nextSignature !== signature || currentTime - lastSeenAt > windowMs) {
+        signature = nextSignature;
+        count = 1;
+        alerted = false;
+      } else {
+        count += 1;
+      }
+      lastSeenAt = currentTime;
+
+      if (count < threshold || alerted) return event;
+
+      alerted = true;
+      return {
+        ...event,
+        summary: "同じエラーが繰り返されている",
+        detail: `${count}回検出: ${event.detail ?? event.summary}`,
+        priority: "urgent",
+      };
+    },
+    reset,
+  };
+}

--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -146,16 +146,16 @@ Supervision and entertaining commentary share one event-detection result; only t
 - PR #259 made Desktop sidecar preparation idempotent, so `dev:desktop:managed` can safely verify and regenerate bundled sidecar assets before startup
 
 **Now**
-- Issue #300 establishes the long-term direction. Supervision event detection is the top priority, beginning with a Phase A-0 dogfooding observation period
-- During Phase A-0, record moments that mattered for supervision but were missed during one week of real work sessions, then use them to specify the five event classes
+- Issue #300 establishes the long-term direction. **Phase A-1 (#304, five supervision event classes) was completed on 2026-07-19**
+  - #305 fixture capture → PR #310; #306 four Claude TUI supervision classes → PR #311
+  - #307 prolonged thinking/silence detection → PR #316; #308 priority-aware event pipeline → PR #317
+  - #309 priority-aware TTS and the Web UI action-required state → PR #321, accepted on real hardware by HUMAN
+- Repeated-error detection promotes the third identical error within two minutes to an urgent “same error is repeating” event
 - Because we are not issuing an Apple Developer ID certificate for now, `#138` is treated as Deferred. Signed distribution readiness remains important, but we will return to it when certificate issuance and external distribution preparation resume
-- Keep local desktop app polish / local readiness sufficient to start Phase A-0 observations reliably
-- Main is current after PR #259, with GitHub CI green across `test`, `test_windows`, `desktop_check`, `desktop_distribution_smoke`, and CodeQL
+- Keep local desktop app polish / local readiness as the launch path for real supervision-event checks
 
 **Next**
-- Break Phase A-0 into an issue with observation fields, recording format, and completion criteria
-- Use the observations to specify permission requests, questions, errors, completion, and prolonged thinking or silence, with priority-aware TTS (Phase A-1)
-- Improve Japanese explanations and summarization, with separate serious and play-by-play presentation layers (Phase B)
+- Improve Japanese explanations and summarization, with separate serious and play-by-play presentation layers (Phase B). Confirm priorities with HUMAN/Gino before implementation
 
 **Later**
 - Complete a manual-free path from launch to live commentary (Phase C)

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -155,12 +155,12 @@ CLI Commentator は、非エンジニアで英語に不慣れな人が、CLI上�
   - #305 fixture採取 → PR #310、#306 Claude TUI監督イベント4分類 → PR #311
   - #307 長考・沈黙検知 → PR #316、#308 優先度付きイベントパイプライン → PR #317
   - #309 優先度付きTTS（urgent割り込み / noticeキュー / progress従来）＋ Web UI 要対応表示 → PR #321。HUMAN実機受け入れ済み。スキンは現行の standard / cli の2種で確認（brutalism / paper は廃止済み）
+- エラー膠着の反復検知を追加。同一エラーを2分以内に3回検出すると、urgentの「同じエラーが繰り返されている」イベントへ昇格する
 - Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
 - local desktop app polish / local readiness は、監督イベントの実機確認へ入るための起動導線として維持する
 
 **Next**
 - 日本語解説・要約と、真面目トーン／実況トーンを分けた提示層を改善する（Phase B）。着手前にHUMAN/Ginoと優先順位を確認する
-- エラー膠着の反復検知（同じ失敗の繰り返し）は、運用で不足を感じたらフォローアップIssueへ切り出す
 
 **Later**
 - 説明書なしで実況開始まで辿り着ける起動導線を完成させる（Phase C）


### PR DESCRIPTION
## Summary
同一エラーの反復を検知し、AI作業が同じ失敗で膠着している可能性をurgentイベントとして通知します。

## Changes
- 同一エラーを2分以内に3回検出すると反復警告へ昇格
- 開始・完了時のリセット、時間切れ、異なるエラー、重複通知防止を実装
- 状態機械の単体テストを追加
- ROADMAP日英を現在のPhase A-1完了状態と反復検知仕様へ同期

## Verification
- pnpm -C apps/server test（371 passed / 5 skipped）
- pnpm -C apps/server build
- pnpm check:doc-sync
- git diff --check origin/main...HEAD

## Review focus
2分以内・3回という初期閾値と、警告後は同じエラーについて再警告しない挙動を確認してください。