### PR TITLE
fix: refresh stale managed sidecar before startup

### DIFF
--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -32,7 +32,7 @@ This is the primary path for checking the app locally as a desktop app.
 pnpm dev:desktop:managed
 ```
 
-`dev:desktop:managed` runs `pnpm ensure:desktop-sidecar` before startup. If `src-tauri/binaries`, `resources/server`, or `sidecar-manifest.json` is missing or incomplete, it regenerates the sidecar assets through `prepare:desktop-sidecar`. You can also run the same ensure command directly when you only want to validate the sidecar state.
+`dev:desktop:managed` runs `pnpm ensure:desktop-sidecar` before startup. If `src-tauri/binaries`, `resources/server`, or `sidecar-manifest.json` is missing or incomplete, or if the server/shared sources, lockfile, or build configuration changed since the previous preparation, it regenerates the sidecar assets through `prepare:desktop-sidecar`. You can also run the same ensure command directly when you only want to validate the sidecar state.
 
 The Desktop Server panel controls server lifecycle (`Start` / `Stop`) and shows status (`stopped` / `starting` / `running` / `stopping` / `failed`).
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -32,7 +32,7 @@ pnpm install
 pnpm dev:desktop:managed
 ```
 
-`dev:desktop:managed` は起動前に `pnpm ensure:desktop-sidecar` を実行し、`src-tauri/binaries`・`resources/server`・`sidecar-manifest.json` が欠けている場合は `prepare:desktop-sidecar` で再生成します。手動で状態確認だけしたい場合も同じコマンドを直接実行できます。
+`dev:desktop:managed` は起動前に `pnpm ensure:desktop-sidecar` を実行し、`src-tauri/binaries`・`resources/server`・`sidecar-manifest.json` が欠けている場合、または server/shared ソース・lockfile・build設定が前回生成時から変わっている場合は、`prepare:desktop-sidecar` で再生成します。手動で状態確認だけしたい場合も同じコマンドを直接実行できます。
 
 Desktop Server パネルで server の状態を操作します（`Start` / `Stop`、`stopped` / `starting` / `running` / `stopping` / `failed`）。
 

--- a/scripts/check-doc-sync.test.mjs
+++ b/scripts/check-doc-sync.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { findViolations } from "./check-doc-sync.mjs";
+import {
+  computeDesktopSidecarFingerprint,
+  listDesktopSidecarInputFiles,
+} from "./desktop-sidecar-fingerprint.mjs";
 
 test("ignores Cargo.lock-only desktop dependency updates", () => {
   assert.deepEqual(
@@ -48,4 +55,84 @@ test("still requires docs for desktop runtime source changes", () => {
 
   assert.equal(violations.length, 1);
   assert.equal(violations[0].ruleId, "desktop-distribution-doc-sync");
+});
+
+function createFingerprintFixture() {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "sidecar-fingerprint-"));
+  const files = {
+    "package.json": "{}\n",
+    "pnpm-lock.yaml": "lockfileVersion: 9\n",
+    "pnpm-workspace.yaml": "packages: []\n",
+    "apps/server/package.json": "{}\n",
+    "apps/server/tsconfig.build.json": "{}\n",
+    "apps/server/src/index.ts": "export const server = true;\n",
+    "packages/shared/package.json": "{}\n",
+    "packages/shared/src/index.ts": "export const shared = true;\n",
+    "scripts/desktop-sidecar-fingerprint.mjs": "fingerprint helper\n",
+    "scripts/prepare-desktop-sidecar.mjs": "prepare script\n",
+  };
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, content);
+  }
+  return repoRoot;
+}
+
+test("desktop sidecar fingerprint is stable when inputs are unchanged", () => {
+  const repoRoot = createFingerprintFixture();
+
+  assert.equal(
+    computeDesktopSidecarFingerprint(repoRoot),
+    computeDesktopSidecarFingerprint(repoRoot)
+  );
+});
+
+test("desktop sidecar fingerprint changes with server source", () => {
+  const repoRoot = createFingerprintFixture();
+  const before = computeDesktopSidecarFingerprint(repoRoot);
+
+  writeFileSync(
+    path.join(repoRoot, "apps/server/src/index.ts"),
+    "export const server = false;\n"
+  );
+
+  assert.notEqual(computeDesktopSidecarFingerprint(repoRoot), before);
+});
+
+test("desktop sidecar fingerprint changes with lockfile and shared source", () => {
+  const repoRoot = createFingerprintFixture();
+  const before = computeDesktopSidecarFingerprint(repoRoot);
+
+  writeFileSync(
+    path.join(repoRoot, "pnpm-lock.yaml"),
+    "lockfileVersion: 9\npackages: changed\n"
+  );
+  const afterLockfile = computeDesktopSidecarFingerprint(repoRoot);
+  assert.notEqual(afterLockfile, before);
+
+  writeFileSync(
+    path.join(repoRoot, "packages/shared/src/index.ts"),
+    "export const shared = false;\n"
+  );
+  assert.notEqual(
+    computeDesktopSidecarFingerprint(repoRoot),
+    afterLockfile
+  );
+});
+
+test("desktop sidecar fingerprint records missing required inputs", () => {
+  const repoRoot = createFingerprintFixture();
+  const missing = "apps/server/tsconfig.build.json";
+  rmSync(path.join(repoRoot, missing));
+
+  const files = listDesktopSidecarInputFiles(repoRoot);
+  assert.ok(
+    files.some(
+      (file) =>
+        file.relativePath === missing &&
+        file.missing === true
+    )
+  );
 });

--- a/scripts/desktop-sidecar-fingerprint.mjs
+++ b/scripts/desktop-sidecar-fingerprint.mjs
@@ -1,0 +1,72 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+
+export const SIDECAR_FINGERPRINT_VERSION = 1;
+
+const SIDECAR_INPUTS = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "apps/server/package.json",
+  "apps/server/tsconfig.build.json",
+  "apps/server/src",
+  "packages/shared/package.json",
+  "packages/shared/src",
+  "scripts/desktop-sidecar-fingerprint.mjs",
+  "scripts/prepare-desktop-sidecar.mjs",
+];
+
+function collectFiles(repoRoot, relativePath, files) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    files.push({ relativePath, missing: true });
+    return;
+  }
+
+  const stat = statSync(absolutePath);
+  if (stat.isDirectory()) {
+    for (const entry of readdirSync(absolutePath).sort()) {
+      collectFiles(repoRoot, path.join(relativePath, entry), files);
+    }
+    return;
+  }
+
+  if (stat.isFile()) {
+    files.push({ relativePath, missing: false });
+  }
+}
+
+export function listDesktopSidecarInputFiles(repoRoot) {
+  const files = [];
+  for (const relativePath of SIDECAR_INPUTS) {
+    collectFiles(repoRoot, relativePath, files);
+  }
+  return files.sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath, "en")
+  );
+}
+
+export function computeDesktopSidecarFingerprint(repoRoot) {
+  const hash = createHash("sha256");
+  hash.update(`version:${SIDECAR_FINGERPRINT_VERSION}\0`);
+
+  const files = listDesktopSidecarInputFiles(repoRoot);
+  for (const file of files) {
+    const normalizedPath = file.relativePath.split(path.sep).join("/");
+    hash.update(`path:${normalizedPath}\0`);
+    if (file.missing) {
+      hash.update("missing\0");
+      continue;
+    }
+    hash.update(readFileSync(path.join(repoRoot, file.relativePath)));
+    hash.update("\0");
+  }
+
+  return hash.digest("hex");
+}

--- a/scripts/ensure-desktop-sidecar-prepared.mjs
+++ b/scripts/ensure-desktop-sidecar-prepared.mjs
@@ -4,6 +4,10 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  computeDesktopSidecarFingerprint,
+  SIDECAR_FINGERPRINT_VERSION,
+} from "./desktop-sidecar-fingerprint.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -57,6 +61,21 @@ function check() {
   }
   if (!fs.existsSync(entryPath)) {
     return { ok: false, reason: `serverEntry not found: ${manifest.serverEntry}` };
+  }
+
+  if (manifest.inputFingerprintVersion !== SIDECAR_FINGERPRINT_VERSION) {
+    return {
+      ok: false,
+      reason: "missing/outdated sidecar input fingerprint",
+    };
+  }
+
+  const currentFingerprint = computeDesktopSidecarFingerprint(repoRoot);
+  if (manifest.inputFingerprint !== currentFingerprint) {
+    return {
+      ok: false,
+      reason: "sidecar inputs changed",
+    };
   }
 
   return { ok: true, reason: "ok" };

--- a/scripts/prepare-desktop-sidecar.mjs
+++ b/scripts/prepare-desktop-sidecar.mjs
@@ -18,6 +18,10 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  computeDesktopSidecarFingerprint,
+  SIDECAR_FINGERPRINT_VERSION,
+} from "./desktop-sidecar-fingerprint.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -197,6 +201,8 @@ try {
     targetTriple,
     nodeVersion: process.version,
     serverVersion: readPackageVersion(path.join(serverDir, "package.json")),
+    inputFingerprintVersion: SIDECAR_FINGERPRINT_VERSION,
+    inputFingerprint: computeDesktopSidecarFingerprint(repoRoot),
     nodeBinary: toPosix(path.relative(tauriDir, sidecarNodePath)),
     serverRoot: toPosix(path.relative(tauriDir, bundledServerDir)),
     serverEntry,


### PR DESCRIPTION
## Summary

- fingerprint the server/shared sources, lockfile, and sidecar build inputs
- store the fingerprint in the prepared sidecar manifest
- rebuild the managed desktop sidecar when those inputs change
- document the managed startup refresh behavior

## Root cause

`ensure:desktop-sidecar` checked only whether the prepared files and manifest existed. A previously prepared sidecar therefore remained valid even after the server source or dependency inputs changed.

## Validation

- `node --test ./scripts/check-doc-sync.test.mjs`
- `pnpm check:doc-sync`
- `pnpm build:server`
- `pnpm ensure:desktop-sidecar` (rebuild on stale manifest, then no-op on second run)
- `pnpm -r test`
- `git diff --check`

## Out of scope

The Homebrew Node shared-library bundling issue remains separate in #342.

Closes #341