### PR TITLE
feat: add session context to commentary

### DIFF
--- a/apps/server/src/commentary/orchestrator.ts
+++ b/apps/server/src/commentary/orchestrator.ts
@@ -8,6 +8,7 @@ import { withTimeout } from "../utils/timeout.js";
 import type { ProfileLLMProviders } from "../profile/types.js";
 import { buildExplanationPrompt, buildNarrationPrompt, normalizeGeneratedCommentaryText } from "../styles/prompt.js";
 import { commentByRules, isSuppressedCommentaryEvent, withCommentaryMode } from "./rule-based.js";
+import type { SessionContextSnapshot } from "../session-context.js";
 
 const COMMENT_TIMEOUT_MS = parseInt(process.env.COMMENT_TIMEOUT_MS ?? "3000", 10);
 const adapterCache = new Map<ProviderName, LLMAdapter | null>();
@@ -96,13 +97,14 @@ async function commentInternal(
   ev: Event,
   style: Style,
   providers: ProfileLLMProviders = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  context?: SessionContextSnapshot
 ): Promise<CommentaryPayload> {
   if (isSuppressedCommentaryEvent(ev)) {
-    return commentByRules(ev, style);
+    return commentByRules(ev, style, context);
   }
 
-  const rules = commentByRules(ev, style);
+  const rules = commentByRules(ev, style, context);
   const resolvedProviders = resolveCommentaryProviders(providers);
   const narrationAdapter = getAdapter(resolvedProviders.narrationProvider);
   const explanationAdapter = getAdapter(resolvedProviders.explanationProvider);
@@ -113,7 +115,7 @@ async function commentInternal(
 
   const [narration, explanation] = await Promise.all([
     narrationAdapter
-      ? generateLLMText(narrationAdapter, buildNarrationPrompt(ev, style), signal)
+      ? generateLLMText(narrationAdapter, buildNarrationPrompt(ev, style, context), signal)
           .then((text) => ({
             text: normalizeGeneratedCommentaryText(text, "narration"),
             provider: narrationAdapter.name,
@@ -121,7 +123,7 @@ async function commentInternal(
           .catch(() => null)
       : Promise.resolve(null),
     explanationAdapter
-      ? generateLLMText(explanationAdapter, buildExplanationPrompt(ev, style), signal)
+      ? generateLLMText(explanationAdapter, buildExplanationPrompt(ev, style, context), signal)
           .then((text) => ({
             text: normalizeGeneratedCommentaryText(text, "explanation"),
             provider: explanationAdapter.name,
@@ -152,7 +154,8 @@ async function commentInternal(
 export async function comment(
   ev: Event,
   style: Style,
-  providers: ProfileLLMProviders = {}
+  providers: ProfileLLMProviders = {},
+  context?: SessionContextSnapshot
 ): Promise<CommentaryPayload> {
   const resolvedProviders = resolveCommentaryProviders(providers);
   const narrationAdapter = getAdapter(resolvedProviders.narrationProvider);
@@ -168,7 +171,7 @@ export async function comment(
 
   // ルールベースのみの場合はタイムアウト不要
   if (!narrationAdapter && !explanationAdapter) {
-    return commentByRules(ev, style);
+    return commentByRules(ev, style, context);
   }
 
   const controller = new AbortController();
@@ -176,7 +179,7 @@ export async function comment(
 
   try {
     const result = await withTimeout(
-      commentInternal(ev, style, providers, controller.signal),
+      commentInternal(ev, style, providers, controller.signal, context),
       {
         ms: COMMENT_TIMEOUT_MS,
         timeoutError: () => new CommentError("comment_timeout"),
@@ -193,6 +196,6 @@ export async function comment(
     } else {
       logComment("llm_error", duration, meta);
     }
-    return commentByRules(ev, style);
+    return commentByRules(ev, style, context);
   }
 }

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -98,7 +98,14 @@ function contextNarration(context: SessionContextSnapshot, style: Style): string
     });
   }
 
-  if (context.target && ["read", "search", "write", "test", "lint", "build"].includes(context.recentEvents.at(-1)?.type ?? "")) {
+  const currentEvent = context.recentEvents.at(-1);
+  const previousEvent = context.recentEvents.at(-2);
+  const targetChanged = currentEvent?.target !== previousEvent?.target;
+  if (
+    context.target &&
+    targetChanged &&
+    ["read", "search", "write", "test", "lint", "build"].includes(currentEvent?.type ?? "")
+  ) {
     return say(style, {
       standard: `現在の対象は${target}です。`,
       kansai: `今の対象は${target}や。`,
@@ -117,11 +124,11 @@ function contextExplanation(
 
   const phase = SESSION_PHASE_LABELS[context.phase];
   const objective = context.task.objective;
-  if (objective && (context.sequence === 1 || context.phaseChanged)) {
-    const purpose = objective.length <= 48 ? objective : `${objective.slice(0, 47).trimEnd()}…`;
-    return `目的「${purpose}」に向けた${phase}段階です。 ${beginner}`.trim();
+  if (objective && context.phaseChanged) {
+    const purpose = objective.length <= 32 ? objective : `${objective.slice(0, 31).trimEnd()}…`;
+    return `目的「${purpose}」に向けた${phase}段階です。`;
   }
-  return `現在は${phase}段階です。 ${beginner}`.trim();
+  return beginner || undefined;
 }
 
 export function commentByRules(
@@ -148,7 +155,7 @@ export function commentByRules(
   const contextual = context ? contextNarration(context, style) : "";
 
   return withCommentaryMode({
-    narration: [contextual, core, spotlight].filter(Boolean).join(" "),
+    narration: [contextual || core, spotlight].filter(Boolean).join(" "),
     explanation: contextExplanation(beginner, context),
     glossaryNotes,
     meta: {

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -6,6 +6,7 @@ import { commentZundamon } from "../styles/zundamon.js";
 import { describeBashMeaning, detailCommand, say } from "./bash-meaning.js";
 import { beginnerOneLine } from "./beginner-lines.js";
 import { getGlossaryNotes } from "./glossary.js";
+import { SESSION_PHASE_LABELS, type SessionContextSnapshot } from "../session-context.js";
 
 const COMMENTERS: Record<Style, (ev: Event) => string> = {
   standard: commentStandard,
@@ -78,7 +79,56 @@ export function withCommentaryMode(payload: CommentaryPayload): CommentaryPayloa
   };
 }
 
-export function commentByRules(ev: Event, style: Style): CommentaryPayload {
+function contextNarration(context: SessionContextSnapshot, style: Style): string {
+  const phase = SESSION_PHASE_LABELS[context.phase];
+  const target = context.target ? `「${context.target}」` : "対象";
+
+  if (context.phaseChanged) {
+    if (context.humanRequired) {
+      return say(style, {
+        standard: `${phase}段階に入り、HUMANの入力を待っています。`,
+        kansai: `${phase}段階に入って、HUMANの入力待ちや。`,
+        zundamon: `${phase}段階に入って、HUMANの入力待ちなのだ。`,
+      });
+    }
+    return say(style, {
+      standard: `${phase}段階に入り、${target}を扱っています。`,
+      kansai: `${phase}段階に入って、${target}を扱ってるで。`,
+      zundamon: `${phase}段階に入って、${target}を扱ってるのだ。`,
+    });
+  }
+
+  if (context.target && ["read", "search", "write", "test", "lint", "build"].includes(context.recentEvents.at(-1)?.type ?? "")) {
+    return say(style, {
+      standard: `現在の対象は${target}です。`,
+      kansai: `今の対象は${target}や。`,
+      zundamon: `今の対象は${target}なのだ。`,
+    });
+  }
+  return "";
+}
+
+function contextExplanation(
+  beginner: string,
+  context?: SessionContextSnapshot
+): string | undefined {
+  if (!beginner && !context) return undefined;
+  if (!context || context.phase === "unknown") return beginner || undefined;
+
+  const phase = SESSION_PHASE_LABELS[context.phase];
+  const objective = context.task.objective;
+  if (objective && (context.sequence === 1 || context.phaseChanged)) {
+    const purpose = objective.length <= 48 ? objective : `${objective.slice(0, 47).trimEnd()}…`;
+    return `目的「${purpose}」に向けた${phase}段階です。 ${beginner}`.trim();
+  }
+  return `現在は${phase}段階です。 ${beginner}`.trim();
+}
+
+export function commentByRules(
+  ev: Event,
+  style: Style,
+  context?: SessionContextSnapshot
+): CommentaryPayload {
   if (isSuppressedCommentaryEvent(ev)) {
     return withCommentaryMode({
       meta: {
@@ -95,10 +145,11 @@ export function commentByRules(ev: Event, style: Style): CommentaryPayload {
   const spotlight = detailSpotlight(ev, style);
 
   const core = COMMENTERS[style](ev);
+  const contextual = context ? contextNarration(context, style) : "";
 
   return withCommentaryMode({
-    narration: [core, spotlight].filter(Boolean).join(" "),
-    explanation: beginner || undefined,
+    narration: [contextual, core, spotlight].filter(Boolean).join(" "),
+    explanation: contextExplanation(beginner, context),
     glossaryNotes,
     meta: {
       narrationProvider: "rules",

--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -4,6 +4,7 @@ import { extractEvents } from "../extract.js";
 import { redact } from "../redact.js";
 import { createRepeatedErrorDetector } from "../repeated-error-detector.js";
 import type { CommentaryPayload, Event, SourceMode, Style, WsOutgoing } from "../types.js";
+import { createSessionContext, type SessionPhase } from "../session-context.js";
 
 export type PhaseBReplayFixture = {
   notice: string[];
@@ -41,6 +42,23 @@ export type PhaseBReplayResult = {
   style: Style;
   taskContext: PhaseBTaskContext;
   messages: Array<Extract<WsOutgoing, { kind: "event" | "commentary" }>>;
+  contextTimeline: Array<{
+    offsetMs: number;
+    eventType: Event["type"];
+    eventSummary: string;
+    sequence: number;
+    phase: SessionPhase;
+    previousPhase: SessionPhase;
+    phaseChanged: boolean;
+    target: string | null;
+    humanRequired: boolean;
+  }>;
+  commentaryComparisons: Array<{
+    offsetMs: number;
+    eventType: Event["type"];
+    withoutContext: Pick<CommentaryPayload, "narration" | "explanation">;
+    withContext: Pick<CommentaryPayload, "narration" | "explanation">;
+  }>;
   suppressions: PhaseBSuppression[];
   metrics: PhaseBReplayMetrics;
 };
@@ -113,13 +131,29 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
   });
   const repeatedErrors = createRepeatedErrorDetector({ now: () => currentOffsetMs });
   const messages: PhaseBReplayResult["messages"] = [];
+  const contextTimeline: PhaseBReplayResult["contextTimeline"] = [];
+  const commentaryComparisons: PhaseBReplayResult["commentaryComparisons"] = [];
   const suppressions: PhaseBSuppression[] = [];
+  const sessionContext = createSessionContext();
+  sessionContext.setTaskContext({ ...fixture.taskContext, source: "fixture" });
 
   for (const entry of fixture.lines) {
     currentOffsetMs = entry.offsetMs;
     const events = extractEvents(redact(entry.line), fixture.source);
     for (const extracted of events) {
       const event = withEventPriority(repeatedErrors.observe({ ...extracted, ts: currentOffsetMs }));
+      const context = sessionContext.observeEvent(event);
+      contextTimeline.push({
+        offsetMs: currentOffsetMs,
+        eventType: event.type,
+        eventSummary: event.summary,
+        sequence: context.sequence,
+        phase: context.phase,
+        previousPhase: context.previousPhase,
+        phaseChanged: context.phaseChanged,
+        target: context.target,
+        humanRequired: context.humanRequired,
+      });
       messages.push({ kind: "event", ev: event });
 
       if (!gate.shouldEmit(event.priority)) {
@@ -127,9 +161,25 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
         continue;
       }
 
-      const payload: CommentaryPayload = await comment(event, fixture.style, {
+      const providers = {
         narrationProvider: "disabled",
         explanationProvider: "disabled",
+      } as const;
+      const [withoutContext, payload] = await Promise.all([
+        comment(event, fixture.style, providers),
+        comment(event, fixture.style, providers, context),
+      ]);
+      commentaryComparisons.push({
+        offsetMs: currentOffsetMs,
+        eventType: event.type,
+        withoutContext: {
+          narration: withoutContext.narration,
+          explanation: withoutContext.explanation,
+        },
+        withContext: {
+          narration: payload.narration,
+          explanation: payload.explanation,
+        },
       });
       messages.push({ kind: "commentary", ts: currentOffsetMs, ev: event, ...payload });
     }
@@ -141,6 +191,8 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
     style: fixture.style,
     taskContext: fixture.taskContext,
     messages,
+    contextTimeline,
+    commentaryComparisons,
     suppressions,
     metrics: buildMetrics(messages, suppressions),
   };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -46,6 +46,7 @@ import { createPtyCapture } from "./pty/capture.js";
 import { createSilenceTimer, parseSilenceTimeoutMs } from "./silence-timer.js";
 import { createCommentaryGate, withEventPriority } from "./event-priority.js";
 import { createRepeatedErrorDetector } from "./repeated-error-detector.js";
+import { createSessionContext } from "./session-context.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -96,6 +97,7 @@ function markPtyUnavailable(error: string): void {
 // Progress commentary remains rate-limited; urgent and notice events bypass the gate.
 const commentaryGate = createCommentaryGate({ intervalMs: 2000 });
 const repeatedErrorDetector = createRepeatedErrorDetector();
+const sessionContext = createSessionContext();
 
 // --- HTTP + WS ---
 const server = http.createServer((req, res) => {
@@ -327,7 +329,7 @@ async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
     broadcast({ kind: "style", style: currentStyle });
     broadcast({ kind: "source", source: sourceState });
 
-    setupPTY(config, null);
+    setupPTY(config, null, { presetName: input.name });
     enableStdinPassthrough();
     currentlyRunningProfileId = null;
   } catch (err) {
@@ -392,10 +394,11 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
 
 function emitEvent(ev: Event): void {
   const prioritizedEvent = withEventPriority(repeatedErrorDetector.observe(ev));
+  const context = sessionContext.observeEvent(prioritizedEvent);
   // The rule-based event reaches clients immediately; LLM commentary follows asynchronously.
   broadcast({ kind: "event", ev: prioritizedEvent });
   if (commentaryGate.shouldEmit(prioritizedEvent.priority)) {
-    void comment(prioritizedEvent, currentStyle, currentCommentaryProviders)
+    void comment(prioritizedEvent, currentStyle, currentCommentaryProviders, context)
       .then((payload) => {
         broadcastCommentary(prioritizedEvent.ts, prioritizedEvent, payload);
       })
@@ -436,7 +439,15 @@ function broadcastSource(nextDetected: SourceState["detected"]) {
 /**
  * Setup PTY with event handlers
  */
-function setupPTY(config: PTYConfig, profileId: string | null): void {
+function setupPTY(
+  config: PTYConfig,
+  profileId: string | null,
+  sessionOptions?: { presetName?: string }
+): void {
+  sessionContext.reset({
+    presetName: sessionOptions?.presetName,
+    acceptsHumanInput: /(?:^|[/\\])(?:codex|claude)(?:$|\s)/i.test(config.cmd),
+  });
   const term = ptyManager.spawn(config);
   silenceTimer.start();
   transitionServerState("setup_pty_success", "pty_running", {
@@ -476,6 +487,7 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
     }
 
     const ev = withEventPriority({ ts: Date.now(), type: "done", summary: `終了 code=${exitCode}` });
+    const context = sessionContext.observeEvent(ev);
     broadcast({ kind: "event", ev });
 
     // 安全タイマー付き二重化（comment()がsettleしなくてもcleanup確実実行）
@@ -490,7 +502,7 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
     // COMMENT_EXIT_TIMEOUT_MS後に強制cleanup（comment()がハングしても確実に終了）
     const hardTimeout = setTimeout(safeCleanup, COMMENT_EXIT_TIMEOUT_MS);
 
-    void comment(ev, currentStyle, currentCommentaryProviders)
+    void comment(ev, currentStyle, currentCommentaryProviders, context)
       .then((payload) => {
         broadcastCommentary(ev.ts, ev, payload);
       })
@@ -508,10 +520,11 @@ function setupPTY(config: PTYConfig, profileId: string | null): void {
     summary: "開始",
     detail: `${config.cmd} ${config.args.join(" ")}`,
   });
+  const context = sessionContext.observeEvent(startEvent);
   broadcast({ kind: "event", ev: startEvent });
 
   // Send commentary for start event
-  void comment(startEvent, currentStyle, currentCommentaryProviders)
+  void comment(startEvent, currentStyle, currentCommentaryProviders, context)
     .then((payload) => {
       broadcastCommentary(Date.now(), startEvent, payload);
     })
@@ -552,6 +565,7 @@ async function restartPTY(profileId: string | null, force = false): Promise<void
   let nextInputMode: InputMode = INPUT_MODE;
   let config: PTYConfig | null = null;
   let filePath: string | null = null;
+  let presetName: string | undefined;
 
   try {
     let newStyle = currentStyle;
@@ -565,6 +579,7 @@ async function restartPTY(profileId: string | null, force = false): Promise<void
         return;
       }
       nextInputMode = profile.inputMode ?? "pty";
+      presetName = profile.name;
       newStyle = profile.style;
       newSourceMode = profile.logSource;
       newCommentaryProviders = {
@@ -625,10 +640,10 @@ async function restartPTY(profileId: string | null, force = false): Promise<void
 
     if (nextInputMode === "file") {
       runtimeInputMode = "file";
-      setupFileTail(filePath ?? "", { fatal: false });
+      setupFileTail(filePath ?? "", { fatal: false, presetName });
     } else {
       runtimeInputMode = "pty";
-      setupPTY(config as PTYConfig, profileId);
+      setupPTY(config as PTYConfig, profileId, { presetName });
       enableStdinPassthrough();
     }
 
@@ -756,6 +771,7 @@ wss.on("connection", async (ws) => {
 
         case "writeInput":
           if (typeof msg.data === "string") {
+            sessionContext.observeInput(msg.data);
             ptyManager.write(msg.data);
           }
           break;
@@ -850,7 +866,7 @@ wss.on("connection", async (ws) => {
  * Setup file tail input source for external log monitoring.
  * @see Issue #40
  */
-function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
+function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName?: string }): void {
   const fatal = options?.fatal ?? true;
   if (!filePath) {
     transitionServerState("file_tail_setup_failed", "failed", {
@@ -869,6 +885,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
   }
 
   console.log(`Starting file tail mode: ${filePath}`);
+  sessionContext.reset({ presetName: options?.presetName });
 
   // Reset auto-detection
   if (sourceState.mode === "auto") {
@@ -890,6 +907,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
   tail.on("error", (err) => {
     console.error("File tail error:", err.message);
     const ev = withEventPriority({ ts: Date.now(), type: "error", summary: "ファイル監視エラー", detail: err.message });
+    sessionContext.observeEvent(ev);
     broadcast({ kind: "event", ev });
   });
 
@@ -909,9 +927,10 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
 
     console.log(`File tail exited with code: ${code}`);
     const ev = withEventPriority({ ts: Date.now(), type: "done", summary: `ファイル監視終了 code=${code}` });
+    const context = sessionContext.observeEvent(ev);
     broadcast({ kind: "event", ev });
 
-    void comment(ev, currentStyle, currentCommentaryProviders)
+    void comment(ev, currentStyle, currentCommentaryProviders, context)
       .then((payload) => {
         broadcastCommentary(ev.ts, ev, payload);
       })
@@ -940,9 +959,10 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean }): void {
       summary: "ファイル監視開始",
       detail: `tail -f ${filePath}`,
     });
+    const context = sessionContext.observeEvent(startEvent);
     broadcast({ kind: "event", ev: startEvent });
 
-    void comment(startEvent, currentStyle, currentCommentaryProviders)
+    void comment(startEvent, currentStyle, currentCommentaryProviders, context)
       .then((payload) => {
         broadcastCommentary(Date.now(), startEvent, payload);
       })

--- a/apps/server/src/session-context.test.ts
+++ b/apps/server/src/session-context.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "./types.js";
+import { createSessionContext } from "./session-context.js";
+
+function event(type: Event["type"], detail?: string, summary: string = type): Event {
+  return { ts: 1, type, summary, detail };
+}
+
+describe("SessionContext", () => {
+  it("starts unknown without inventing a task", () => {
+    expect(createSessionContext().snapshot()).toMatchObject({
+      task: { objective: null, userPrompt: null, source: null },
+      target: null,
+      recentEvents: [],
+      phase: "unknown",
+      previousPhase: "unknown",
+      phaseChanged: false,
+      humanRequired: false,
+      sequence: 0,
+    });
+  });
+
+  it("sets sanitized, bounded task context", () => {
+    const context = createSessionContext();
+    context.setTaskContext({
+      objective: `調査 sk-abcdefghijklmnopqrstuvwxyz123456 ${"x".repeat(400)}`,
+      userPrompt: "実況の流れを確認してください",
+      source: "fixture",
+    });
+
+    const task = context.snapshot().task;
+    expect(task.source).toBe("fixture");
+    expect(task.objective).toContain("sk-[REDACTED]");
+    expect(task.objective?.length).toBeLessThanOrEqual(320);
+    expect(task.userPrompt).toBe("実況の流れを確認してください");
+  });
+
+  it("buffers trusted interactive input until a newline", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true });
+    context.observeInput("実況の流れを");
+    expect(context.snapshot().task.objective).toBeNull();
+    context.observeInput("確認してください\r");
+    expect(context.snapshot().task).toEqual({
+      objective: "実況の流れを確認してください",
+      userPrompt: "実況の流れを確認してください",
+      source: "human_input",
+    });
+  });
+
+  it("does not accept input when the session is not a trusted human-prompt CLI", () => {
+    const context = createSessionContext();
+    context.observeInput("もっともらしい目的\n");
+    expect(context.snapshot().task.objective).toBeNull();
+  });
+
+  it("uses a sanitized preset name only as an observed fallback", () => {
+    const context = createSessionContext();
+    context.reset({ presetName: "安全な調査プリセット sk-abcdefghijklmnopqrstuvwxyz123456" });
+    expect(context.snapshot().task).toEqual({
+      objective: "安全な調査プリセット sk-[REDACTED]",
+      userPrompt: null,
+      source: "preset",
+    });
+  });
+
+  it("bounds recent history to three through five entries", () => {
+    const context = createSessionContext({ historyLimit: 3 });
+    for (let index = 0; index < 7; index += 1) {
+      context.observeEvent(event("read", `⏺ Read(src/file-${index}.ts)`));
+    }
+    expect(context.snapshot().recentEvents).toHaveLength(3);
+    expect(context.snapshot().recentEvents.map((item) => item.sequence)).toEqual([5, 6, 7]);
+  });
+
+  it("updates file and module targets", () => {
+    const context = createSessionContext();
+    expect(context.observeEvent(event("read", "⏺ Read(apps/server/src/index.ts)")).target)
+      .toBe("apps/server/src/index.ts");
+    expect(context.observeEvent(event("write", "⏺ Update(packages/shared/src/protocol.ts)")).target)
+      .toBe("packages/shared/src/protocol.ts");
+  });
+
+  it("follows investigation to editing to verification to publishing", () => {
+    const context = createSessionContext();
+    expect(context.observeEvent(event("search", "⏺ Grep(rg SessionContext apps/server/src)")).phase)
+      .toBe("investigation");
+    expect(context.observeEvent(event("read", "⏺ Read(apps/server/src/index.ts)")).phaseChanged)
+      .toBe(false);
+    expect(context.observeEvent(event("write", "apply_patch")).phase).toBe("editing");
+    expect(context.observeEvent(event("test", "pnpm -C apps/server test")).phase).toBe("verification");
+    const published = context.observeEvent(event("git", "⏺ Bash(git push origin feat/context)"));
+    expect(published).toMatchObject({
+      phase: "publishing",
+      previousPhase: "verification",
+      phaseChanged: true,
+    });
+  });
+
+  it("recognizes scoped package build and lint commands as verification", () => {
+    const context = createSessionContext();
+    context.observeEvent(event("write", "apply_patch"));
+    expect(context.observeEvent(event("stdout", "⏺ Bash(pnpm -C apps/server build)")).phase)
+      .toBe("verification");
+    context.observeEvent(event("write", "apply_patch"));
+    expect(context.observeEvent(event("stdout", "⏺ Bash(npm --workspace web run lint:check)")).phase)
+      .toBe("verification");
+  });
+
+  it("does not treat package installation as verification", () => {
+    const context = createSessionContext();
+    expect(context.observeEvent(event("install", "⏺ Bash(pnpm install build)")).phase)
+      .toBe("unknown");
+  });
+
+  it("does not move an active phase back for a supporting read or git status", () => {
+    const context = createSessionContext();
+    context.observeEvent(event("write", "apply_patch"));
+    expect(context.observeEvent(event("read", "⏺ Read(src/check.ts)")).phase).toBe("editing");
+    expect(context.observeEvent(event("git", "⏺ Bash(git status --short)")).phase).toBe("editing");
+    context.observeEvent(event("test", "pnpm test"));
+    expect(context.observeEvent(event("search", "⏺ Grep(rg failure src)")).phase).toBe("verification");
+  });
+
+  it("enters waiting, marks explicit HUMAN need, and clears it on work", () => {
+    const context = createSessionContext();
+    context.observeEvent(event("write", "apply_patch"));
+    const waiting = context.observeEvent(event("stdout", undefined, "コマンド実行の確認待ち"));
+    expect(waiting).toMatchObject({ phase: "waiting", humanRequired: true });
+
+    const resumed = context.observeEvent(event("write", "apply_patch"));
+    expect(resumed).toMatchObject({ phase: "editing", humanRequired: false });
+  });
+
+  it("treats silence as waiting without claiming HUMAN action is required", () => {
+    const context = createSessionContext();
+    context.observeEvent(event("search", "rg context src"));
+    const waiting = context.observeEvent(event("stdout", "30000ms outputなし", "長考・沈黙が続いている"));
+    expect(waiting).toMatchObject({ phase: "waiting", humanRequired: false });
+    expect(context.observeEvent(event("read", "⏺ Read(src/index.ts)")).phase).toBe("investigation");
+  });
+
+  it("does not infer HUMAN action or a new phase from an ordinary error", () => {
+    const context = createSessionContext();
+    const failed = context.observeEvent(event("error", "test failed", "エラーが出ている"));
+    expect(failed.humanRequired).toBe(false);
+    expect(failed.phase).toBe("unknown");
+  });
+
+  it("resets all session state and keeps prior snapshots immutable", () => {
+    const context = createSessionContext();
+    context.setTaskContext({ objective: "目的", userPrompt: "依頼", source: "fixture" });
+    const oldSnapshot = context.observeEvent(event("write", "⏺ Update(src/a.ts)"));
+    context.observeEvent(event("test", "pnpm test"));
+    context.reset();
+
+    expect(oldSnapshot).toMatchObject({
+      task: { objective: "目的" },
+      phase: "editing",
+      sequence: 1,
+      target: "src/a.ts",
+    });
+    expect(context.snapshot()).toMatchObject({
+      task: { objective: null },
+      phase: "unknown",
+      sequence: 0,
+      target: null,
+      recentEvents: [],
+      humanRequired: false,
+    });
+    expect(Object.isFrozen(oldSnapshot)).toBe(true);
+    expect(Object.isFrozen(oldSnapshot.recentEvents)).toBe(true);
+  });
+});

--- a/apps/server/src/session-context.test.ts
+++ b/apps/server/src/session-context.test.ts
@@ -9,7 +9,7 @@ function event(type: Event["type"], detail?: string, summary: string = type): Ev
 describe("SessionContext", () => {
   it("starts unknown without inventing a task", () => {
     expect(createSessionContext().snapshot()).toMatchObject({
-      task: { objective: null, userPrompt: null, source: null },
+      task: { objective: null, userPrompt: null, sessionLabel: null, source: null },
       target: null,
       recentEvents: [],
       phase: "unknown",
@@ -44,6 +44,7 @@ describe("SessionContext", () => {
     expect(context.snapshot().task).toEqual({
       objective: "実況の流れを確認してください",
       userPrompt: "実況の流れを確認してください",
+      sessionLabel: null,
       source: "human_input",
     });
   });
@@ -54,14 +55,41 @@ describe("SessionContext", () => {
     expect(context.snapshot().task.objective).toBeNull();
   });
 
-  it("uses a sanitized preset name only as an observed fallback", () => {
+  it("keeps a sanitized preset name as a session label rather than a task objective", () => {
     const context = createSessionContext();
     context.reset({ presetName: "安全な調査プリセット sk-abcdefghijklmnopqrstuvwxyz123456" });
     expect(context.snapshot().task).toEqual({
-      objective: "安全な調査プリセット sk-[REDACTED]",
+      objective: null,
       userPrompt: null,
+      sessionLabel: "安全な調査プリセット sk-[REDACTED]",
       source: "preset",
     });
+  });
+
+  it("starts a fresh task flow for a confirmed instruction in the same PTY", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true, presetName: "開発用" });
+    context.observeInput("最初の変更を公開してください\n");
+    context.observeEvent(event("write", "⏺ Update(src/old.ts)"));
+    context.observeEvent(event("git", "⏺ Bash(git push origin feat/old)"));
+
+    context.observeInput("次のIssueを調査してください\n");
+    const fresh = context.snapshot();
+    expect(fresh).toMatchObject({
+      task: {
+        objective: "次のIssueを調査してください",
+        userPrompt: "次のIssueを調査してください",
+        sessionLabel: "開発用",
+        source: "human_input",
+      },
+      target: null,
+      recentEvents: [],
+      phase: "unknown",
+      sequence: 0,
+      humanRequired: false,
+    });
+    expect(context.observeEvent(event("search", "⏺ Grep(rg SessionContext apps/server/src)")).phase)
+      .toBe("investigation");
   });
 
   it("bounds recent history to three through five entries", () => {
@@ -132,6 +160,31 @@ describe("SessionContext", () => {
     expect(resumed).toMatchObject({ phase: "editing", humanRequired: false });
   });
 
+  it("treats confirmed input during waiting as a response without replacing the objective", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true });
+    context.observeInput("実況文脈を実装してください\n");
+    context.observeEvent(event("write", "apply_patch"));
+    context.observeEvent(event("stdout", undefined, "コマンド実行の確認待ち"));
+
+    context.observeInput("承認します\n");
+    expect(context.snapshot()).toMatchObject({
+      task: { objective: "実況文脈を実装してください" },
+      phase: "editing",
+      previousPhase: "waiting",
+      phaseChanged: true,
+      humanRequired: false,
+    });
+  });
+
+  it("does not infer waiting from keywords inside a search command", () => {
+    const context = createSessionContext();
+    const searched = context.observeEvent(
+      event("search", '⏺ Grep(rg "確認待ち|承認待ち" apps/server/src)')
+    );
+    expect(searched).toMatchObject({ phase: "investigation", humanRequired: false });
+  });
+
   it("treats silence as waiting without claiming HUMAN action is required", () => {
     const context = createSessionContext();
     context.observeEvent(event("search", "rg context src"));
@@ -145,6 +198,16 @@ describe("SessionContext", () => {
     const failed = context.observeEvent(event("error", "test failed", "エラーが出ている"));
     expect(failed.humanRequired).toBe(false);
     expect(failed.phase).toBe("unknown");
+  });
+
+  it("treats mutating PR review and lifecycle commands as publishing", () => {
+    const review = createSessionContext();
+    expect(review.observeEvent(event("github", "⏺ Bash(gh pr review --approve 335)")).phase)
+      .toBe("publishing");
+
+    const close = createSessionContext();
+    expect(close.observeEvent(event("github", "⏺ Bash(gh pr close 335)")).phase)
+      .toBe("publishing");
   });
 
   it("resets all session state and keeps prior snapshots immutable", () => {

--- a/apps/server/src/session-context.ts
+++ b/apps/server/src/session-context.ts
@@ -15,6 +15,7 @@ export type TaskContextSource = "fixture" | "human_input" | "human_log" | "prese
 export type SessionTaskContext = {
   objective: string | null;
   userPrompt: string | null;
+  sessionLabel: string | null;
   source: TaskContextSource | null;
 };
 
@@ -84,18 +85,19 @@ function limited(value: string | null | undefined, max: number): string | null {
 }
 
 function isWaitingEvent(event: Event): boolean {
-  const text = `${event.summary} ${event.detail ?? ""}`;
-  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|長考・沈黙)/u.test(text);
+  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|長考・沈黙)/u.test(
+    event.summary
+  );
 }
 
 function explicitlyRequiresHuman(event: Event): boolean {
-  const text = `${event.summary} ${event.detail ?? ""}`;
-  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|HUMAN(?:の)?(?:判断|対応))/iu.test(text);
+  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|HUMAN(?:の)?(?:判断|対応))/iu.test(
+    event.summary
+  );
 }
 
 function isHumanResponseEvent(event: Event): boolean {
-  const text = `${event.summary} ${event.detail ?? ""}`;
-  return /(?:承認された|approved|入力を受け付け|回答済み)/iu.test(text);
+  return /(?:承認された|approved|入力を受け付け|回答済み)/iu.test(event.summary);
 }
 
 function isPublishingOperation(event: Event): boolean {
@@ -103,7 +105,7 @@ function isPublishingOperation(event: Event): boolean {
   const command = unwrapCommandDetail(event.detail ?? "");
   return (
     /\bgit\s+(?:commit|push)\b/i.test(command) ||
-    /\bgh\s+pr\s+(?:create|edit|comment|merge|ready)\b/i.test(command) ||
+    /\bgh\s+pr\s+(?:create|edit|comment|merge|ready|review|close|reopen|update-branch)\b/i.test(command) ||
     /\bgh\s+release\s+(?:create|upload|edit)\b/i.test(command)
   );
 }
@@ -206,7 +208,7 @@ export function inferEventTarget(event: Event): string | null {
 
 function initialState(): MutableState {
   return {
-    task: { objective: null, userPrompt: null, source: null },
+    task: { objective: null, userPrompt: null, sessionLabel: null, source: null },
     target: null,
     recentEvents: [],
     phase: "unknown",
@@ -238,7 +240,15 @@ function immutableSnapshot(state: MutableState): SessionContextSnapshot {
 function looksLikeHumanRequest(line: string): boolean {
   if (line.length < 4 || /^[/:.\w-]+$/u.test(line)) return false;
   if (/^(?:codex|claude|exit|quit|clear|help)$/i.test(line)) return false;
+  if (/^\/\S+(?:\s+.*)?$/u.test(line)) return false;
   return true;
+}
+
+function resumeFromHumanResponse(state: MutableState): void {
+  state.phase = state.phaseBeforeWaiting;
+  state.previousPhase = "waiting";
+  state.phaseChanged = state.phase !== "waiting";
+  state.humanRequired = false;
 }
 
 function appendTerminalInput(buffer: string, data: string): string {
@@ -267,6 +277,7 @@ export function createSessionContext(options?: { historyLimit?: number }): Sessi
       state.task = {
         objective,
         userPrompt,
+        sessionLabel: state.task.sessionLabel,
         source: objective || userPrompt ? input.source : null,
       };
     },
@@ -282,7 +293,23 @@ export function createSessionContext(options?: { historyLimit?: number }): Sessi
       for (const part of parts) {
         const prompt = limited(part, MAX_CONTEXT_LENGTH);
         if (prompt && looksLikeHumanRequest(prompt)) {
-          state.task = { objective: prompt, userPrompt: prompt, source: "human_input" };
+          if (state.phase === "waiting") {
+            resumeFromHumanResponse(state);
+            continue;
+          }
+
+          // A confirmed HUMAN instruction starts a new task within the same PTY.
+          // Preserve only session-scoped launch metadata and input trust.
+          const acceptsHumanInput: boolean = state.acceptsHumanInput;
+          const sessionLabel: string | null = state.task.sessionLabel;
+          state = initialState();
+          state.acceptsHumanInput = acceptsHumanInput;
+          state.task = {
+            objective: prompt,
+            userPrompt: prompt,
+            sessionLabel,
+            source: "human_input",
+          };
         }
       }
     },
@@ -329,7 +356,12 @@ export function createSessionContext(options?: { historyLimit?: number }): Sessi
       state.acceptsHumanInput = resetOptions?.acceptsHumanInput ?? false;
       const presetName = limited(resetOptions?.presetName, MAX_CONTEXT_LENGTH);
       if (presetName) {
-        state.task = { objective: presetName, userPrompt: null, source: "preset" };
+        state.task = {
+          objective: null,
+          userPrompt: null,
+          sessionLabel: presetName,
+          source: "preset",
+        };
       }
     },
   };

--- a/apps/server/src/session-context.ts
+++ b/apps/server/src/session-context.ts
@@ -1,0 +1,336 @@
+import type { Event } from "./types.js";
+import { tokenizeShellCommand, unwrapCommandDetail } from "./command-analysis.js";
+import { redact } from "./redact.js";
+
+export type SessionPhase =
+  | "unknown"
+  | "investigation"
+  | "editing"
+  | "verification"
+  | "publishing"
+  | "waiting";
+
+export type TaskContextSource = "fixture" | "human_input" | "human_log" | "preset";
+
+export type SessionTaskContext = {
+  objective: string | null;
+  userPrompt: string | null;
+  source: TaskContextSource | null;
+};
+
+export type SessionEventSummary = {
+  sequence: number;
+  type: Event["type"];
+  summary: string;
+  target: string | null;
+};
+
+export type SessionContextSnapshot = Readonly<{
+  task: Readonly<SessionTaskContext>;
+  target: string | null;
+  recentEvents: readonly Readonly<SessionEventSummary>[];
+  phase: SessionPhase;
+  previousPhase: SessionPhase;
+  phaseChanged: boolean;
+  humanRequired: boolean;
+  sequence: number;
+}>;
+
+export type SessionContext = {
+  setTaskContext(input: {
+    objective?: string | null;
+    userPrompt?: string | null;
+    source: TaskContextSource;
+  }): void;
+  observeInput(data: string): void;
+  observeEvent(event: Event): SessionContextSnapshot;
+  snapshot(): SessionContextSnapshot;
+  reset(options?: { presetName?: string; acceptsHumanInput?: boolean }): void;
+};
+
+type MutableState = {
+  task: SessionTaskContext;
+  target: string | null;
+  recentEvents: SessionEventSummary[];
+  phase: SessionPhase;
+  previousPhase: SessionPhase;
+  phaseChanged: boolean;
+  humanRequired: boolean;
+  sequence: number;
+  phaseBeforeWaiting: SessionPhase;
+  inputBuffer: string;
+  acceptsHumanInput: boolean;
+};
+
+const DEFAULT_HISTORY_LIMIT = 5;
+const MAX_CONTEXT_LENGTH = 320;
+const MAX_INPUT_BUFFER_LENGTH = MAX_CONTEXT_LENGTH * 2;
+const MAX_SUMMARY_LENGTH = 120;
+const MAX_TARGET_LENGTH = 160;
+
+export const SESSION_PHASE_LABELS: Record<SessionPhase, string> = {
+  unknown: "未判定",
+  investigation: "調査",
+  editing: "編集",
+  verification: "検証",
+  publishing: "公開",
+  waiting: "待機",
+};
+
+function limited(value: string | null | undefined, max: number): string | null {
+  const compact = redact(value ?? "").replace(/\s+/g, " ").trim();
+  if (!compact) return null;
+  return compact.length <= max ? compact : `${compact.slice(0, max - 1).trimEnd()}…`;
+}
+
+function isWaitingEvent(event: Event): boolean {
+  const text = `${event.summary} ${event.detail ?? ""}`;
+  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|長考・沈黙)/u.test(text);
+}
+
+function explicitlyRequiresHuman(event: Event): boolean {
+  const text = `${event.summary} ${event.detail ?? ""}`;
+  return /(?:確認待ち|許可を待|承認待ち|回答を待|入力待ち|質問への回答|HUMAN(?:の)?(?:判断|対応))/iu.test(text);
+}
+
+function isHumanResponseEvent(event: Event): boolean {
+  const text = `${event.summary} ${event.detail ?? ""}`;
+  return /(?:承認された|approved|入力を受け付け|回答済み)/iu.test(text);
+}
+
+function isPublishingOperation(event: Event): boolean {
+  if (event.type !== "git" && event.type !== "github") return false;
+  const command = unwrapCommandDetail(event.detail ?? "");
+  return (
+    /\bgit\s+(?:commit|push)\b/i.test(command) ||
+    /\bgh\s+pr\s+(?:create|edit|comment|merge|ready)\b/i.test(command) ||
+    /\bgh\s+release\s+(?:create|upload|edit)\b/i.test(command)
+  );
+}
+
+function verificationCommand(event: Event): boolean {
+  if (event.type !== "stdout" && event.type !== "install") return false;
+  const detail = event.detail ?? "";
+  if (!/^[⏺•]\s*Bash\(|^>\s/u.test(detail)) return false;
+  const tokens = tokenizeShellCommand(unwrapCommandDetail(detail));
+  if (!tokens) return false;
+
+  const valueOptions = new Set([
+    "-C", "--dir", "--filter", "--prefix", "-w", "--workspace", "--cwd",
+  ]);
+  for (let index = 0; index < tokens.length; index += 1) {
+    const manager = tokens[index].replace(/\\/g, "/").split("/").at(-1)?.toLowerCase();
+    if (!manager || !["pnpm", "npm", "yarn"].includes(manager)) continue;
+
+    let actionAt = index + 1;
+    while (actionAt < tokens.length && tokens[actionAt].startsWith("-")) {
+      const option = tokens[actionAt];
+      actionAt += 1;
+      if (valueOptions.has(option)) actionAt += 1;
+    }
+    if (manager === "yarn" && tokens[actionAt] === "workspace") actionAt += 2;
+    if (tokens[actionAt] === "run") actionAt += 1;
+    if (/^(?:test|typecheck|build|lint)(?::|$)/i.test(tokens[actionAt] ?? "")) return true;
+  }
+  return false;
+}
+
+function explicitPhaseFor(event: Event): SessionPhase | null {
+  if (isWaitingEvent(event)) return "waiting";
+  if (isPublishingOperation(event)) return "publishing";
+  if (event.type === "write") return "editing";
+  if (
+    event.type === "test" ||
+    event.type === "lint" ||
+    event.type === "build" ||
+    verificationCommand(event)
+  ) return "verification";
+  if (event.type === "read" || event.type === "search") return "investigation";
+  return null;
+}
+
+function nextPhase(state: MutableState, event: Event): SessionPhase {
+  const explicit = explicitPhaseFor(event);
+  if (explicit === "waiting") return explicit;
+
+  if (state.phase === "waiting") {
+    if (explicit) return explicit;
+    if (isHumanResponseEvent(event)) return state.phaseBeforeWaiting;
+    if (["start", "stderr", "error", "done"].includes(event.type)) return state.phase;
+    return state.phaseBeforeWaiting;
+  }
+
+  if (!explicit) return state.phase;
+
+  // Phase transition table:
+  // - read/search starts or maintains investigation.
+  // - write always advances to editing.
+  // - test/lint/build advances to verification.
+  // - commit/push/explicit PR publication advances to publishing.
+  // - a supporting read/search never moves editing, verification, or publishing back
+  //   to investigation; a new write or verification event can still start the next cycle.
+  if (
+    explicit === "investigation" &&
+    (state.phase === "editing" || state.phase === "verification" || state.phase === "publishing")
+  ) {
+    return state.phase;
+  }
+  return explicit;
+}
+
+function pathLike(token: string): boolean {
+  return (
+    /(?:^|\/)\.?[A-Za-z0-9_.-]+\.[A-Za-z0-9]+(?::\d+)?$/u.test(token) ||
+    /^(?:apps|packages|src|test|tests|docs|scripts)\//u.test(token)
+  );
+}
+
+function cleanTarget(value: string): string | null {
+  return limited(value.replace(/^["']|["'),;:]$/g, ""), MAX_TARGET_LENGTH);
+}
+
+export function inferEventTarget(event: Event): string | null {
+  const detail = event.detail?.trim();
+  if (!detail) return null;
+
+  const wrapped = detail.match(/^[⏺•]\s*(?:Read|Update|Write|Grep|Glob)\((.*)\)$/s)?.[1];
+  const command = wrapped ?? unwrapCommandDetail(detail);
+  const tokens = tokenizeShellCommand(command) ?? command.split(/\s+/);
+  const candidates = tokens
+    .filter((token) => !token.startsWith("-") && pathLike(token))
+    .map(cleanTarget)
+    .filter((token): token is string => Boolean(token));
+
+  return candidates[0] ?? null;
+}
+
+function initialState(): MutableState {
+  return {
+    task: { objective: null, userPrompt: null, source: null },
+    target: null,
+    recentEvents: [],
+    phase: "unknown",
+    previousPhase: "unknown",
+    phaseChanged: false,
+    humanRequired: false,
+    sequence: 0,
+    phaseBeforeWaiting: "unknown",
+    inputBuffer: "",
+    acceptsHumanInput: false,
+  };
+}
+
+function immutableSnapshot(state: MutableState): SessionContextSnapshot {
+  const task = Object.freeze({ ...state.task });
+  const recentEvents = Object.freeze(state.recentEvents.map((event) => Object.freeze({ ...event })));
+  return Object.freeze({
+    task,
+    target: state.target,
+    recentEvents,
+    phase: state.phase,
+    previousPhase: state.previousPhase,
+    phaseChanged: state.phaseChanged,
+    humanRequired: state.humanRequired,
+    sequence: state.sequence,
+  });
+}
+
+function looksLikeHumanRequest(line: string): boolean {
+  if (line.length < 4 || /^[/:.\w-]+$/u.test(line)) return false;
+  if (/^(?:codex|claude|exit|quit|clear|help)$/i.test(line)) return false;
+  return true;
+}
+
+function appendTerminalInput(buffer: string, data: string): string {
+  let next = buffer;
+  const clean = data.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+  for (const char of clean) {
+    if (char === "\u0003" || char === "\u0015") {
+      next = "";
+    } else if (char === "\b" || char === "\u007f") {
+      next = Array.from(next).slice(0, -1).join("");
+    } else {
+      next += char;
+    }
+  }
+  return next;
+}
+
+export function createSessionContext(options?: { historyLimit?: number }): SessionContext {
+  const historyLimit = Math.min(5, Math.max(3, options?.historyLimit ?? DEFAULT_HISTORY_LIMIT));
+  let state = initialState();
+
+  return {
+    setTaskContext(input) {
+      const objective = limited(input.objective, MAX_CONTEXT_LENGTH);
+      const userPrompt = limited(input.userPrompt, MAX_CONTEXT_LENGTH);
+      state.task = {
+        objective,
+        userPrompt,
+        source: objective || userPrompt ? input.source : null,
+      };
+    },
+
+    observeInput(data) {
+      if (!state.acceptsHumanInput || state.task.source === "fixture") return;
+      state.inputBuffer = appendTerminalInput(state.inputBuffer, data);
+      if (state.inputBuffer.length > MAX_INPUT_BUFFER_LENGTH) {
+        state.inputBuffer = state.inputBuffer.slice(-MAX_INPUT_BUFFER_LENGTH);
+      }
+      const parts = state.inputBuffer.split(/\r\n|\n|\r/);
+      state.inputBuffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const prompt = limited(part, MAX_CONTEXT_LENGTH);
+        if (prompt && looksLikeHumanRequest(prompt)) {
+          state.task = { objective: prompt, userPrompt: prompt, source: "human_input" };
+        }
+      }
+    },
+
+    observeEvent(event) {
+      state.sequence += 1;
+      const target = inferEventTarget(event);
+      if (target) state.target = target;
+
+      const priorPhase = state.phase;
+      const resolvedPhase = nextPhase(state, event);
+      if (resolvedPhase === "waiting" && priorPhase !== "waiting") {
+        state.phaseBeforeWaiting = priorPhase;
+      }
+      state.previousPhase = priorPhase;
+      state.phase = resolvedPhase;
+      state.phaseChanged = priorPhase !== resolvedPhase;
+
+      if (explicitlyRequiresHuman(event)) state.humanRequired = true;
+      else if (
+        isHumanResponseEvent(event) ||
+        (priorPhase === "waiting" && resolvedPhase !== "waiting") ||
+        (!isWaitingEvent(event) && explicitPhaseFor(event) !== null)
+      ) {
+        state.humanRequired = false;
+      }
+
+      state.recentEvents.push({
+        sequence: state.sequence,
+        type: event.type,
+        summary: limited(event.summary, MAX_SUMMARY_LENGTH) ?? event.type,
+        target: target ?? state.target,
+      });
+      state.recentEvents = state.recentEvents.slice(-historyLimit);
+      return immutableSnapshot(state);
+    },
+
+    snapshot() {
+      return immutableSnapshot(state);
+    },
+
+    reset(resetOptions) {
+      state = initialState();
+      state.acceptsHumanInput = resetOptions?.acceptsHumanInput ?? false;
+      const presetName = limited(resetOptions?.presetName, MAX_CONTEXT_LENGTH);
+      if (presetName) {
+        state.task = { objective: presetName, userPrompt: null, source: "preset" };
+      }
+    },
+  };
+}

--- a/apps/server/src/styles/prompt.ts
+++ b/apps/server/src/styles/prompt.ts
@@ -1,4 +1,5 @@
 import type { Event, Style } from "../types.js";
+import { SESSION_PHASE_LABELS, type SessionContextSnapshot } from "../session-context.js";
 
 type CommentaryRole = "narration" | "explanation";
 
@@ -120,10 +121,32 @@ function buildCommonEventSection(ev: Event): string {
   ].join("\n");
 }
 
+function buildContextSection(context?: SessionContextSnapshot): string {
+  if (!context) return "";
+  const recentFlow = context.recentEvents
+    .slice(-3)
+    .map((event) => `${event.type}:${event.summary}`)
+    .join(" → ");
+  return [
+    "観測済みセッション文脈:",
+    context.task.objective ? `- 確認済みの作業目的: ${context.task.objective}` : "- 作業目的: 不明",
+    context.task.userPrompt ? `- 確認済みのHUMAN依頼: ${context.task.userPrompt}` : "- HUMAN依頼: 不明",
+    `- 現在フェーズ: ${SESSION_PHASE_LABELS[context.phase]} (${context.phase})`,
+    context.phaseChanged
+      ? `- フェーズ変化: ${SESSION_PHASE_LABELS[context.previousPhase]} → ${SESSION_PHASE_LABELS[context.phase]}`
+      : "- フェーズ変化: なし",
+    `- 現在対象: ${context.target ?? "不明"}`,
+    `- HUMAN対応: ${context.humanRequired ? "明示的に必要" : "明示されていない"}`,
+    ...(recentFlow ? [`- 直近の流れ: ${recentFlow}`] : []),
+    "この文脈は観測済みの事実だけとして使い、不明な目的・結果・成功見込みを補わない。",
+  ].join("\n");
+}
+
 function buildPrompt(
   role: CommentaryRole,
   ev: Event,
-  style: Style
+  style: Style,
+  context?: SessionContextSnapshot
 ): string {
   const roleLine =
     role === "narration"
@@ -160,17 +183,26 @@ function buildPrompt(
     `イベント別の指示: ${eventGuidance}`,
     ...(role === "explanation" ? [`説明の組み立て: ${explanationStructureHint(ev)}`] : []),
     ...(ambiguity ? [`曖昧さの扱い: ${ambiguity}`] : []),
+    ...(context ? [buildContextSection(context)] : []),
     buildCommonEventSection(ev),
     answerLine,
   ].join("\n");
 }
 
-export function buildNarrationPrompt(ev: Event, style: Style): string {
-  return buildPrompt("narration", ev, style);
+export function buildNarrationPrompt(
+  ev: Event,
+  style: Style,
+  context?: SessionContextSnapshot
+): string {
+  return buildPrompt("narration", ev, style, context);
 }
 
-export function buildExplanationPrompt(ev: Event, style: Style): string {
-  return buildPrompt("explanation", ev, style);
+export function buildExplanationPrompt(
+  ev: Event,
+  style: Style,
+  context?: SessionContextSnapshot
+): string {
+  return buildPrompt("explanation", ev, style, context);
 }
 
 export function normalizeGeneratedCommentaryText(

--- a/apps/server/src/styles/prompt.ts
+++ b/apps/server/src/styles/prompt.ts
@@ -131,6 +131,7 @@ function buildContextSection(context?: SessionContextSnapshot): string {
     "観測済みセッション文脈:",
     context.task.objective ? `- 確認済みの作業目的: ${context.task.objective}` : "- 作業目的: 不明",
     context.task.userPrompt ? `- 確認済みのHUMAN依頼: ${context.task.userPrompt}` : "- HUMAN依頼: 不明",
+    ...(context.task.sessionLabel ? [`- 起動プリセット: ${context.task.sessionLabel}`] : []),
     `- 現在フェーズ: ${SESSION_PHASE_LABELS[context.phase]} (${context.phase})`,
     context.phaseChanged
       ? `- フェーズ変化: ${SESSION_PHASE_LABELS[context.previousPhase]} → ${SESSION_PHASE_LABELS[context.phase]}`

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -7,8 +7,8 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "eventType": "search",
       "offsetMs": 400,
       "withContext": {
-        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
-        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
+        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用…」に向けた調査段階です。",
+        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
       },
       "withoutContext": {
         "explanation": "「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
@@ -19,8 +19,8 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "eventType": "read",
       "offsetMs": 3218,
       "withContext": {
-        "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
-        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
+        "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
       },
       "withoutContext": {
         "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
@@ -31,8 +31,8 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "eventType": "search",
       "offsetMs": 7355,
       "withContext": {
-        "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
-        "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
+        "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+        "narration": "今の対象は「apps/web/src」や。",
       },
       "withoutContext": {
         "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
@@ -43,8 +43,8 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "eventType": "read",
       "offsetMs": 10573,
       "withContext": {
-        "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
-        "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
+        "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "今の対象は「apps/server/src/extract.ts」や。",
       },
       "withoutContext": {
         "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
@@ -129,7 +129,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 400,
         "type": "search",
       },
-      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用…」に向けた調査段階です。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -137,7 +137,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
+      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
       "ts": 400,
     },
     {
@@ -158,7 +158,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 3218,
         "type": "read",
       },
-      "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -166,7 +166,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
+      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
       "ts": 3218,
     },
     {
@@ -187,7 +187,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 7355,
         "type": "search",
       },
-      "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
         "補足: rg はプロジェクト全体を高速検索するコマンド",
       ],
@@ -197,7 +197,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
+      "narration": "今の対象は「apps/web/src」や。",
       "ts": 7355,
     },
     {
@@ -228,7 +228,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 10573,
         "type": "read",
       },
-      "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -236,7 +236,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
+      "narration": "今の対象は「apps/server/src/extract.ts」や。",
       "ts": 10573,
     },
   ],

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -2,6 +2,113 @@
 
 exports[`Phase B evaluation replay > replays the minimal sanitized session deterministically 1`] = `
 {
+  "commentaryComparisons": [
+    {
+      "eventType": "search",
+      "offsetMs": 400,
+      "withContext": {
+        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
+      },
+      "withoutContext": {
+        "explanation": "「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+        "narration": "原因っぽいとこ探してるで。",
+      },
+    },
+    {
+      "eventType": "read",
+      "offsetMs": 3218,
+      "withContext": {
+        "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
+      },
+      "withoutContext": {
+        "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "ファイル読んで状況確認してるで。",
+      },
+    },
+    {
+      "eventType": "search",
+      "offsetMs": 7355,
+      "withContext": {
+        "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+        "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
+      },
+      "withoutContext": {
+        "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+        "narration": "原因っぽいとこ探してるで。",
+      },
+    },
+    {
+      "eventType": "read",
+      "offsetMs": 10573,
+      "withContext": {
+        "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
+      },
+      "withoutContext": {
+        "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+        "narration": "ファイル読んで状況確認してるで。",
+      },
+    },
+  ],
+  "contextTimeline": [
+    {
+      "eventSummary": "該当箇所を検索している",
+      "eventType": "search",
+      "humanRequired": false,
+      "offsetMs": 400,
+      "phase": "investigation",
+      "phaseChanged": true,
+      "previousPhase": "unknown",
+      "sequence": 1,
+      "target": "pnpm-workspace.yaml",
+    },
+    {
+      "eventSummary": "ファイルを読み込んでいる",
+      "eventType": "read",
+      "humanRequired": false,
+      "offsetMs": 3218,
+      "phase": "investigation",
+      "phaseChanged": false,
+      "previousPhase": "investigation",
+      "sequence": 2,
+      "target": "apps/server/src/commentary/orchestrator.ts",
+    },
+    {
+      "eventSummary": "該当箇所を検索している",
+      "eventType": "search",
+      "humanRequired": false,
+      "offsetMs": 7355,
+      "phase": "investigation",
+      "phaseChanged": false,
+      "previousPhase": "investigation",
+      "sequence": 3,
+      "target": "apps/web/src",
+    },
+    {
+      "eventSummary": "ファイルを読み込んでいる",
+      "eventType": "read",
+      "humanRequired": false,
+      "offsetMs": 8734,
+      "phase": "investigation",
+      "phaseChanged": false,
+      "previousPhase": "investigation",
+      "sequence": 4,
+      "target": "apps/server/src/tests/commentary.test.ts",
+    },
+    {
+      "eventSummary": "ファイルを読み込んでいる",
+      "eventType": "read",
+      "humanRequired": false,
+      "offsetMs": 10573,
+      "phase": "investigation",
+      "phaseChanged": false,
+      "previousPhase": "investigation",
+      "sequence": 5,
+      "target": "apps/server/src/extract.ts",
+    },
+  ],
   "fixtureId": "phase-b-codex-session",
   "messages": [
     {
@@ -22,7 +129,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 400,
         "type": "search",
       },
-      "explanation": "「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「"name": "cli-commentator"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -30,7 +137,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "原因っぽいとこ探してるで。",
+      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
       "ts": 400,
     },
     {
@@ -51,7 +158,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 3218,
         "type": "read",
       },
-      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -59,7 +166,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "ファイル読んで状況確認してるで。",
+      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
       "ts": 3218,
     },
     {
@@ -80,7 +187,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 7355,
         "type": "search",
       },
-      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
         "補足: rg はプロジェクト全体を高速検索するコマンド",
       ],
@@ -90,7 +197,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "原因っぽいとこ探してるで。",
+      "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
       "ts": 7355,
     },
     {
@@ -121,7 +228,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "ts": 10573,
         "type": "read",
       },
-      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "kind": "commentary",
       "meta": {
@@ -129,7 +236,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "mode": "both",
         "narrationProvider": "rules",
       },
-      "narration": "ファイル読んで状況確認してるで。",
+      "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
       "ts": 10573,
     },
   ],
@@ -140,7 +247,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "read": 3,
       "search": 2,
     },
-    "exactNarrationRepeats": 2,
+    "exactNarrationRepeats": 0,
     "glossaryNotes": 1,
     "suppressed": 1,
   },

--- a/apps/server/src/tests/comment.prompt.test.ts
+++ b/apps/server/src/tests/comment.prompt.test.ts
@@ -8,6 +8,7 @@ import {
   buildNarrationPrompt,
   normalizeGeneratedCommentaryText,
 } from "../styles/prompt.js";
+import { createSessionContext } from "../session-context.js";
 
 type PromptFixture = {
   id: string;
@@ -97,6 +98,70 @@ describe("rule-based supervision layer", () => {
     expect(kansai.explanation).toBe(standard.explanation);
     expect(zundamon.explanation).toBe(standard.explanation);
     expect(kansai.explanation).not.toMatch(/やで|や。|へん|なのだ/u);
+  });
+
+  it("keeps context-free output compatible and uses observed context when provided", async () => {
+    const { comment } = await import("../styles/index.js");
+    const event: Event = {
+      ts: 1,
+      type: "read",
+      summary: "ファイルを読み込んでいる",
+      detail: "⏺ Read(apps/server/src/index.ts)",
+    };
+    const context = createSessionContext();
+    expect(await comment(event, "standard", {}, context.snapshot())).toEqual(
+      await comment(event, "standard")
+    );
+
+    context.setTaskContext({
+      objective: "実況のセッション文脈を確認する",
+      userPrompt: "実装を読んでください",
+      source: "fixture",
+    });
+    const snapshot = context.observeEvent(event);
+    const contextual = await comment(event, "standard", {}, snapshot);
+    expect(contextual.narration).toContain("調査段階");
+    expect(contextual.narration).toContain("apps/server/src/index.ts");
+    expect(contextual.explanation).toContain("実況のセッション文脈を確認する");
+    expect(contextual.explanation).not.toMatch(/成功|完了見込み/u);
+  });
+});
+
+describe("session context prompts", () => {
+  it("keeps an unobserved purpose explicitly unknown", () => {
+    const event: Event = { ts: 1, type: "stdout", summary: "進行中" };
+    const prompt = buildNarrationPrompt(event, "standard", createSessionContext().snapshot());
+    expect(prompt).toContain("作業目的: 不明");
+    expect(prompt).toContain("不明な目的・結果・成功見込みを補わない");
+  });
+
+  it("adds only bounded observed context and omits prior raw event details", () => {
+    const context = createSessionContext();
+    context.setTaskContext({
+      objective: "実況の流れを確認する",
+      userPrompt: "関連実装を読んでください",
+      source: "fixture",
+    });
+    context.observeEvent({
+      ts: 1,
+      type: "search",
+      summary: "関連箇所を検索している",
+      detail: "rg secret-pattern-that-must-not-enter-history apps/server/src",
+    });
+    const current: Event = {
+      ts: 2,
+      type: "read",
+      summary: "ファイルを読み込んでいる",
+      detail: "⏺ Read(apps/server/src/index.ts)",
+    };
+    const prompt = buildExplanationPrompt(current, "standard", context.observeEvent(current));
+
+    expect(prompt).toContain("観測済みセッション文脈");
+    expect(prompt).toContain("実況の流れを確認する");
+    expect(prompt).toContain("調査 (investigation)");
+    expect(prompt).toContain("apps/server/src/index.ts");
+    expect(prompt).toContain("search:関連箇所を検索している");
+    expect(prompt).not.toContain("secret-pattern-that-must-not-enter-history");
   });
 });
 

--- a/apps/server/src/tests/comment.prompt.test.ts
+++ b/apps/server/src/tests/comment.prompt.test.ts
@@ -135,6 +135,19 @@ describe("session context prompts", () => {
     expect(prompt).toContain("不明な目的・結果・成功見込みを補わない");
   });
 
+  it("labels a preset without presenting it as a confirmed objective", () => {
+    const context = createSessionContext();
+    context.reset({ presetName: "Claude Code 開発用" });
+    const prompt = buildNarrationPrompt(
+      { ts: 1, type: "start", summary: "開始" },
+      "standard",
+      context.snapshot()
+    );
+    expect(prompt).toContain("作業目的: 不明");
+    expect(prompt).toContain("起動プリセット: Claude Code 開発用");
+    expect(prompt).not.toContain("確認済みの作業目的: Claude Code 開発用");
+  });
+
   it("adds only bounded observed context and omits prior raw event details", () => {
     const context = createSessionContext();
     context.setTaskContext({

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -48,7 +48,7 @@ describe("Phase B evaluation replay", () => {
       humanRequired: false,
     });
     expect(result.commentaryComparisons[0].withContext.explanation).toContain(
-      fixture.taskContext.objective
+      fixture.taskContext.objective.slice(0, 24)
     );
     expect(result.commentaryComparisons.some(({ withoutContext, withContext }) =>
       withoutContext.narration !== withContext.narration

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -33,7 +33,26 @@ describe("Phase B evaluation replay", () => {
       suppressed: 1,
       eventsByType: { search: 2, read: 3 },
       glossaryNotes: 1,
+      exactNarrationRepeats: 0,
     });
+    expect(result.contextTimeline.map(({ phase }) => phase)).toEqual([
+      "investigation",
+      "investigation",
+      "investigation",
+      "investigation",
+      "investigation",
+    ]);
+    expect(result.contextTimeline[0]).toMatchObject({
+      previousPhase: "unknown",
+      phaseChanged: true,
+      humanRequired: false,
+    });
+    expect(result.commentaryComparisons[0].withContext.explanation).toContain(
+      fixture.taskContext.objective
+    );
+    expect(result.commentaryComparisons.some(({ withoutContext, withContext }) =>
+      withoutContext.narration !== withContext.narration
+    )).toBe(true);
     expect(result).toMatchSnapshot();
   });
 

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -27,8 +27,8 @@
         "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '\"name\": \"cli-commentator\"' package.json && git remote -v)",
         "priority": "progress"
       },
-      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
-      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
+      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用…」に向けた調査段階です。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -56,8 +56,8 @@
         "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
-      "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
+      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -85,8 +85,8 @@
         "detail": "⏺ Grep(rg -n \"buildSpeechText|queueSpeech|commentaryDisplayMode\" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
         "priority": "progress"
       },
-      "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
-      "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "narration": "今の対象は「apps/web/src」や。",
+      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
         "補足: rg はプロジェクト全体を高速検索するコマンド"
       ],
@@ -126,8 +126,8 @@
         "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
-      "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "narration": "今の対象は「apps/server/src/extract.ts」や。",
+      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -202,8 +202,8 @@
         "explanation": "「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
       },
       "withContext": {
-        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
-        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
+        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用…」に向けた調査段階です。"
       }
     },
     {
@@ -214,8 +214,8 @@
         "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
       },
       "withContext": {
-        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
-        "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
+        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
+        "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
       }
     },
     {
@@ -226,8 +226,8 @@
         "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
       },
       "withContext": {
-        "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
-        "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+        "narration": "今の対象は「apps/web/src」や。",
+        "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
       }
     },
     {
@@ -238,8 +238,8 @@
         "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
       },
       "withContext": {
-        "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
-        "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
+        "narration": "今の対象は「apps/server/src/extract.ts」や。",
+        "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
       }
     }
   ],

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -27,8 +27,8 @@
         "detail": "⏺ Grep(test -f pnpm-workspace.yaml && grep -q '\"name\": \"cli-commentator\"' package.json && git remote -v)",
         "priority": "progress"
       },
-      "narration": "原因っぽいとこ探してるで。",
-      "explanation": "「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
+      "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -56,8 +56,8 @@
         "detail": "⏺ Read(nl -ba apps/server/src/commentary/orchestrator.ts | sed -n '1,120p'; nl -ba apps/server/src/commentary/rule-based.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "ファイル読んで状況確認してるで。",
-      "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
+      "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
@@ -85,8 +85,8 @@
         "detail": "⏺ Grep(rg -n \"buildSpeechText|queueSpeech|commentaryDisplayMode\" apps/web/src; nl -ba apps/web/src/lib/tsx-runner.ts | sed -n '1,80p')",
         "priority": "progress"
       },
-      "narration": "原因っぽいとこ探してるで。",
-      "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
+      "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
+      "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。",
       "glossaryNotes": [
         "補足: rg はプロジェクト全体を高速検索するコマンド"
       ],
@@ -126,13 +126,120 @@
         "detail": "⏺ Read(nl -ba apps/server/src/extract.ts | sed -n '1,180p'; nl -ba apps/server/src/event-priority.ts | sed -n '1,120p')",
         "priority": "progress"
       },
-      "narration": "ファイル読んで状況確認してるで。",
-      "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
+      "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
+      "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。",
       "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
         "explanationProvider": "rules",
         "mode": "both"
+      }
+    }
+  ],
+  "contextTimeline": [
+    {
+      "offsetMs": 400,
+      "eventType": "search",
+      "eventSummary": "該当箇所を検索している",
+      "sequence": 1,
+      "phase": "investigation",
+      "previousPhase": "unknown",
+      "phaseChanged": true,
+      "target": "pnpm-workspace.yaml",
+      "humanRequired": false
+    },
+    {
+      "offsetMs": 3218,
+      "eventType": "read",
+      "eventSummary": "ファイルを読み込んでいる",
+      "sequence": 2,
+      "phase": "investigation",
+      "previousPhase": "investigation",
+      "phaseChanged": false,
+      "target": "apps/server/src/commentary/orchestrator.ts",
+      "humanRequired": false
+    },
+    {
+      "offsetMs": 7355,
+      "eventType": "search",
+      "eventSummary": "該当箇所を検索している",
+      "sequence": 3,
+      "phase": "investigation",
+      "previousPhase": "investigation",
+      "phaseChanged": false,
+      "target": "apps/web/src",
+      "humanRequired": false
+    },
+    {
+      "offsetMs": 8734,
+      "eventType": "read",
+      "eventSummary": "ファイルを読み込んでいる",
+      "sequence": 4,
+      "phase": "investigation",
+      "previousPhase": "investigation",
+      "phaseChanged": false,
+      "target": "apps/server/src/tests/commentary.test.ts",
+      "humanRequired": false
+    },
+    {
+      "offsetMs": 10573,
+      "eventType": "read",
+      "eventSummary": "ファイルを読み込んでいる",
+      "sequence": 5,
+      "phase": "investigation",
+      "previousPhase": "investigation",
+      "phaseChanged": false,
+      "target": "apps/server/src/extract.ts",
+      "humanRequired": false
+    }
+  ],
+  "commentaryComparisons": [
+    {
+      "offsetMs": 400,
+      "eventType": "search",
+      "withoutContext": {
+        "narration": "原因っぽいとこ探してるで。",
+        "explanation": "「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+      },
+      "withContext": {
+        "narration": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。 原因っぽいとこ探してるで。",
+        "explanation": "目的「Phase Bの実況品質について、反復・目的説明・状態変化・用語補足・読み上げ密度を調査する」に向けた調査段階です。 「\"name\": \"cli-commentator\"」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+      }
+    },
+    {
+      "offsetMs": 3218,
+      "eventType": "read",
+      "withoutContext": {
+        "narration": "ファイル読んで状況確認してるで。",
+        "explanation": "rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
+      },
+      "withContext": {
+        "narration": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。 ファイル読んで状況確認してるで。",
+        "explanation": "現在は調査段階です。 rule-based.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
+      }
+    },
+    {
+      "offsetMs": 7355,
+      "eventType": "search",
+      "withoutContext": {
+        "narration": "原因っぽいとこ探してるで。",
+        "explanation": "「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+      },
+      "withContext": {
+        "narration": "今の対象は「apps/web/src」や。 原因っぽいとこ探してるで。",
+        "explanation": "現在は調査段階です。 「buildSpeechText|queueSpeech|commentaryDisplayMode」を手がかりにプロジェクト全体を横断検索して、関係する場所を絞っています。"
+      }
+    },
+    {
+      "offsetMs": 10573,
+      "eventType": "read",
+      "withoutContext": {
+        "narration": "ファイル読んで状況確認してるで。",
+        "explanation": "event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
+      },
+      "withContext": {
+        "narration": "今の対象は「apps/server/src/extract.ts」や。 ファイル読んで状況確認してるで。",
+        "explanation": "現在は調査段階です。 event-priority.ts | sed -n '1,120p' を読んで、現在の実装を確認しています。"
       }
     }
   ],
@@ -158,6 +265,6 @@
       "read": 3
     },
     "glossaryNotes": 1,
-    "exactNarrationRepeats": 2
+    "exactNarrationRepeats": 0
   }
 }

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -28,6 +28,19 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     ["exactNarrationRepeats", baseline.metrics.exactNarrationRepeats, candidate.metrics.exactNarrationRepeats],
   ];
   const eventTypeRows = comparePhaseBEventTypes(baseline.metrics, candidate.metrics);
+  const contextRows = candidate.contextTimeline.map(({ offsetMs, eventType, phase, previousPhase, phaseChanged, target, humanRequired }) => [
+    offsetMs,
+    eventType,
+    phase,
+    phaseChanged ? `${previousPhase} → ${phase}` : "-",
+    target ?? "-",
+    humanRequired ? "yes" : "no",
+  ]);
+  const commentaryRows = candidate.commentaryComparisons.map(({ offsetMs, withoutContext, withContext }) => [
+    offsetMs,
+    withoutContext.narration ?? "-",
+    withContext.narration ?? "-",
+  ]);
   return [
     "# Phase B fixture replay report",
     "",
@@ -46,6 +59,18 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     ...eventTypeRows.map(({ eventType, baseline: before, candidate: after }) =>
       `| ${eventType} | ${before} | ${after} |`
     ),
+    "",
+    "## Session context timeline",
+    "",
+    "| offset (ms) | event | phase | transition | target | HUMAN required |",
+    "|---:|---|---|---|---|---|",
+    ...contextRows.map((row) => `| ${row.join(" | ")} |`),
+    "",
+    "## Commentary with / without context",
+    "",
+    "| offset (ms) | without context | with context |",
+    "|---:|---|---|",
+    ...commentaryRows.map((row) => `| ${row.join(" | ")} |`),
     "",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

Add a server-owned `SessionContext` so rule-based commentary and LLM prompts can use an immutable snapshot of the observed task, target, recent flow, phase transition, and explicit HUMAN-wait state.

The Web/TTS layer is unchanged. No environment variables or public protocol fields changed, so CLAUDE/ROADMAP/LLM adapter docs did not need updates; the deterministic transition table is documented beside the implementation.

## Related Issues

Closes #329

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Main changes

- Add an independently instantiable `createSessionContext()` API with `setTaskContext`, confirmed-input buffering, `observeEvent`, immutable `snapshot`, and `reset`.
- Reset context on new PTY, profile restart/switch, ad-hoc launch, and new file-tail start; pass the event-time snapshot through `comment()`, rules, fallback, and both LLM prompts.
- Extend Phase B output with the per-event phase/transition/target/HUMAN state and context-on/off commentary, plus deterministic transition and safety tests.
- Treat each confirmed HUMAN instruction as a fresh task flow within a long-lived PTY, while confirmed responses resume the phase that was waiting.
- Restrict HUMAN-wait inference to classified event summaries, keep preset names as session labels rather than objectives, and cover additional mutating PR operations.

## Phase decision table

| Observed event/operation | Phase | Maintain / transition rule |
|---|---|---|
| `read`, `search` | `investigation` | Starts/maintains investigation; supporting reads do not pull editing, verification, or publishing backward |
| `write`, patch | `editing` | Explicitly enters editing, including a new edit cycle after verification/publishing |
| `test`, `lint`, `build`; explicit scoped package scripts | `verification` | Explicitly enters verification |
| `git commit`, `git push`, explicit PR/release publication | `publishing` | `git status`/diff/read-only checks do not enter publishing |
| approval/input/HUMAN decision wait; silence | `waiting` | HUMAN is required only for explicit approval/input/decision evidence; silence alone does not set it |
| clear work after waiting | prior or explicit phase | Clears the waiting/HUMAN state without inventing a result |
| ordinary error/output | current phase | Does not invent a purpose, phase, or HUMAN requirement |

Phase IDs and Japanese labels are kept separate. History is capped at five distilled events; task text, summaries, targets, and input buffers are bounded and task strings pass through existing redaction.

## Work-purpose sources and safety

Purpose sources used by this change:

1. Synthetic Phase B `taskContext`
2. A newline-confirmed `writeInput` line, only for directly launched `codex`/`claude` sessions

A sanitized preset name is retained only as an observed session label and is never presented as the HUMAN's task objective.

Current Codex/Claude log parsing does not expose a sufficiently reliable role-tagged HUMAN line, so ambiguous log text and agent output are deliberately not ingested. Split/IME input is buffered until newline; terminal editing controls are handled. Unknown purpose keeps the prior commentary behavior.

## Phase B before / after

| Metric | Before | After |
|---|---:|---:|
| events | 5 | 5 |
| commentaries | 4 | 4 |
| suppressed | 1 | 1 |
| search | 2 | 2 |
| read | 3 | 3 |
| glossary notes | 1 | 1 |
| exact narration repeats | 2 | 0 |

All five fixture events remain `investigation`; only the first event transitions `unknown → investigation`. The synthetic objective and changing targets now appear in context-aware output. `pnpm eval:phase-b` is `MATCH` after the expected baseline review/update.

## Checklist

### General

- [x] Tests pass locally (`pnpm -C apps/server test`)
- [x] No new TypeScript errors
- [x] Code follows existing patterns in the codebase

### LLM / Comment Changes

- [x] Timeout fallback still receives the same immutable context snapshot
- [x] Logs do NOT add task summaries/prompts
- [x] Existing AbortSignal handling is unchanged
- [x] Existing error fallback behavior is unchanged

### Documentation

- [x] No env/config documentation update needed
- [x] Doc-sync reviewed and passed
- [x] Inline transition comments added for non-obvious logic

### Reviewer Focus

- [x] Web/TTS remains presentation-only
- [x] Supporting-read hysteresis is retained within a task; a confirmed new HUMAN instruction resets task-scoped phase, target, history, and sequence.
- [x] Preset names are stored as session labels and are not narrated as task objectives.
- [x] Context-aware Phase B speech density was reduced from 119–177 characters to 85–109 characters per emitted commentary before #330.

## Test Plan

- `pnpm eval:phase-b` — MATCH
- `pnpm -C apps/server test` — 44 files passed, 1 platform-dependent file skipped; 500 tests passed, 5 skipped
- `pnpm -C apps/server build` — passed (TypeScript build/type check)
- `pnpm -C apps/web test` — 9 files / 72 tests passed
- `pnpm -C apps/web build` — passed
- `pnpm check:doc-sync` — passed
- `git diff --check` — passed

### Review follow-up (`dac18a8`)

- Added regression coverage for consecutive tasks in one PTY, HUMAN responses during waiting, waiting keywords inside search commands, preset-label semantics, and mutating PR commands.
- `pnpm -C apps/server test` — 40 files / 447 tests passed in the follow-up checkout.
- `pnpm -C apps/server build` — passed.
- `pnpm eval:phase-b` — MATCH.
- `pnpm check:doc-sync` — passed.
- `git diff --check` — passed.

No `.codex/`, `evaluation/`, or raw log data is included.
