### PR TITLE
test: add Phase B evaluation replay harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist
 
 # Raw PTY diagnostic captures can contain secrets and local paths.
 *.pty-capture.jsonl
+
+# Local raw evaluation captures may contain session identifiers and prompts.
+/evaluation/

--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -10,8 +10,14 @@ export type PhaseBReplayFixture = {
   id: string;
   source: SourceMode;
   style: Style;
+  taskContext: PhaseBTaskContext;
   commentaryIntervalMs: number;
   lines: Array<{ offsetMs: number; line: string }>;
+};
+
+export type PhaseBTaskContext = {
+  objective: string;
+  userPrompt: string;
 };
 
 export type PhaseBSuppression = {
@@ -33,10 +39,34 @@ export type PhaseBReplayResult = {
   fixtureId: string;
   source: SourceMode;
   style: Style;
+  taskContext: PhaseBTaskContext;
   messages: Array<Extract<WsOutgoing, { kind: "event" | "commentary" }>>;
   suppressions: PhaseBSuppression[];
   metrics: PhaseBReplayMetrics;
 };
+
+export type PhaseBEventTypeComparison = {
+  eventType: string;
+  baseline: number;
+  candidate: number;
+};
+
+export function comparePhaseBEventTypes(
+  baseline: PhaseBReplayMetrics,
+  candidate: PhaseBReplayMetrics
+): PhaseBEventTypeComparison[] {
+  const eventTypes = new Set([
+    ...Object.keys(baseline.eventsByType),
+    ...Object.keys(candidate.eventsByType),
+  ]);
+  return Array.from(eventTypes)
+    .sort((left, right) => left.localeCompare(right, "en"))
+    .map((eventType) => ({
+      eventType,
+      baseline: baseline.eventsByType[eventType] ?? 0,
+      candidate: candidate.eventsByType[eventType] ?? 0,
+    }));
+}
 
 function countExactNarrationRepeats(messages: PhaseBReplayResult["messages"]): number {
   const counts = new Map<string, number>();
@@ -109,6 +139,7 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
     fixtureId: fixture.id,
     source: fixture.source,
     style: fixture.style,
+    taskContext: fixture.taskContext,
     messages,
     suppressions,
     metrics: buildMetrics(messages, suppressions),

--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -1,0 +1,116 @@
+import { comment } from "../commentary/orchestrator.js";
+import { withEventPriority, createCommentaryGate } from "../event-priority.js";
+import { extractEvents } from "../extract.js";
+import { redact } from "../redact.js";
+import { createRepeatedErrorDetector } from "../repeated-error-detector.js";
+import type { CommentaryPayload, Event, SourceMode, Style, WsOutgoing } from "../types.js";
+
+export type PhaseBReplayFixture = {
+  notice: string[];
+  id: string;
+  source: SourceMode;
+  style: Style;
+  commentaryIntervalMs: number;
+  lines: Array<{ offsetMs: number; line: string }>;
+};
+
+export type PhaseBSuppression = {
+  offsetMs: number;
+  reason: "progress_interval";
+  event: Event;
+};
+
+export type PhaseBReplayMetrics = {
+  events: number;
+  commentaries: number;
+  suppressed: number;
+  eventsByType: Record<string, number>;
+  glossaryNotes: number;
+  exactNarrationRepeats: number;
+};
+
+export type PhaseBReplayResult = {
+  fixtureId: string;
+  source: SourceMode;
+  style: Style;
+  messages: Array<Extract<WsOutgoing, { kind: "event" | "commentary" }>>;
+  suppressions: PhaseBSuppression[];
+  metrics: PhaseBReplayMetrics;
+};
+
+function countExactNarrationRepeats(messages: PhaseBReplayResult["messages"]): number {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    if (message.kind !== "commentary" || !message.narration) continue;
+    counts.set(message.narration, (counts.get(message.narration) ?? 0) + 1);
+  }
+  return Array.from(counts.values()).reduce((total, count) => total + Math.max(0, count - 1), 0);
+}
+
+function buildMetrics(
+  messages: PhaseBReplayResult["messages"],
+  suppressions: PhaseBSuppression[]
+): PhaseBReplayMetrics {
+  const eventMessages = messages.filter((message): message is Extract<WsOutgoing, { kind: "event" }> =>
+    message.kind === "event"
+  );
+  const commentaryMessages = messages.filter(
+    (message): message is Extract<WsOutgoing, { kind: "commentary" }> => message.kind === "commentary"
+  );
+  const eventsByType: Record<string, number> = {};
+  for (const message of eventMessages) {
+    eventsByType[message.ev.type] = (eventsByType[message.ev.type] ?? 0) + 1;
+  }
+
+  return {
+    events: eventMessages.length,
+    commentaries: commentaryMessages.length,
+    suppressed: suppressions.length,
+    eventsByType,
+    glossaryNotes: commentaryMessages.reduce(
+      (total, message) => total + (message.glossaryNotes?.length ?? 0),
+      0
+    ),
+    exactNarrationRepeats: countExactNarrationRepeats(messages),
+  };
+}
+
+export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise<PhaseBReplayResult> {
+  let currentOffsetMs = 0;
+  const gate = createCommentaryGate({
+    intervalMs: fixture.commentaryIntervalMs,
+    now: () => currentOffsetMs,
+  });
+  const repeatedErrors = createRepeatedErrorDetector({ now: () => currentOffsetMs });
+  const messages: PhaseBReplayResult["messages"] = [];
+  const suppressions: PhaseBSuppression[] = [];
+
+  for (const entry of fixture.lines) {
+    currentOffsetMs = entry.offsetMs;
+    const events = extractEvents(redact(entry.line), fixture.source);
+    for (const extracted of events) {
+      const event = withEventPriority(repeatedErrors.observe({ ...extracted, ts: currentOffsetMs }));
+      messages.push({ kind: "event", ev: event });
+
+      if (!gate.shouldEmit(event.priority)) {
+        suppressions.push({ offsetMs: currentOffsetMs, reason: "progress_interval", event });
+        continue;
+      }
+
+      const payload: CommentaryPayload = await comment(event, fixture.style, {
+        narrationProvider: "disabled",
+        explanationProvider: "disabled",
+      });
+      messages.push({ kind: "commentary", ts: currentOffsetMs, ev: event, ...payload });
+    }
+  }
+
+  return {
+    fixtureId: fixture.id,
+    source: fixture.source,
+    style: fixture.style,
+    messages,
+    suppressions,
+    metrics: buildMetrics(messages, suppressions),
+  };
+}

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Phase B evaluation replay > replays the minimal sanitized session deterministically 1`] = `
+{
+  "fixtureId": "phase-b-codex-session",
+  "messages": [
+    {
+      "ev": {
+        "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '"name": "cli-commentator"' package.json && git remote -v)",
+        "priority": "progress",
+        "summary": "該当箇所を検索している",
+        "ts": 400,
+        "type": "search",
+      },
+      "kind": "event",
+    },
+    {
+      "ev": {
+        "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '"name": "cli-commentator"' package.json && git remote -v)",
+        "priority": "progress",
+        "summary": "該当箇所を検索している",
+        "ts": 400,
+        "type": "search",
+      },
+      "explanation": "「name」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [
+        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
+        "補足: git は変更履歴を管理する仕組み",
+      ],
+      "kind": "commentary",
+      "meta": {
+        "explanationProvider": "rules",
+        "mode": "both",
+        "narrationProvider": "rules",
+      },
+      "narration": "原因っぽいとこ探してるで。",
+      "ts": 400,
+    },
+    {
+      "ev": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "priority": "progress",
+        "summary": "コマンドを実行している",
+        "ts": 3218,
+        "type": "stdout",
+      },
+      "kind": "event",
+    },
+    {
+      "ev": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "priority": "progress",
+        "summary": "コマンドを実行している",
+        "ts": 3218,
+        "type": "stdout",
+      },
+      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "glossaryNotes": [],
+      "kind": "commentary",
+      "meta": {
+        "explanationProvider": "rules",
+        "mode": "both",
+        "narrationProvider": "rules",
+      },
+      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "ts": 3218,
+    },
+    {
+      "ev": {
+        "detail": "⏺ Grep(rg -n "buildSpeechText|queueSpeech|commentaryDisplayMode" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
+        "priority": "progress",
+        "summary": "該当箇所を検索している",
+        "ts": 7355,
+        "type": "search",
+      },
+      "kind": "event",
+    },
+    {
+      "ev": {
+        "detail": "⏺ Grep(rg -n "buildSpeechText|queueSpeech|commentaryDisplayMode" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
+        "priority": "progress",
+        "summary": "該当箇所を検索している",
+        "ts": 7355,
+        "type": "search",
+      },
+      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [
+        "補足: rg はプロジェクト全体を高速検索するコマンド",
+        "補足: tsx は TypeScript をそのまま実行する仕組み",
+      ],
+      "kind": "commentary",
+      "meta": {
+        "explanationProvider": "rules",
+        "mode": "both",
+        "narrationProvider": "rules",
+      },
+      "narration": "原因っぽいとこ探してるで。",
+      "ts": 7355,
+    },
+    {
+      "ev": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "priority": "progress",
+        "summary": "テスト/型チェックを実行している",
+        "ts": 8734,
+        "type": "test",
+      },
+      "kind": "event",
+    },
+    {
+      "ev": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "priority": "progress",
+        "summary": "コマンドを実行している",
+        "ts": 10573,
+        "type": "stdout",
+      },
+      "kind": "event",
+    },
+    {
+      "ev": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "priority": "progress",
+        "summary": "コマンドを実行している",
+        "ts": 10573,
+        "type": "stdout",
+      },
+      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "glossaryNotes": [],
+      "kind": "commentary",
+      "meta": {
+        "explanationProvider": "rules",
+        "mode": "both",
+        "narrationProvider": "rules",
+      },
+      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "ts": 10573,
+    },
+  ],
+  "metrics": {
+    "commentaries": 4,
+    "events": 5,
+    "eventsByType": {
+      "search": 2,
+      "stdout": 2,
+      "test": 1,
+    },
+    "exactNarrationRepeats": 2,
+    "glossaryNotes": 4,
+    "suppressed": 1,
+  },
+  "source": "codex",
+  "style": "kansai",
+  "suppressions": [
+    {
+      "event": {
+        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "priority": "progress",
+        "summary": "テスト/型チェックを実行している",
+        "ts": 8734,
+        "type": "test",
+      },
+      "offsetMs": 8734,
+      "reason": "progress_interval",
+    },
+  ],
+}
+`;

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -164,5 +164,9 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "reason": "progress_interval",
     },
   ],
+  "taskContext": {
+    "objective": "Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する",
+    "userPrompt": "実況生成と読み上げに関係する実装とテストを読み、現状と改善候補を整理してください。",
+  },
 }
 `;

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  comparePhaseBEventTypes,
   replayPhaseBFixture,
   type PhaseBReplayFixture,
 } from "../evaluation/phase-b-replay.js";
@@ -25,6 +26,7 @@ describe("Phase B evaluation replay", () => {
       "Identifiers, paths, timestamps, and user-authored content are synthetic.",
     ]);
     expect(fixture.lines).toHaveLength(28);
+    expect(result.taskContext).toEqual(fixture.taskContext);
     expect(result.metrics).toMatchObject({
       events: 5,
       commentaries: 4,
@@ -32,5 +34,30 @@ describe("Phase B evaluation replay", () => {
       eventsByType: { search: 2, stdout: 2, test: 1 },
     });
     expect(result).toMatchSnapshot();
+  });
+
+  it("compares event classifications in a stable order", () => {
+    expect(comparePhaseBEventTypes(
+      {
+        events: 2,
+        commentaries: 0,
+        suppressed: 0,
+        eventsByType: { test: 1, search: 1 },
+        glossaryNotes: 0,
+        exactNarrationRepeats: 0,
+      },
+      {
+        events: 2,
+        commentaries: 0,
+        suppressed: 0,
+        eventsByType: { read: 1, search: 1 },
+        glossaryNotes: 0,
+        exactNarrationRepeats: 0,
+      }
+    )).toEqual([
+      { eventType: "read", baseline: 0, candidate: 1 },
+      { eventType: "search", baseline: 1, candidate: 1 },
+      { eventType: "test", baseline: 1, candidate: 0 },
+    ]);
   });
 });

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  replayPhaseBFixture,
+  type PhaseBReplayFixture,
+} from "../evaluation/phase-b-replay.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturePath = path.resolve(__dirname, "../../test/fixtures/phase-b-codex-session.json");
+
+async function loadFixture(): Promise<PhaseBReplayFixture> {
+  return JSON.parse(await fs.readFile(fixturePath, "utf8")) as PhaseBReplayFixture;
+}
+
+describe("Phase B evaluation replay", () => {
+  it("replays the minimal sanitized session deterministically", async () => {
+    const fixture = await loadFixture();
+    const result = await replayPhaseBFixture(fixture);
+
+    expect(fixture.notice).toEqual([
+      "This fixture was derived from a real Codex CLI session and sanitized.",
+      "Identifiers, paths, timestamps, and user-authored content are synthetic.",
+    ]);
+    expect(fixture.lines).toHaveLength(28);
+    expect(result.metrics).toMatchObject({
+      events: 5,
+      commentaries: 4,
+      suppressed: 1,
+      eventsByType: { search: 2, stdout: 2, test: 1 },
+    });
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -2,6 +2,10 @@
   "fixtureId": "phase-b-codex-session",
   "source": "codex",
   "style": "kansai",
+  "taskContext": {
+    "objective": "Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する",
+    "userPrompt": "実況生成と読み上げに関係する実装とテストを読み、現状と改善候補を整理してください。"
+  },
   "messages": [
     {
       "kind": "event",

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -1,0 +1,164 @@
+{
+  "fixtureId": "phase-b-codex-session",
+  "source": "codex",
+  "style": "kansai",
+  "messages": [
+    {
+      "kind": "event",
+      "ev": {
+        "ts": 400,
+        "type": "search",
+        "summary": "該当箇所を検索している",
+        "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '\"name\": \"cli-commentator\"' package.json && git remote -v)",
+        "priority": "progress"
+      }
+    },
+    {
+      "kind": "commentary",
+      "ts": 400,
+      "ev": {
+        "ts": 400,
+        "type": "search",
+        "summary": "該当箇所を検索している",
+        "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '\"name\": \"cli-commentator\"' package.json && git remote -v)",
+        "priority": "progress"
+      },
+      "narration": "原因っぽいとこ探してるで。",
+      "explanation": "「name」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [
+        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
+        "補足: git は変更履歴を管理する仕組み"
+      ],
+      "meta": {
+        "narrationProvider": "rules",
+        "explanationProvider": "rules",
+        "mode": "both"
+      }
+    },
+    {
+      "kind": "event",
+      "ev": {
+        "ts": 3218,
+        "type": "stdout",
+        "summary": "コマンドを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "priority": "progress"
+      }
+    },
+    {
+      "kind": "commentary",
+      "ts": 3218,
+      "ev": {
+        "ts": 3218,
+        "type": "stdout",
+        "summary": "コマンドを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "priority": "progress"
+      },
+      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "glossaryNotes": [],
+      "meta": {
+        "narrationProvider": "rules",
+        "explanationProvider": "rules",
+        "mode": "both"
+      }
+    },
+    {
+      "kind": "event",
+      "ev": {
+        "ts": 7355,
+        "type": "search",
+        "summary": "該当箇所を検索している",
+        "detail": "⏺ Grep(rg -n \"buildSpeechText|queueSpeech|commentaryDisplayMode\" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
+        "priority": "progress"
+      }
+    },
+    {
+      "kind": "commentary",
+      "ts": 7355,
+      "ev": {
+        "ts": 7355,
+        "type": "search",
+        "summary": "該当箇所を検索している",
+        "detail": "⏺ Grep(rg -n \"buildSpeechText|queueSpeech|commentaryDisplayMode\" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
+        "priority": "progress"
+      },
+      "narration": "原因っぽいとこ探してるで。",
+      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [
+        "補足: rg はプロジェクト全体を高速検索するコマンド",
+        "補足: tsx は TypeScript をそのまま実行する仕組み"
+      ],
+      "meta": {
+        "narrationProvider": "rules",
+        "explanationProvider": "rules",
+        "mode": "both"
+      }
+    },
+    {
+      "kind": "event",
+      "ev": {
+        "ts": 8734,
+        "type": "test",
+        "summary": "テスト/型チェックを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "priority": "progress"
+      }
+    },
+    {
+      "kind": "event",
+      "ev": {
+        "ts": 10573,
+        "type": "stdout",
+        "summary": "コマンドを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "priority": "progress"
+      }
+    },
+    {
+      "kind": "commentary",
+      "ts": 10573,
+      "ev": {
+        "ts": 10573,
+        "type": "stdout",
+        "summary": "コマンドを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "priority": "progress"
+      },
+      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "glossaryNotes": [],
+      "meta": {
+        "narrationProvider": "rules",
+        "explanationProvider": "rules",
+        "mode": "both"
+      }
+    }
+  ],
+  "suppressions": [
+    {
+      "offsetMs": 8734,
+      "reason": "progress_interval",
+      "event": {
+        "ts": 8734,
+        "type": "test",
+        "summary": "テスト/型チェックを実行している",
+        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "priority": "progress"
+      }
+    }
+  ],
+  "metrics": {
+    "events": 5,
+    "commentaries": 4,
+    "suppressed": 1,
+    "eventsByType": {
+      "search": 2,
+      "stdout": 2,
+      "test": 1
+    },
+    "glossaryNotes": 4,
+    "exactNarrationRepeats": 2
+  }
+}

--- a/apps/server/test/fixtures/phase-b-codex-session.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.json
@@ -6,6 +6,10 @@
   "id": "phase-b-codex-session",
   "source": "codex",
   "style": "kansai",
+  "taskContext": {
+    "objective": "Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する",
+    "userPrompt": "実況生成と読み上げに関係する実装とテストを読み、現状と改善候補を整理してください。"
+  },
   "commentaryIntervalMs": 2000,
   "lines": [
     { "offsetMs": 0, "line": "2030-01-01T00:00:00.000Z INFO codex_core::client: close time.busy=1ms" },

--- a/apps/server/test/fixtures/phase-b-codex-session.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.json
@@ -1,0 +1,40 @@
+{
+  "notice": [
+    "This fixture was derived from a real Codex CLI session and sanitized.",
+    "Identifiers, paths, timestamps, and user-authored content are synthetic."
+  ],
+  "id": "phase-b-codex-session",
+  "source": "codex",
+  "style": "kansai",
+  "commentaryIntervalMs": 2000,
+  "lines": [
+    { "offsetMs": 0, "line": "2030-01-01T00:00:00.000Z INFO codex_core::client: close time.busy=1ms" },
+    { "offsetMs": 100, "line": "2030-01-01T00:00:00.100Z INFO codex_core::client: close time.idle=2ms" },
+    { "offsetMs": 200, "line": "2030-01-01T00:00:00.200Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::client: close" },
+    { "offsetMs": 300, "line": "2030-01-01T00:00:00.300Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::client: close" },
+    { "offsetMs": 400, "line": "2030-01-01T00:00:00.400Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({\"cmd\":\"test -f pnpm-workspace.yaml && grep -q '\\\"name\\\": \\\"cli-commentator\\\"' package.json && git remote -v\",\"workdir\":\"/Users/demo/project\"}); text(r.output);" },
+    { "offsetMs": 500, "line": "2030-01-01T00:00:00.500Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-001" },
+    { "offsetMs": 600, "line": "2030-01-01T00:00:00.600Z INFO codex_core::client: close time.idle=3ms" },
+    { "offsetMs": 1000, "line": "2030-01-01T00:00:01.000Z INFO codex_core::client: close time.idle=4ms" },
+    { "offsetMs": 1500, "line": "2030-01-01T00:00:01.500Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-002" },
+    { "offsetMs": 2000, "line": "2030-01-01T00:00:02.000Z INFO codex_core::client: close time.idle=5ms" },
+    { "offsetMs": 3000, "line": "2030-01-01T00:00:03.000Z INFO codex_core::client: close time.idle=6ms" },
+    { "offsetMs": 3218, "line": "2030-01-01T00:00:03.218Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({\"cmd\":\"nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p'\",\"workdir\":\"/Users/demo/project\"}); text(r.output);" },
+    { "offsetMs": 3500, "line": "2030-01-01T00:00:03.500Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-003" },
+    { "offsetMs": 4000, "line": "2030-01-01T00:00:04.000Z INFO codex_core::client: close time.idle=7ms" },
+    { "offsetMs": 5000, "line": "2030-01-01T00:00:05.000Z INFO codex_core::client: close time.idle=8ms" },
+    { "offsetMs": 6000, "line": "2030-01-01T00:00:06.000Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-004" },
+    { "offsetMs": 6500, "line": "2030-01-01T00:00:06.500Z INFO codex_core::client: close time.idle=9ms" },
+    { "offsetMs": 7000, "line": "2030-01-01T00:00:07.000Z INFO codex_core::client: close time.idle=10ms" },
+    { "offsetMs": 7200, "line": "2030-01-01T00:00:07.200Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-005" },
+    { "offsetMs": 7300, "line": "2030-01-01T00:00:07.300Z INFO codex_core::client: close time.idle=11ms" },
+    { "offsetMs": 7355, "line": "2030-01-01T00:00:07.355Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({\"cmd\":\"rg -n \\\"buildSpeechText|queueSpeech|commentaryDisplayMode\\\" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p'\",\"workdir\":\"/Users/demo/project\"}); text(r.output);" },
+    { "offsetMs": 7500, "line": "2030-01-01T00:00:07.500Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-006" },
+    { "offsetMs": 8000, "line": "2030-01-01T00:00:08.000Z INFO codex_core::client: close time.idle=12ms" },
+    { "offsetMs": 8734, "line": "2030-01-01T00:00:08.734Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({\"cmd\":\"nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p'\",\"workdir\":\"/Users/demo/project\"}); text(r.output);" },
+    { "offsetMs": 9000, "line": "2030-01-01T00:00:09.000Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-007" },
+    { "offsetMs": 10000, "line": "2030-01-01T00:00:10.000Z INFO codex_core::client: close time.idle=13ms" },
+    { "offsetMs": 10500, "line": "2030-01-01T00:00:10.500Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: tool call completed call_id=call-008" },
+    { "offsetMs": 10573, "line": "2030-01-01T00:00:10.573Z INFO session_loop{thread_id=thread-demo}:turn{turn.id=turn-001}: codex_core::stream_events_utils: ToolCall: exec const r = await tools.exec_command({\"cmd\":\"nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p'\",\"workdir\":\"/Users/demo/project\"}); text(r.output);" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:doc-sync": "node ./scripts/check-doc-sync.mjs",
     "smoke:desktop-distribution": "node ./scripts/desktop-distribution-smoke.mjs",
     "smoke:llm": "bash ./scripts/smoke-llm.sh",
+    "eval:phase-b": "pnpm -C apps/server exec tsx ../../scripts/run-phase-b-evaluation.mts",
     "verify:apple-signing:detect": "node ./scripts/verify-apple-signing-secrets.mjs --mode detect",
     "verify:apple-signing": "node ./scripts/verify-apple-signing-secrets.mjs --mode require",
     "verify:desktop-bundle-artifacts": "node ./scripts/verify-desktop-bundle-artifacts.mjs",

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  comparePhaseBEventTypes,
   replayPhaseBFixture,
   type PhaseBReplayFixture,
   type PhaseBReplayResult,
@@ -26,6 +27,7 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     ["glossaryNotes", baseline.metrics.glossaryNotes, candidate.metrics.glossaryNotes],
     ["exactNarrationRepeats", baseline.metrics.exactNarrationRepeats, candidate.metrics.exactNarrationRepeats],
   ];
+  const eventTypeRows = comparePhaseBEventTypes(baseline.metrics, candidate.metrics);
   return [
     "# Phase B fixture replay report",
     "",
@@ -36,6 +38,14 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     "| metric | baseline | candidate |",
     "|---|---:|---:|",
     ...rows.map(([name, before, after]) => `| ${name} | ${before} | ${after} |`),
+    "",
+    "## Event classifications",
+    "",
+    "| event type | baseline | candidate |",
+    "|---|---:|---:|",
+    ...eventTypeRows.map(({ eventType, baseline: before, candidate: after }) =>
+      `| ${eventType} | ${before} | ${after} |`
+    ),
     "",
   ].join("\n");
 }

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  replayPhaseBFixture,
+  type PhaseBReplayFixture,
+  type PhaseBReplayResult,
+} from "../apps/server/src/evaluation/phase-b-replay.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..");
+const fixturePath = path.join(repoRoot, "apps/server/test/fixtures/phase-b-codex-session.json");
+const baselinePath = path.join(repoRoot, "apps/server/test/fixtures/phase-b-codex-session.expected.json");
+
+function getArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayResult, matches: boolean): string {
+  const rows = [
+    ["events", baseline.metrics.events, candidate.metrics.events],
+    ["commentaries", baseline.metrics.commentaries, candidate.metrics.commentaries],
+    ["suppressed", baseline.metrics.suppressed, candidate.metrics.suppressed],
+    ["glossaryNotes", baseline.metrics.glossaryNotes, candidate.metrics.glossaryNotes],
+    ["exactNarrationRepeats", baseline.metrics.exactNarrationRepeats, candidate.metrics.exactNarrationRepeats],
+  ];
+  return [
+    "# Phase B fixture replay report",
+    "",
+    `- fixture: \`${candidate.fixtureId}\``,
+    `- snapshot: ${matches ? "MATCH" : "DIFF"}`,
+    "- scope: 28 sanitized lines / 5 extracted events",
+    "",
+    "| metric | baseline | candidate |",
+    "|---|---:|---:|",
+    ...rows.map(([name, before, after]) => `| ${name} | ${before} | ${after} |`),
+    "",
+  ].join("\n");
+}
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, "utf8")) as PhaseBReplayFixture;
+const candidate = await replayPhaseBFixture(fixture);
+
+if (process.argv.includes("--update-baseline")) {
+  await fs.writeFile(baselinePath, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
+  console.log(`Updated baseline: ${baselinePath}`);
+  process.exit(0);
+}
+
+const baseline = JSON.parse(await fs.readFile(baselinePath, "utf8")) as PhaseBReplayResult;
+const matches = JSON.stringify(baseline) === JSON.stringify(candidate);
+const outputDir = path.resolve(getArg("--output-dir") ?? path.join(os.tmpdir(), "cli-commentator-phase-b-eval"));
+await fs.mkdir(outputDir, { recursive: true });
+const candidatePath = path.join(outputDir, "candidate.json");
+const reportPath = path.join(outputDir, "report.md");
+await fs.writeFile(candidatePath, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
+await fs.writeFile(reportPath, markdownReport(baseline, candidate, matches), "utf8");
+
+console.log(`Candidate: ${candidatePath}`);
+console.log(`Report: ${reportPath}`);
+console.log(`Snapshot: ${matches ? "MATCH" : "DIFF"}`);
+if (!matches) process.exitCode = 1;


### PR DESCRIPTION
## 何をしたか

Issue #327 の最小構成として、サニタイズ済み28行fixtureを同じserver処理へ再生し、5イベントの event / commentary / 抑止結果をbefore/after比較できるハーネスを追加しました。

Closes #327

## 変更点

- 合成ID・合成パス・合成日時のみを含む28行fixtureと基準スナップショットを追加
- pnpm eval:phase-b で再生、JSON収集、Markdown比較レポート出力を一括実行
- raw評価ファイル用 evaluation/ をgitignoreへ追加。分類修正・文脈モデル・実音声評価は未変更

## 確認してほしいこと

- 判断: 5イベント再生とスナップショット比較の最小構成として承認可能か
- リスク: 低。評価ハーネスとfixture追加が中心で、実行時の通常server挙動は変更なし
- Todoist/gate: Issue #327 / gate/human

## 検証

- pnpm -C apps/server build
- pnpm -C apps/server exec vitest run（41 files / 377 tests）
- pnpm -C apps/web test（9 files / 72 tests）
- pnpm -C apps/web build
- pnpm check:doc-sync
- pnpm eval:phase-b（Snapshot: MATCH）