### PR TITLE
feat: add guided first-run launcher

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -182,9 +182,20 @@
 
 .launcher-panel__toolbar {
   display: grid;
-  grid-template-columns: auto minmax(220px, 1fr) minmax(120px, 0.7fr) minmax(140px, 0.9fr) auto;
+  grid-template-columns: auto minmax(260px, 1fr) auto;
   gap: var(--space-2);
   align-items: end;
+}
+
+.launcher-panel__step {
+  display: grid;
+  gap: 2px;
+}
+
+.launcher-panel__step-label {
+  color: var(--color-fg-secondary);
+  font-size: var(--text-xs);
+  text-align: left;
 }
 
 .launcher-panel__presets {
@@ -230,7 +241,25 @@
 
 .launcher-panel__launch-btn {
   align-self: stretch;
-  min-width: 72px;
+  min-width: 150px;
+}
+
+.launcher-panel__advanced {
+  color: var(--color-fg-secondary);
+  font-size: var(--text-xs);
+  text-align: left;
+}
+
+.launcher-panel__advanced summary {
+  cursor: pointer;
+  width: fit-content;
+}
+
+.launcher-panel__advanced-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-1);
 }
 
 .terminal-panel {
@@ -494,6 +523,10 @@
 
 @media (max-width: 768px) {
   .launcher-panel__toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .launcher-panel__advanced-fields {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -65,7 +65,7 @@ export default function App() {
   const [items, setItems] = useState<CommentaryItem[]>([]);
   const [style, setStyle] = useState<Style>("kansai");
   const [source, setSource] = useState<SourceState>({ mode: "auto", detected: null });
-  const [launchDraft, setLaunchDraft] = useState<LaunchDraft>(() => buildLaunchDraft("bash", "kansai"));
+  const [launchDraft, setLaunchDraft] = useState<LaunchDraft>(() => buildLaunchDraft("claude", "kansai"));
   const [currentSessionLabel, setCurrentSessionLabel] = useState("bash");
   const [tauriServerPort, setTauriServerPort] = useState<number | null>(null);
   const [skin, setSkin] = useState<Skin>(() => {

--- a/apps/web/src/components/LauncherPanel.tsx
+++ b/apps/web/src/components/LauncherPanel.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { LAUNCH_PRESETS, type LaunchDraft, type LaunchPresetId } from "../lib/session-launcher";
+import { LAUNCH_PRESETS, getLaunchButtonLabel, type LaunchDraft, type LaunchPresetId } from "../lib/session-launcher";
 import type { Style } from "../types";
 
 type LauncherPanelProps = {
@@ -15,45 +15,55 @@ export function LauncherPanel({ launchDraft, setLaunchDraft, style, connected, o
   return (
     <div className="panel launcher-panel">
       <div className="launcher-panel__header">
-        <div className="launcher-panel__title">Quick Launch</div>
-        <div className="launcher-panel__hint">ここから直接 CLI を起動します。</div>
+        <div className="launcher-panel__title">実況を始める</div>
+        <div className="launcher-panel__hint">3ステップでAIの作業をこの画面から監督できます。</div>
       </div>
       <div className="launcher-panel__toolbar">
-        <div className="launcher-panel__presets" role="tablist" aria-label="launch presets">
-          {LAUNCH_PRESETS.map((preset) => (
-            <button
-              key={preset.id}
-              type="button"
-              className={`launcher-panel__preset ${launchDraft.presetId === preset.id ? "launcher-panel__preset--active" : ""}`}
-              onClick={() => onSelectPreset(preset.id)}
-              title={preset.description}
-            >
-              {preset.label}
-            </button>
-          ))}
+        <div className="launcher-panel__step">
+          <div className="launcher-panel__step-label">1. 起動するAIを選ぶ</div>
+          <div className="launcher-panel__presets" role="tablist" aria-label="起動するCLI">
+            {LAUNCH_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                role="tab"
+                aria-selected={launchDraft.presetId === preset.id}
+                className={`launcher-panel__preset ${launchDraft.presetId === preset.id ? "launcher-panel__preset--active" : ""}`}
+                onClick={() => onSelectPreset(preset.id)}
+                title={preset.description}
+              >
+                {preset.label}{preset.recommended ? "（推奨）" : ""}
+              </button>
+            ))}
+          </div>
         </div>
         <label className="launcher-panel__field launcher-panel__field--cwd">
-          <span>作業ディレクトリ</span>
-          <input value={launchDraft.cwd} onChange={(e) => setLaunchDraft((prev) => ({ ...prev, cwd: e.target.value }))} placeholder="/path/to/repo" />
-        </label>
-        <label className="launcher-panel__field launcher-panel__field--cmd">
-          <span>コマンド</span>
-          <input
-            value={launchDraft.cmd}
-            onChange={(e) => setLaunchDraft((prev) => ({ ...prev, cmd: e.target.value, presetId: "custom", name: prev.presetId === "custom" ? prev.name : "Custom" }))}
-            placeholder="bash / codex / claude"
-          />
-        </label>
-        <label className="launcher-panel__field launcher-panel__field--args">
-          <span>引数</span>
-          <input value={launchDraft.args} onChange={(e) => setLaunchDraft((prev) => ({ ...prev, args: e.target.value }))} placeholder="--no-alt-screen" />
+          <span>2. 作業フォルダを指定（空欄なら既定のフォルダ）</span>
+          <input value={launchDraft.cwd} onChange={(e) => setLaunchDraft((prev) => ({ ...prev, cwd: e.target.value }))} placeholder="例: /path/to/project" />
         </label>
         <button type="button" className="debug-panel__btn debug-panel__btn--primary launcher-panel__launch-btn" onClick={onLaunch} disabled={!connected}>
-          起動
+          3. {getLaunchButtonLabel(launchDraft, connected)}
         </button>
       </div>
+      <details className="launcher-panel__advanced">
+        <summary>詳細設定（通常は変更不要）</summary>
+        <div className="launcher-panel__advanced-fields">
+          <label className="launcher-panel__field launcher-panel__field--cmd">
+            <span>コマンド</span>
+            <input
+              value={launchDraft.cmd}
+              onChange={(e) => setLaunchDraft((prev) => ({ ...prev, cmd: e.target.value, presetId: "custom", name: prev.presetId === "custom" ? prev.name : "Custom" }))}
+              placeholder="bash / codex / claude"
+            />
+          </label>
+          <label className="launcher-panel__field launcher-panel__field--args">
+            <span>引数</span>
+            <input value={launchDraft.args} onChange={(e) => setLaunchDraft((prev) => ({ ...prev, args: e.target.value }))} placeholder="--no-alt-screen" />
+          </label>
+        </div>
+      </details>
       <div className="launcher-panel__meta">
-        口調 `{style}` / source `{launchDraft.logSource}` で起動します。
+        実況口調: {style} ／ ログ判定: {launchDraft.logSource}
       </div>
     </div>
   );

--- a/apps/web/src/lib/session-launcher.test.ts
+++ b/apps/web/src/lib/session-launcher.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { LAUNCH_PRESETS, buildLaunchDraft, buildLaunchSessionInput } from "./session-launcher";
+import { LAUNCH_PRESETS, buildLaunchDraft, buildLaunchSessionInput, getLaunchButtonLabel } from "./session-launcher";
 
 describe("session-launcher", () => {
   it("exposes expected built-in presets", () => {
-    expect(LAUNCH_PRESETS.map((preset) => preset.id)).toEqual(["bash", "codex", "claude", "custom"]);
+    expect(LAUNCH_PRESETS.map((preset) => preset.id)).toEqual(["claude", "codex", "bash", "custom"]);
+    expect(LAUNCH_PRESETS.find((preset) => preset.recommended)?.id).toBe("claude");
   });
 
   it("builds codex preset with fixed source mode", () => {
@@ -33,5 +34,12 @@ describe("session-launcher", () => {
       style: "standard",
       logSource: "auto",
     });
+  });
+
+  it("describes the next launch action without requiring instructions", () => {
+    const draft = buildLaunchDraft("claude", "standard");
+    expect(getLaunchButtonLabel(draft, false)).toBe("サーバー接続待ち");
+    expect(getLaunchButtonLabel(draft, true)).toBe("Claude Codeを起動");
+    expect(getLaunchButtonLabel(buildLaunchDraft("custom", "standard"), true)).toBe("CLIを起動");
   });
 });

--- a/apps/web/src/lib/session-launcher.ts
+++ b/apps/web/src/lib/session-launcher.ts
@@ -16,11 +16,12 @@ export type LaunchPreset = {
   id: LaunchPresetId;
   label: string;
   description: string;
+  recommended?: boolean;
 };
 
 const PRESET_CONFIG: Record<
   LaunchPresetId,
-  { label: string; description: string; cmd: string; args: string; logSource: SourceState["mode"] }
+  { label: string; description: string; cmd: string; args: string; logSource: SourceState["mode"]; recommended?: boolean }
 > = {
   bash: {
     label: "bash",
@@ -42,6 +43,7 @@ const PRESET_CONFIG: Record<
     cmd: "claude",
     args: "",
     logSource: "claude",
+    recommended: true,
   },
   custom: {
     label: "Custom",
@@ -52,12 +54,13 @@ const PRESET_CONFIG: Record<
   },
 };
 
-export const LAUNCH_PRESETS: LaunchPreset[] = (Object.entries(PRESET_CONFIG) as Array<
-  [LaunchPresetId, (typeof PRESET_CONFIG)[LaunchPresetId]]
->).map(([id, config]) => ({
+const PRESET_ORDER: LaunchPresetId[] = ["claude", "codex", "bash", "custom"];
+
+export const LAUNCH_PRESETS: LaunchPreset[] = PRESET_ORDER.map((id) => ({
   id,
-  label: config.label,
-  description: config.description,
+  label: PRESET_CONFIG[id].label,
+  description: PRESET_CONFIG[id].description,
+  recommended: PRESET_CONFIG[id].recommended,
 }));
 
 export function buildLaunchDraft(presetId: LaunchPresetId, style: Style, cwd = ""): LaunchDraft {
@@ -86,4 +89,10 @@ export function buildLaunchSessionInput(draft: LaunchDraft): LaunchSessionInput 
     style: draft.style,
     logSource: draft.logSource,
   };
+}
+
+export function getLaunchButtonLabel(draft: LaunchDraft, connected: boolean): string {
+  if (!connected) return "サーバー接続待ち";
+  if (draft.presetId === "custom") return "CLIを起動";
+  return `${PRESET_CONFIG[draft.presetId].label}を起動`;
 }


### PR DESCRIPTION
## 何をしたか

初回利用者が起動方法を迷わないよう、ランチャーパネルに段階的な初回起動導線を追加しました。

## 変更点

- 初回利用者向けに、起動対象・起動方法・実行までの案内と状態表示を整理
- セッション起動処理とテストを更新
- 変更対象はWeb中心の5ファイルのみ（App.css、App.tsx、LauncherPanel.tsx、session-launcher.ts、session-launcher.test.ts）。ServerやDesktopの実装は変更していません
- origin/mainへ競合なしでrebase済み（検証対象コミット: 47c5618）
- ローカルの.codex/は未追跡・未コミットのままです

## 確認済み

- Web: 72 tests PASS
- Web: build PASS
- Web: lint PASS
- Server: 376 tests PASS
- Server: build PASS
- Server: typecheck PASS
- doc-sync PASS
- diff check PASS

## 確認してほしいこと

- 判断: 初回利用者向け起動導線の文言、段階構成、既存利用者への影響が妥当か
- リスク: 低。変更はWebのランチャー表示と起動パラメータ生成に限定され、関連テストと全CI相当チェックが通過済み
- Todoist/gate: 初回起動導線（最後の導線PR） / gate/human