### PR TITLE
fix: improve Codex event classification accuracy

### DIFF
--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -126,6 +126,53 @@ describe("extractEvents fixtures", () => {
     expect(events).toEqual([]);
   });
 
+  it.each([
+    "ToolCall: wait",
+    'ToolCall: wait {"cell_id":"cell-demo","yield_time_ms":1000}',
+    'ToolCall: tools.wait {"cell_id":"cell-demo"}',
+  ])("suppresses Codex wait polling: %s", (line) => {
+    expect(extractEvents(line, "codex")).toEqual([]);
+  });
+
+  it("keeps ordinary Codex tool calls after suppressing wait", () => {
+    expect(extractEvents('ToolCall: read_mcp_resource {"server":"demo","uri":"demo://resource"}', "codex"))
+      .toMatchObject([{ type: "read", summary: "ファイルを読み込んでいる" }]);
+  });
+
+  it.each([
+    "nl -ba apps/server/src/commentary.test.ts",
+    "sed -n '1,80p' apps/server/src/commentary.test.ts",
+    "cat apps/server/src/__tests__/extract.test.ts",
+    "head -n 20 apps/server/src/__tests__/extract.test.ts",
+  ])("classifies test-file reads as reads: %s", (cmd) => {
+    const events = extractEvents(`ToolCall: exec_command {"cmd":${JSON.stringify(cmd)}}`, "codex");
+    expect(events).toMatchObject([{ type: "read", summary: "ファイルを読み込んでいる" }]);
+  });
+
+  it.each([
+    "rg -n '__tests__' apps/server/src",
+    "grep -R '__tests__' apps/server/src",
+  ])("does not classify searches for test paths as test runs: %s", (cmd) => {
+    const events = extractEvents(`ToolCall: exec_command {"cmd":${JSON.stringify(cmd)}}`, "codex");
+    expect(events).toMatchObject([{ type: "search" }]);
+  });
+
+  it.each([
+    "pnpm -C apps/server test",
+    "pnpm -C apps/server exec vitest run",
+    "npx jest --runInBand",
+    "playwright test",
+    "playwright test --grep smoke",
+  ])("keeps actual test executions classified as tests: %s", (cmd) => {
+    const events = extractEvents(`ToolCall: exec_command {"cmd":${JSON.stringify(cmd)}}`, "codex");
+    expect(events).toMatchObject([{ type: "test", summary: "テスト/型チェックを実行している" }]);
+  });
+
+  it("does not confuse the shell test builtin with a test runner", () => {
+    const events = extractEvents('ToolCall: exec_command {"cmd":"test -f package.json"}', "codex");
+    expect(events).toMatchObject([{ type: "stdout", summary: "コマンドを実行している" }]);
+  });
+
   it("does not treat an empty failed-id field as an error", () => {
     expect(extractEvents("failed_remote_plugin_ids=[]", "codex")).toEqual([]);
   });

--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -160,6 +160,10 @@ describe("extractEvents fixtures", () => {
   it.each([
     "pnpm -C apps/server test",
     "pnpm -C apps/server exec vitest run",
+    "npm --prefix apps/server test",
+    "npm --workspace web test",
+    "yarn --cwd apps/server test",
+    "yarn workspace server test",
     "npx jest --runInBand",
     "playwright test",
     "playwright test --grep smoke",

--- a/apps/server/src/command-analysis.test.ts
+++ b/apps/server/src/command-analysis.test.ts
@@ -36,9 +36,18 @@ describe("shell command analysis", () => {
     ["rg __tests__ src", false],
     ["test -f package.json", false],
     ["pnpm -C apps/server test", true],
+    ["pnpm --filter server test", true],
     ["pnpm exec vitest run", true],
     ["npm run test:unit", true],
+    ["npm --prefix apps/server test", true],
+    ["npm --workspace web test", true],
+    ["npm -w web run test:unit", true],
     ["yarn jest", true],
+    ["yarn --cwd apps/server test", true],
+    ["yarn workspace server test", true],
+    ["yarn workspace server run test:unit", true],
+    ["npm --prefix test-fixtures run build", false],
+    ["yarn workspace test-utils build", false],
     ["playwright test", true],
   ])("detects only executable test commands: %s", (command, expected) => {
     expect(isTestExecution(`⏺ Bash(${command})`)).toBe(expected);

--- a/apps/server/src/command-analysis.test.ts
+++ b/apps/server/src/command-analysis.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { extractSearchPattern, isSearchExecution, isTestExecution, tokenizeShellCommand } from "./command-analysis.js";
+import { getGlossaryNotes } from "./commentary/glossary.js";
+
+describe("shell command analysis", () => {
+  it("tokenizes quoted shell operators without evaluating the command", () => {
+    expect(tokenizeShellCommand('rg -n "alpha|beta" src && git status')).toEqual([
+      "rg", "-n", "alpha|beta", "src", "&&", "git", "status",
+    ]);
+    expect(tokenizeShellCommand("rg 'unterminated")).toBeNull();
+  });
+
+  it.each([
+    ['rg -n "needle" src', "needle"],
+    ['rg -n -g "*.ts" "needle" apps/server/src', "needle"],
+    ['rg --glob="*.ts" -- "-literal" apps/server/src', "-literal"],
+    ["grep -R -n 'legacy value' src", "legacy value"],
+    ["grep --include='*.ts' -e 'named export' src", "named export"],
+    ["git status && rg -n 'representative search' src", "representative search"],
+  ])("extracts the structural rg/grep pattern from %s", (command, expected) => {
+    expect(extractSearchPattern(command)).toBe(expected);
+  });
+
+  it.each([
+    "rg --mystery value src",
+    "grep -f patterns.txt src",
+    "rg -g '*.ts'",
+    "rg 'unterminated",
+    "echo rg needle",
+  ])("omits uncertain search patterns from %s", (command) => {
+    expect(extractSearchPattern(command)).toBeNull();
+  });
+
+  it.each([
+    ["nl -ba src/commentary.test.ts", false],
+    ["rg __tests__ src", false],
+    ["test -f package.json", false],
+    ["pnpm -C apps/server test", true],
+    ["pnpm exec vitest run", true],
+    ["npm run test:unit", true],
+    ["yarn jest", true],
+    ["playwright test", true],
+  ])("detects only executable test commands: %s", (command, expected) => {
+    expect(isTestExecution(`⏺ Bash(${command})`)).toBe(expected);
+  });
+
+  it("distinguishes a search command from a test runner's grep option", () => {
+    expect(isSearchExecution("rg -n TODO src")).toBe(true);
+    expect(isSearchExecution("playwright test --grep smoke")).toBe(false);
+  });
+});
+
+describe("representative glossary notes", () => {
+  it("ignores tool names that appear only in paths or unrelated arguments", () => {
+    expect(getGlossaryNotes("⏺ Bash(cat /tmp/git/pnpm-notes.txt)", "stdout")).toEqual([]);
+    expect(getGlossaryNotes('⏺ Grep(grep -n "git" apps/pnpm/src)', "search")).toEqual([]);
+  });
+
+  it.each([
+    ["⏺ Bash(git status -sb)", "git", "補足: git は変更履歴を管理する仕組み"],
+    ["pnpm add -D vitest", "install", "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う"],
+    ["rg -n TODO src", "search", "補足: rg はプロジェクト全体を高速検索するコマンド"],
+    ["pnpm exec vitest run", "test", "補足: Vitest/Jest は自動テストを走らせる仕組み"],
+    ["Update src/index.ts for node-pty websocket reconnect", "write", "補足: pty は CLI を仮想端末として包んで動かす仕組み"],
+  ] as const)("keeps one note for the representative operation in %s", (detail, type, expected) => {
+    expect(getGlossaryNotes(detail, type)).toEqual([expected]);
+  });
+
+  it("emits at most one glossary note", () => {
+    expect(getGlossaryNotes("gh pr checks 328 && git status", "github")).toEqual([
+      "補足: gh は GitHub を操作する公式CLI",
+    ]);
+  });
+});

--- a/apps/server/src/command-analysis.ts
+++ b/apps/server/src/command-analysis.ts
@@ -99,8 +99,14 @@ function executableIndex(segment: string[]): number {
   return index;
 }
 
-function skipPackageManagerOptions(tokens: string[], start: number): number {
-  const valueOptions = new Set(["-C", "--dir", "--filter", "--workspace-concurrency", "--config"]);
+const PACKAGE_MANAGER_VALUE_OPTIONS: Record<string, Set<string>> = {
+  pnpm: new Set(["-C", "--dir", "--filter", "--workspace-concurrency", "--config"]),
+  npm: new Set(["-w", "--workspace", "--prefix"]),
+  yarn: new Set(["--cwd"]),
+};
+
+function skipPackageManagerOptions(manager: string, tokens: string[], start: number): number {
+  const valueOptions = PACKAGE_MANAGER_VALUE_OPTIONS[manager] ?? new Set<string>();
   let index = start;
   while (index < tokens.length && tokens[index].startsWith("-")) {
     const option = tokens[index];
@@ -119,8 +125,13 @@ function isRunnerInvocation(tokens: string[], start: number): boolean {
 
 function isPackageTestInvocation(segment: string[], start: number): boolean {
   const manager = commandName(segment[start] ?? "");
-  let index = skipPackageManagerOptions(segment, start + 1);
-  const action = segment[index]?.toLowerCase();
+  let index = skipPackageManagerOptions(manager, segment, start + 1);
+  let action = segment[index]?.toLowerCase();
+
+  if (manager === "yarn" && action === "workspace") {
+    index += 2;
+    action = segment[index]?.toLowerCase();
+  }
 
   if (action === "test" || action?.startsWith("test:")) return true;
   if (action === "run") return /^test(?::|$)/i.test(segment[index + 1] ?? "");

--- a/apps/server/src/command-analysis.ts
+++ b/apps/server/src/command-analysis.ts
@@ -1,0 +1,239 @@
+import type { EventType } from "./types.js";
+
+const SHELL_OPERATORS = new Set(["&&", "||", ";", "|"]);
+
+function commandName(value: string): string {
+  return value.replace(/\\/g, "/").split("/").at(-1)?.toLowerCase() ?? value.toLowerCase();
+}
+
+export function unwrapCommandDetail(detail: string): string {
+  const wrapped = detail.match(/^[⏺•]\s*(?:Bash|Grep|Glob)\((.*)\)$/s);
+  return (wrapped?.[1] ?? detail).trim().replace(/^>\s+/, "");
+}
+
+export function tokenizeShellCommand(command: string): string[] | null {
+  const tokens: string[] = [];
+  let token = "";
+  let quote: "'" | "\"" | null = null;
+  let escaped = false;
+
+  const pushToken = () => {
+    if (token) tokens.push(token);
+    token = "";
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+
+    if (escaped) {
+      token += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      else token += char;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      pushToken();
+      continue;
+    }
+    const pair = command.slice(index, index + 2);
+    if (pair === "&&" || pair === "||") {
+      pushToken();
+      tokens.push(pair);
+      index += 1;
+      continue;
+    }
+    if (char === ";" || char === "|") {
+      pushToken();
+      tokens.push(char);
+      continue;
+    }
+    token += char;
+  }
+
+  if (quote || escaped) return null;
+  pushToken();
+  return tokens;
+}
+
+function commandSegments(command: string): string[][] {
+  const tokens = tokenizeShellCommand(command);
+  if (!tokens) return [];
+
+  const segments: string[][] = [[]];
+  for (const token of tokens) {
+    if (SHELL_OPERATORS.has(token)) segments.push([]);
+    else segments.at(-1)?.push(token);
+  }
+  return segments.filter((segment) => segment.length > 0);
+}
+
+function commandInvocations(command: string): Array<{ segment: string[]; start: number; executable: string }> {
+  return commandSegments(command).map((segment) => {
+    const start = executableIndex(segment);
+    return { segment, start, executable: commandName(segment[start] ?? "") };
+  });
+}
+
+function executableIndex(segment: string[]): number {
+  let index = 0;
+  while (index < segment.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(segment[index])) index += 1;
+  if (commandName(segment[index] ?? "") === "env") {
+    index += 1;
+    while (index < segment.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(segment[index]) || segment[index].startsWith("-"))) {
+      index += 1;
+    }
+  }
+  if (["command", "sudo"].includes(commandName(segment[index] ?? ""))) index += 1;
+  return index;
+}
+
+function skipPackageManagerOptions(tokens: string[], start: number): number {
+  const valueOptions = new Set(["-C", "--dir", "--filter", "--workspace-concurrency", "--config"]);
+  let index = start;
+  while (index < tokens.length && tokens[index].startsWith("-")) {
+    const option = tokens[index];
+    index += 1;
+    if (valueOptions.has(option) && index < tokens.length) index += 1;
+  }
+  return index;
+}
+
+function isRunnerInvocation(tokens: string[], start: number): boolean {
+  const executable = commandName(tokens[start] ?? "");
+  if (["vitest", "jest", "tsc", "typecheck"].includes(executable)) return true;
+  if (executable === "playwright") return tokens[start + 1] === "test";
+  return false;
+}
+
+function isPackageTestInvocation(segment: string[], start: number): boolean {
+  const manager = commandName(segment[start] ?? "");
+  let index = skipPackageManagerOptions(segment, start + 1);
+  const action = segment[index]?.toLowerCase();
+
+  if (action === "test" || action?.startsWith("test:")) return true;
+  if (action === "run") return /^test(?::|$)/i.test(segment[index + 1] ?? "");
+  if (manager === "npx") return isRunnerInvocation(segment, index);
+  if (action === "exec") {
+    index += 1;
+    while (segment[index]?.startsWith("-")) index += 1;
+    return isRunnerInvocation(segment, index);
+  }
+  return manager === "yarn" && isRunnerInvocation(segment, index);
+}
+
+export function isTestExecution(detail: string): boolean {
+  const command = unwrapCommandDetail(detail);
+  return commandInvocations(command).some(({ segment, start, executable }) => {
+    if (isRunnerInvocation(segment, start)) return true;
+    if (["pnpm", "npm", "yarn", "npx"].includes(executable)) {
+      return isPackageTestInvocation(segment, start);
+    }
+    return false;
+  });
+}
+
+export function isSearchExecution(command: string): boolean {
+  return commandInvocations(unwrapCommandDetail(command))
+    .some(({ executable }) => executable === "rg" || executable === "grep");
+}
+
+export function isFileListExecution(command: string): boolean {
+  return commandInvocations(unwrapCommandDetail(command)).some(({ segment, start, executable }) =>
+    executable === "find" || executable === "fd" || (executable === "rg" && segment.slice(start + 1).includes("--files"))
+  );
+}
+
+const SEARCH_VALUE_OPTIONS = new Set([
+  "-A", "-B", "-C", "-g", "-j", "-m", "-t", "-T",
+  "--after-context", "--before-context", "--context", "--encoding", "--engine",
+  "--exclude", "--exclude-dir", "--glob", "--include", "--max-count", "--max-depth",
+  "--max-filesize", "--sort", "--sortr", "--threads", "--type", "--type-not",
+]);
+
+const SEARCH_BOOLEAN_OPTIONS = new Set([
+  "-F", "-H", "-I", "-L", "-N", "-P", "-R", "-S", "-U", "-V", "-b", "-c", "-h",
+  "-i", "-l", "-n", "-o", "-q", "-s", "-u", "-v", "-w", "-x",
+  "--case-sensitive", "--count", "--files-with-matches", "--fixed-strings", "--heading",
+  "--hidden", "--ignore-case", "--invert-match", "--line-number", "--no-heading", "--no-ignore",
+  "--only-matching", "--quiet", "--recursive", "--smart-case", "--text", "--version", "--word-regexp",
+]);
+
+function searchPatternFromSegment(segment: string[], executableAt: number): string | null {
+  let index = executableAt + 1;
+  while (index < segment.length) {
+    const token = segment[index];
+    if (token === "--") return segment[index + 1] || null;
+    if (token === "-e" || token === "--regexp") return segment[index + 1] || null;
+    if (token.startsWith("--regexp=")) return token.slice("--regexp=".length) || null;
+    if (token === "-f" || token === "--file" || token.startsWith("--file=")) return null;
+    if (SEARCH_VALUE_OPTIONS.has(token)) {
+      index += 2;
+      continue;
+    }
+    if ([...SEARCH_VALUE_OPTIONS].some((option) => option.startsWith("--") && token.startsWith(`${option}=`))) {
+      index += 1;
+      continue;
+    }
+    if (/^-g.+/.test(token) || /^-[ABCjmtT]\d?.+/.test(token)) {
+      index += 1;
+      continue;
+    }
+    if (SEARCH_BOOLEAN_OPTIONS.has(token) || (/^-[A-Za-z]+$/.test(token) && [...token.slice(1)].every((flag) => SEARCH_BOOLEAN_OPTIONS.has(`-${flag}`)))) {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return null;
+    return token;
+  }
+  return null;
+}
+
+export function extractSearchPattern(detail: string): string | null {
+  const command = unwrapCommandDetail(detail);
+  for (const { segment, start, executable } of commandInvocations(command)) {
+    if (["rg", "grep"].includes(executable)) {
+      return searchPatternFromSegment(segment, start);
+    }
+  }
+  return null;
+}
+
+export function representativeGlossaryTerm(detail: string, eventType?: EventType): string | null {
+  const command = unwrapCommandDetail(detail);
+  const invocations = commandInvocations(command);
+
+  if (eventType === "search") {
+    return invocations.find(({ executable }) => executable === "rg") ? "rg" : null;
+  }
+  if (eventType === "git") return invocations.some(({ executable }) => executable === "git") ? "git" : null;
+  if (eventType === "github") return invocations.some(({ executable }) => executable === "gh") ? "gh" : null;
+  if (eventType === "test") {
+    for (const { segment, start, executable } of invocations) {
+      if (["vitest", "jest", "playwright", "tsc", "typecheck"].includes(executable)) return executable;
+      if (["pnpm", "npm", "yarn", "npx"].includes(executable)) {
+        const runner = segment.find((token) => ["vitest", "jest", "playwright", "tsc", "typecheck"].includes(commandName(token)));
+        return runner ? commandName(runner) : executable === "npx" ? null : executable;
+      }
+    }
+  }
+  if (["install", "build", "lint", "server"].includes(eventType ?? "")) {
+    return invocations.find(({ executable }) => ["pnpm", "npm", "yarn"].includes(executable))?.executable ?? null;
+  }
+  if (eventType === "error" && /\b(?:tsc|typecheck|TS\d{4,5})\b/i.test(detail)) return "tsc";
+
+  if (/^[⏺•]\s*(?:Bash|Grep|Glob)\(/.test(detail)) return null;
+  const contextualTokens = tokenizeShellCommand(detail) ?? [];
+  return contextualTokens.find((token) => !token.includes("/") && /^(?:rg|tsc|typecheck|pnpm|npm|yarn|vite|tsx|node-pty|pty|ws|websocket|playwright|vitest|jest|gh|git)$/i.test(token))?.toLowerCase() ?? null;
+}

--- a/apps/server/src/commentary/bash-meaning.ts
+++ b/apps/server/src/commentary/bash-meaning.ts
@@ -1,4 +1,5 @@
 import type { Style } from "../types.js";
+import { extractSearchPattern } from "../command-analysis.js";
 
 export function say(style: Style, text: Record<Style, string>): string {
   return text[style];
@@ -26,14 +27,7 @@ export function extractWriteTarget(detail?: string): string | null {
 
 export function extractSearchTerm(detail?: string): string | null {
   if (!detail) return null;
-  const quoted =
-    detail.match(/"(.*?)"/)?.[1] ??
-    detail.match(/'(.*?)'/)?.[1] ??
-    detail.match(/`(.*?)`/)?.[1];
-  if (quoted) return quoted.trim();
-
-  const grepMatch = detail.match(/\b(?:rg|grep)\b(?:\s+-\S+|\s+--\S+)*\s+([^\s][^|&;]*)/i);
-  return grepMatch ? grepMatch[1].trim() : null;
+  return extractSearchPattern(detail);
 }
 
 export function detailCommand(detail?: string): string {

--- a/apps/server/src/commentary/glossary.ts
+++ b/apps/server/src/commentary/glossary.ts
@@ -1,3 +1,6 @@
+import type { EventType } from "../types.js";
+import { representativeGlossaryTerm } from "../command-analysis.js";
+
 const GLOSSARY: Array<{ re: RegExp; note: string }> = [
   { re: /\brg\b/, note: "補足: rg はプロジェクト全体を高速検索するコマンド" },
   { re: /\btsc\b|\btypecheck\b/i, note: "補足: tsc/typecheck は型の整合性を自動確認するチェック" },
@@ -12,7 +15,10 @@ const GLOSSARY: Array<{ re: RegExp; note: string }> = [
   { re: /\bgit\b/i, note: "補足: git は変更履歴を管理する仕組み" }
 ];
 
-export function getGlossaryNotes(detail?: string): string[] {
+export function getGlossaryNotes(detail?: string, eventType?: EventType): string[] {
   if (!detail) return [];
-  return Array.from(new Set(GLOSSARY.filter((g) => g.re.test(detail)).map((g) => g.note)));
+  const term = representativeGlossaryTerm(detail, eventType);
+  if (!term) return [];
+  const match = GLOSSARY.find((entry) => entry.re.test(term));
+  return match ? [match.note] : [];
 }

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -91,7 +91,7 @@ export function commentByRules(ev: Event, style: Style): CommentaryPayload {
   // Keep the beginner explanation useful as a supervision layer regardless of
   // the selected entertainment/narration style.
   const beginner = stripMemoPrefix(beginnerOneLine(ev, "standard"));
-  const glossaryNotes = getGlossaryNotes(ev.detail);
+  const glossaryNotes = getGlossaryNotes(ev.detail, ev.type);
   const spotlight = detailSpotlight(ev, style);
 
   const core = COMMENTERS[style](ev);

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -2,6 +2,7 @@ import type { Event } from "./types.js";
 import { rulesForLine } from "./rulesets/index.js";
 import { isCodexProgressNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
+import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
 
 // Remove ANSI/VT control sequences so TUI apps like Claude Code still match rules.
 const ANSI_ESCAPE_RE =
@@ -302,15 +303,15 @@ function classifyExecCommand(cmd: string): string {
   const compact = cmd.trim();
   if (!compact) return "⏺ Bash(exec_command)";
 
-  if (/\b(rg\s+--files|find|fd)\b/i.test(compact)) {
+  if (isFileListExecution(compact)) {
     return `⏺ Glob(${compact})`;
   }
 
-  if (/\b(rg|grep)\b/i.test(compact)) {
+  if (isSearchExecution(compact)) {
     return `⏺ Grep(${compact})`;
   }
 
-  if (/^\s*(cat|sed|head|tail|less|more)\b/i.test(compact)) {
+  if (/^\s*(cat|sed|head|tail|less|more|nl)\b/i.test(compact)) {
     return `⏺ Read(${compact})`;
   }
 
@@ -335,6 +336,7 @@ function canonicalizeCodexToolCall(rawLine: string): string | null {
     }
     case "apply_patch":
       return "apply_patch";
+    case "wait":
     case "write_stdin":
       return "";
     case "list_mcp_resources":
@@ -431,7 +433,7 @@ export function extractEvents(chunk: string, sourceEnv: string | undefined = pro
     if (!line) continue;
 
     const rules = rulesForLine(sourceLine, sourceEnv);
-    const hit = rules.find((rule) => rule.re.test(line));
+    const hit = rules.find((rule) => rule.match ? rule.match(line) : rule.re.test(line));
     if (hit) events.push({ ts, type: hit.type, summary: hit.summary, detail: line });
     else events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
   }

--- a/apps/server/src/rulesets/codex.ts
+++ b/apps/server/src/rulesets/codex.ts
@@ -1,4 +1,5 @@
 import type { RuleSet } from "./types.js";
+import { isSearchExecution, isTestExecution } from "../command-analysis.js";
 
 export const codexRuleset: RuleSet = {
   id: "codex",
@@ -14,8 +15,8 @@ export const codexRuleset: RuleSet = {
     { id: "codex.approval.ask", priority: 65, re: /would you like to run the following command/i, type: "stdout", summary: "コマンド実行の確認待ち" },
     { id: "codex.approval.ok", priority: 64, re: /you approved .* to run/i, type: "stdout", summary: "コマンド実行が承認された" },
 
-    { id: "codex.search", priority: 60, re: /\b(rg|grep)\b/i, type: "search", summary: "該当箇所を検索している" },
-    { id: "codex.test", priority: 50, re: /\b(playwright|vitest|jest|test|typecheck|tsc)\b/i, type: "test", summary: "テスト/型チェックを実行している" },
+    { id: "codex.search", priority: 60, re: /\b(rg|grep)\b/i, match: isSearchExecution, type: "search", summary: "該当箇所を検索している" },
+    { id: "codex.test", priority: 50, re: /\b(playwright|vitest|jest|typecheck|tsc)\b/i, match: isTestExecution, type: "test", summary: "テスト/型チェックを実行している" },
 
     { id: "codex.github", priority: 40, re: /\bgh\s+(issue|pr|repo)\b/i, type: "github", summary: "GitHub操作をしている" },
     { id: "codex.git", priority: 30, re: /\bgit\s+(status|add|commit|push|pull|checkout|switch|merge|rebase)\b/i, type: "git", summary: "Git操作をしている" },

--- a/apps/server/src/rulesets/types.ts
+++ b/apps/server/src/rulesets/types.ts
@@ -6,6 +6,7 @@ export type Rule = {
   id: string;
   priority: number;
   re: RegExp;
+  match?: (line: string) => boolean;
   type: EventType;
   summary: string;
 };

--- a/apps/server/src/tests/__snapshots__/commentary.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/commentary.test.ts.snap
@@ -11,7 +11,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
           "glossaryNotes": [
             "補足: rg はプロジェクト全体を高速検索するコマンド",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -27,7 +26,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
           "glossaryNotes": [
             "補足: rg はプロジェクト全体を高速検索するコマンド",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -43,7 +41,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "「TODO」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
           "glossaryNotes": [
             "補足: rg はプロジェクト全体を高速検索するコマンド",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -65,7 +62,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "問題を直すために内容を更新しています。",
           "glossaryNotes": [
             "補足: pty は CLI を仮想端末として包んで動かす仕組み",
-            "補足: WebSocket は画面とサーバーをつなぐ常時接続",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -81,7 +77,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "問題を直すために内容を更新しています。",
           "glossaryNotes": [
             "補足: pty は CLI を仮想端末として包んで動かす仕組み",
-            "補足: WebSocket は画面とサーバーをつなぐ常時接続",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -97,7 +92,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "問題を直すために内容を更新しています。",
           "glossaryNotes": [
             "補足: pty は CLI を仮想端末として包んで動かす仕組み",
-            "補足: WebSocket は画面とサーバーをつなぐ常時接続",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -119,7 +113,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしています。",
           "glossaryNotes": [
             "補足: gh は GitHub を操作する公式CLI",
-            "補足: git は変更履歴を管理する仕組み",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -135,7 +128,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしています。",
           "glossaryNotes": [
             "補足: gh は GitHub を操作する公式CLI",
-            "補足: git は変更履歴を管理する仕組み",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -151,7 +143,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "PRの自動チェック結果を見て、公開前の安全確認をしています。",
           "glossaryNotes": [
             "補足: gh は GitHub を操作する公式CLI",
-            "補足: git は変更履歴を管理する仕組み",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -589,7 +580,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
         "commentary": {
           "explanation": "変更の副作用がないか、自動テストで機械的に確認しています。",
           "glossaryNotes": [
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
             "補足: Vitest/Jest は自動テストを走らせる仕組み",
           ],
           "meta": {
@@ -605,7 +595,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
         "commentary": {
           "explanation": "変更の副作用がないか、自動テストで機械的に確認しています。",
           "glossaryNotes": [
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
             "補足: Vitest/Jest は自動テストを走らせる仕組み",
           ],
           "meta": {
@@ -621,7 +610,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
         "commentary": {
           "explanation": "変更の副作用がないか、自動テストで機械的に確認しています。",
           "glossaryNotes": [
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
             "補足: Vitest/Jest は自動テストを走らせる仕組み",
           ],
           "meta": {
@@ -644,7 +632,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "プログラム同士のつながりが噛み合っているか、型ルールで機械確認しています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -660,7 +647,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "プログラム同士のつながりが噛み合っているか、型ルールで機械確認しています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",
@@ -676,7 +662,6 @@ exports[`commentary quality fixtures > renders styles consistently 1`] = `
           "explanation": "プログラム同士のつながりが噛み合っているか、型ルールで機械確認しています。",
           "glossaryNotes": [
             "補足: tsc/typecheck は型の整合性を自動確認するチェック",
-            "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
           ],
           "meta": {
             "explanationProvider": "rules",

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -22,11 +22,8 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 400,
         "type": "search",
       },
-      "explanation": "「name」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
-      "glossaryNotes": [
-        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
-        "補足: git は変更履歴を管理する仕組み",
-      ],
+      "explanation": "「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
         "explanationProvider": "rules",
@@ -38,23 +35,23 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
     },
     {
       "ev": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress",
-        "summary": "コマンドを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 3218,
-        "type": "stdout",
+        "type": "read",
       },
       "kind": "event",
     },
     {
       "ev": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress",
-        "summary": "コマンドを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 3218,
-        "type": "stdout",
+        "type": "read",
       },
-      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -62,7 +59,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "narration": "ファイル読んで状況確認してるで。",
       "ts": 3218,
     },
     {
@@ -86,7 +83,6 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
         "補足: rg はプロジェクト全体を高速検索するコマンド",
-        "補足: tsx は TypeScript をそのまま実行する仕組み",
       ],
       "kind": "commentary",
       "meta": {
@@ -99,33 +95,33 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
     },
     {
       "ev": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
         "priority": "progress",
-        "summary": "テスト/型チェックを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 8734,
-        "type": "test",
+        "type": "read",
       },
       "kind": "event",
     },
     {
       "ev": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress",
-        "summary": "コマンドを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 10573,
-        "type": "stdout",
+        "type": "read",
       },
       "kind": "event",
     },
     {
       "ev": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress",
-        "summary": "コマンドを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 10573,
-        "type": "stdout",
+        "type": "read",
       },
-      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -133,7 +129,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
+      "narration": "ファイル読んで状況確認してるで。",
       "ts": 10573,
     },
   ],
@@ -141,12 +137,11 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
     "commentaries": 4,
     "events": 5,
     "eventsByType": {
+      "read": 3,
       "search": 2,
-      "stdout": 2,
-      "test": 1,
     },
     "exactNarrationRepeats": 2,
-    "glossaryNotes": 4,
+    "glossaryNotes": 1,
     "suppressed": 1,
   },
   "source": "codex",
@@ -154,11 +149,11 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
   "suppressions": [
     {
       "event": {
-        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "detail": "⏺ Read(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
         "priority": "progress",
-        "summary": "テスト/型チェックを実行している",
+        "summary": "ファイルを読み込んでいる",
         "ts": 8734,
-        "type": "test",
+        "type": "read",
       },
       "offsetMs": 8734,
       "reason": "progress_interval",

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -31,7 +31,8 @@ describe("Phase B evaluation replay", () => {
       events: 5,
       commentaries: 4,
       suppressed: 1,
-      eventsByType: { search: 2, stdout: 2, test: 1 },
+      eventsByType: { search: 2, read: 3 },
+      glossaryNotes: 1,
     });
     expect(result).toMatchSnapshot();
   });

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -28,11 +28,8 @@
         "priority": "progress"
       },
       "narration": "原因っぽいとこ探してるで。",
-      "explanation": "「name」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
-      "glossaryNotes": [
-        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う",
-        "補足: git は変更履歴を管理する仕組み"
-      ],
+      "explanation": "「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
         "explanationProvider": "rules",
@@ -43,9 +40,9 @@
       "kind": "event",
       "ev": {
         "ts": 3218,
-        "type": "stdout",
-        "summary": "コマンドを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress"
       }
     },
@@ -54,13 +51,13 @@
       "ts": 3218,
       "ev": {
         "ts": 3218,
-        "type": "stdout",
-        "summary": "コマンドを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
-      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "narration": "ファイル読んで状況確認してるで。",
+      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -91,8 +88,7 @@
       "narration": "原因っぽいとこ探してるで。",
       "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
-        "補足: rg はプロジェクト全体を高速検索するコマンド",
-        "補足: tsx は TypeScript をそのまま実行する仕組み"
+        "補足: rg はプロジェクト全体を高速検索するコマンド"
       ],
       "meta": {
         "narrationProvider": "rules",
@@ -104,9 +100,9 @@
       "kind": "event",
       "ev": {
         "ts": 8734,
-        "type": "test",
-        "summary": "テスト/型チェックを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
         "priority": "progress"
       }
     },
@@ -114,9 +110,9 @@
       "kind": "event",
       "ev": {
         "ts": 10573,
-        "type": "stdout",
-        "summary": "コマンドを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress"
       }
     },
@@ -125,13 +121,13 @@
       "ts": 10573,
       "ev": {
         "ts": 10573,
-        "type": "stdout",
-        "summary": "コマンドを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "今やってるのは、ファイルの中身を直接確認する作業や。",
-      "explanation": "設定やログの実物を見て、仮説が合っているか確かめています。",
+      "narration": "ファイル読んで状況確認してるで。",
+      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -146,9 +142,9 @@
       "reason": "progress_interval",
       "event": {
         "ts": 8734,
-        "type": "test",
-        "summary": "テスト/型チェックを実行している",
-        "detail": "⏺ Bash(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
+        "type": "read",
+        "summary": "ファイルを読み込んでいる",
+        "detail": "⏺ Read(nl -ba apps/server/src/tests/commentary.test.ts | sed -n '1,160p'; nl -ba apps/server/src/tests/state-event.test.ts | sed -n '1,160p')",
         "priority": "progress"
       }
     }
@@ -159,10 +155,9 @@
     "suppressed": 1,
     "eventsByType": {
       "search": 2,
-      "stdout": 2,
-      "test": 1
+      "read": 3
     },
-    "glossaryNotes": 4,
+    "glossaryNotes": 1,
     "exactNarrationRepeats": 2
   }
 }


### PR DESCRIPTION
## 何をしたか

Codex CLI実況のPhase B P0精度改善として、待機イベントの抑止、コマンド構造に基づく分類・検索語抽出、代表操作に限定した用語補足を実装しました。

Closes #328

## 根本原因と変更点

- `wait` が `write_stdin` と同じ待機系として扱われず、汎用ToolCall実況へフォールバックしていた
- Codexのテスト判定が行全体の `test` に一致し、閲覧対象のファイル名やパスを実行コマンドと混同していた
- 検索語が最初の引用文字列から抽出され、`-g` などのオプション値を選び得た
- 用語補足がdetail全体を走査し、パスや後続コマンドの無関係語にも反応していた

小さなシェルトークナイザを追加し、実行位置・オプション・複合コマンドを評価せずに解析する純粋関数を、分類・検索語・用語補足で共有しています。

## Phase B before / after

| 指標 | before | after |
|---|---:|---:|
| search | 2 | 2 |
| read | 0 | 3 |
| stdout | 2 | 0 |
| test | 1 | 0 |
| ファイル閲覧のtest誤分類 | 1 | 0 |
| 用語補足数 | 4 | 1 |
| 完全一致する反復実況数 | 2 | 2 |

- `wait` 実況: サニタイズ済み回帰3ケースで 3 → 0（既存28行fixtureにはwaitなし）
- 検索語代表例: `name` → `"name": "cli-commentator"`
- 既存の正しい検索語 `buildSpeechText|queueSpeech|commentaryDisplayMode` は維持
- 反復実況はPhase B P2の対象なので本PRでは変更していません
- baseline更新前にMarkdown/JSONの `DIFF` を確認し、期待差分確認後にbaseline/snapshotを更新、最終 `MATCH` を確認しました

## 追加した回帰テスト

- 現行・旧形式の `ToolCall: wait` 抑止と通常ToolCallの維持
- `nl` / `sed` / `cat` / `head` によるテストファイル閲覧
- `rg` / `grep` での `__tests__` 検索
- pnpm、npm、Yarn、Vitest、Jest、Playwrightの実テスト実行とシェル `test -f` の区別
- npm `--prefix` / `--workspace`、Yarn `--cwd` / `workspace` を含むパッケージ指定付きテスト実行
- 値あり・値なしオプション、引用、`--`、複合コマンドを含む検索語テーブル
- パス中のgit/pnpm無視、代表操作の補足維持、1実況最大1補足

## 検証

- `pnpm -C apps/server test`: 43 files / 463 tests passed
- `pnpm -C apps/server build`: passed
- `pnpm -C apps/web test`: 9 files / 72 tests passed
- `pnpm -C apps/web build`: passed
- `pnpm eval:phase-b`: MATCH
- `pnpm check:doc-sync`: passed
- `git diff --check`: passed

## 確認してほしいこと

- コマンド構造の判定範囲がPhase B P0として妥当か
- 用語補足を代表操作1語へ限定した優先順位が妥当か
- `.codex/` と `evaluation/` は変更・ステージ・コミットしていません

Ready化とmergeは行わず、KUROレビュー待ちです。
