### PR TITLE
fix: validate bundled Node runtime portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Web lint
         run: pnpm -C apps/web lint
 
+      - name: Desktop sidecar runtime tests
+        run: pnpm test:desktop-sidecar-runtime
+
   desktop_check:
     runs-on: windows-latest
 

--- a/apps/desktop/src-tauri/SIDECAR_LAYOUT.md
+++ b/apps/desktop/src-tauri/SIDECAR_LAYOUT.md
@@ -26,5 +26,12 @@ This command:
 1. Builds `apps/server` into `dist/`
 2. Deploys production server dependencies
 3. Copies server runtime artifacts into `src-tauri/resources/server`
-4. Copies current Node runtime into `src-tauri/binaries/node-$TARGET_TRIPLE/node(.exe)`
-5. Writes `src-tauri/resources/sidecar-manifest.json`
+4. On macOS, rejects a Node runtime that depends on non-system libraries outside the bundle
+5. Copies the current Node runtime into `src-tauri/binaries/node-$TARGET_TRIPLE/node(.exe)`
+6. Runs the copied Node with `--version` as a startup smoke test
+7. Writes `src-tauri/resources/sidecar-manifest.json`
+
+Homebrew Node builds can depend on `@rpath/libnode.*.dylib` and libraries under
+`/opt/homebrew`. Those builds cannot be packaged by copying only the executable,
+so preparation stops with `[sidecar_node_not_portable]`. Use a self-contained
+Node distribution, such as the installer from nodejs.org, and rerun the command.

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -34,6 +34,13 @@ pnpm dev:desktop:managed
 
 `dev:desktop:managed` runs `pnpm ensure:desktop-sidecar` before startup. If `src-tauri/binaries`, `resources/server`, or `sidecar-manifest.json` is missing or incomplete, or if the server/shared sources, lockfile, or build configuration changed since the previous preparation, it regenerates the sidecar assets through `prepare:desktop-sidecar`. You can also run the same ensure command directly when you only want to validate the sidecar state.
 
+On macOS, sidecar preparation requires a self-contained Node runtime. If your
+Node executable depends on Homebrew libraries such as
+`@rpath/libnode.*.dylib` or files under `/opt/homebrew`, preparation stops with
+`[sidecar_node_not_portable]` before building. Install Node from nodejs.org (or
+use another self-contained distribution) and rerun
+`pnpm prepare:desktop-sidecar`.
+
 The Desktop Server panel controls server lifecycle (`Start` / `Stop`) and shows status (`stopped` / `starting` / `running` / `stopping` / `failed`).
 
 If status becomes `failed`, use the guidance shown in the panel and check logs from the same terminal.

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -34,6 +34,8 @@ pnpm dev:desktop:managed
 
 `dev:desktop:managed` は起動前に `pnpm ensure:desktop-sidecar` を実行し、`src-tauri/binaries`・`resources/server`・`sidecar-manifest.json` が欠けている場合、または server/shared ソース・lockfile・build設定が前回生成時から変わっている場合は、`prepare:desktop-sidecar` で再生成します。手動で状態確認だけしたい場合も同じコマンドを直接実行できます。
 
+macOSでsidecarを生成する場合は、自己完結型のNodeランタイムが必要です。Node実行ファイルが`@rpath/libnode.*.dylib`や`/opt/homebrew`配下のHomebrewライブラリへ依存していると、ビルド前に`[sidecar_node_not_portable]`で停止します。nodejs.org版などの自己完結型Nodeへ切り替え、`pnpm prepare:desktop-sidecar`を再実行してください。
+
 Desktop Server パネルで server の状態を操作します（`Start` / `Stop`、`stopped` / `starting` / `running` / `stopping` / `failed`）。
 
 `failed` になった場合は、パネルの復旧ガイダンスと同じターミナルのログを確認してください。

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ensure:desktop-sidecar": "node ./scripts/ensure-desktop-sidecar-prepared.mjs",
     "prepare:desktop-sidecar": "node ./scripts/prepare-desktop-sidecar.mjs",
     "build:sidecar": "pnpm prepare:desktop-sidecar",
+    "test:desktop-sidecar-runtime": "node --test ./scripts/desktop-sidecar-runtime.test.mjs",
     "check:doc-sync": "node ./scripts/check-doc-sync.mjs",
     "smoke:desktop-distribution": "node ./scripts/desktop-distribution-smoke.mjs",
     "smoke:llm": "bash ./scripts/smoke-llm.sh",

--- a/scripts/check-doc-sync.mjs
+++ b/scripts/check-doc-sync.mjs
@@ -26,6 +26,7 @@ export const RULES = [
     triggers: [
       /^apps\/desktop\//,
       /^scripts\/prepare-desktop-sidecar\.mjs$/,
+      /^scripts\/desktop-sidecar-runtime\.mjs$/,
       /^\.github\/workflows\/ci\.yml$/,
       /^\.github\/workflows\/release-desktop\.yml$/,
     ],

--- a/scripts/check-doc-sync.test.mjs
+++ b/scripts/check-doc-sync.test.mjs
@@ -57,6 +57,15 @@ test("still requires docs for desktop runtime source changes", () => {
   assert.equal(violations[0].ruleId, "desktop-distribution-doc-sync");
 });
 
+test("still requires docs for desktop sidecar runtime validation changes", () => {
+  const violations = findViolations([
+    "scripts/desktop-sidecar-runtime.mjs",
+  ]);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].ruleId, "desktop-distribution-doc-sync");
+});
+
 function createFingerprintFixture() {
   const repoRoot = mkdtempSync(path.join(os.tmpdir(), "sidecar-fingerprint-"));
   const files = {
@@ -69,6 +78,7 @@ function createFingerprintFixture() {
     "packages/shared/package.json": "{}\n",
     "packages/shared/src/index.ts": "export const shared = true;\n",
     "scripts/desktop-sidecar-fingerprint.mjs": "fingerprint helper\n",
+    "scripts/desktop-sidecar-runtime.mjs": "runtime helper\n",
     "scripts/prepare-desktop-sidecar.mjs": "prepare script\n",
   };
 
@@ -96,6 +106,18 @@ test("desktop sidecar fingerprint changes with server source", () => {
   writeFileSync(
     path.join(repoRoot, "apps/server/src/index.ts"),
     "export const server = false;\n"
+  );
+
+  assert.notEqual(computeDesktopSidecarFingerprint(repoRoot), before);
+});
+
+test("desktop sidecar fingerprint changes with runtime validation", () => {
+  const repoRoot = createFingerprintFixture();
+  const before = computeDesktopSidecarFingerprint(repoRoot);
+
+  writeFileSync(
+    path.join(repoRoot, "scripts/desktop-sidecar-runtime.mjs"),
+    "updated runtime helper\n"
   );
 
   assert.notEqual(computeDesktopSidecarFingerprint(repoRoot), before);

--- a/scripts/desktop-sidecar-fingerprint.mjs
+++ b/scripts/desktop-sidecar-fingerprint.mjs
@@ -19,6 +19,7 @@ const SIDECAR_INPUTS = [
   "packages/shared/package.json",
   "packages/shared/src",
   "scripts/desktop-sidecar-fingerprint.mjs",
+  "scripts/desktop-sidecar-runtime.mjs",
   "scripts/prepare-desktop-sidecar.mjs",
 ];
 

--- a/scripts/desktop-sidecar-runtime.mjs
+++ b/scripts/desktop-sidecar-runtime.mjs
@@ -1,0 +1,97 @@
+import { execFileSync, spawnSync } from "node:child_process";
+
+const MACOS_SYSTEM_LIBRARY_PREFIXES = [
+  "/System/Library/",
+  "/usr/lib/",
+];
+
+export function parseOtoolDependencies(output) {
+  return String(output)
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim().match(/^(.+?)\s+\(compatibility version/))
+    .filter(Boolean)
+    .map((match) => match[1]);
+}
+
+export function findNonSystemMacOSDependencies(dependencies) {
+  return dependencies.filter(
+    (dependency) =>
+      !MACOS_SYSTEM_LIBRARY_PREFIXES.some((prefix) =>
+        dependency.startsWith(prefix)
+      )
+  );
+}
+
+export function assertMacOSNodeRuntimePortableFromOtool(nodePath, output) {
+  const dependencies = parseOtoolDependencies(output);
+  const nonSystemDependencies =
+    findNonSystemMacOSDependencies(dependencies);
+
+  if (nonSystemDependencies.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      "[sidecar_node_not_portable] Current Node runtime cannot be bundled as a single file.",
+      `source=${nodePath}`,
+      `non_system_dependencies=${nonSystemDependencies.join(",")}`,
+      "Use a self-contained Node distribution (for example, Node from nodejs.org or actions/setup-node), then rerun `pnpm prepare:desktop-sidecar`.",
+    ].join(" | ")
+  );
+}
+
+export function assertNodeRuntimePortable(
+  nodePath,
+  {
+    platform = process.platform,
+    runOtool = execFileSync,
+  } = {}
+) {
+  if (platform !== "darwin") {
+    return;
+  }
+
+  let output;
+  try {
+    output = runOtool("otool", ["-L", nodePath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[sidecar_node_dependency_inspection_failed] Failed to inspect Node runtime with otool. | source=${nodePath} | error=${detail}`
+    );
+  }
+
+  assertMacOSNodeRuntimePortableFromOtool(nodePath, output);
+}
+
+export function smokeTestNodeRuntime(
+  nodePath,
+  expectedVersion,
+  { runNode = spawnSync } = {}
+) {
+  const result = runNode(nodePath, ["--version"], {
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = String(result.stdout ?? "").trim();
+  const stderr = String(result.stderr ?? "").trim();
+
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message || stderr || `exit=${result.status}`;
+    throw new Error(
+      `[sidecar_node_smoke_failed] Bundled Node runtime failed to start. | node=${nodePath} | error=${detail}`
+    );
+  }
+
+  if (stdout !== expectedVersion) {
+    throw new Error(
+      `[sidecar_node_smoke_failed] Bundled Node runtime returned an unexpected version. | node=${nodePath} | expected=${expectedVersion} | actual=${stdout || "(empty)"}`
+    );
+  }
+}

--- a/scripts/desktop-sidecar-runtime.test.mjs
+++ b/scripts/desktop-sidecar-runtime.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertMacOSNodeRuntimePortableFromOtool,
+  assertNodeRuntimePortable,
+  findNonSystemMacOSDependencies,
+  parseOtoolDependencies,
+  smokeTestNodeRuntime,
+} from "./desktop-sidecar-runtime.mjs";
+
+const portableOtoolOutput = `/tmp/node:
+\t/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
+\t/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 4201.0.0)
+\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
+`;
+
+const homebrewOtoolOutput = `/opt/homebrew/bin/node:
+\t@rpath/libnode.127.dylib (compatibility version 0.0.0, current version 0.0.0)
+\t/opt/homebrew/opt/libuv/lib/libuv.1.dylib (compatibility version 1.0.0, current version 1.0.0)
+\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
+`;
+
+test("parses dependencies from otool output", () => {
+  assert.deepEqual(parseOtoolDependencies(portableOtoolOutput), [
+    "/usr/lib/libz.1.dylib",
+    "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
+    "/usr/lib/libSystem.B.dylib",
+  ]);
+});
+
+test("classifies rpath and Homebrew libraries as non-system dependencies", () => {
+  assert.deepEqual(
+    findNonSystemMacOSDependencies(
+      parseOtoolDependencies(homebrewOtoolOutput)
+    ),
+    [
+      "@rpath/libnode.127.dylib",
+      "/opt/homebrew/opt/libuv/lib/libuv.1.dylib",
+    ]
+  );
+});
+
+test("accepts a macOS Node runtime with system dependencies only", () => {
+  assert.doesNotThrow(() =>
+    assertMacOSNodeRuntimePortableFromOtool(
+      "/tmp/node",
+      portableOtoolOutput
+    )
+  );
+});
+
+test("rejects a Homebrew-linked macOS Node runtime with recovery guidance", () => {
+  assert.throws(
+    () =>
+      assertMacOSNodeRuntimePortableFromOtool(
+        "/opt/homebrew/bin/node",
+        homebrewOtoolOutput
+      ),
+    (error) => {
+      assert.match(error.message, /\[sidecar_node_not_portable\]/);
+      assert.match(error.message, /@rpath\/libnode\.127\.dylib/);
+      assert.match(error.message, /\/opt\/homebrew\/opt\/libuv/);
+      assert.match(error.message, /nodejs\.org/);
+      return true;
+    }
+  );
+});
+
+test("runs otool only on macOS", () => {
+  let calls = 0;
+  assertNodeRuntimePortable("/tmp/node", {
+    platform: "linux",
+    runOtool: () => {
+      calls += 1;
+      return homebrewOtoolOutput;
+    },
+  });
+  assert.equal(calls, 0);
+});
+
+test("reports an otool inspection failure clearly", () => {
+  assert.throws(
+    () =>
+      assertNodeRuntimePortable("/tmp/node", {
+        platform: "darwin",
+        runOtool: () => {
+          throw new Error("otool unavailable");
+        },
+      }),
+    /\[sidecar_node_dependency_inspection_failed\].*otool unavailable/
+  );
+});
+
+test("accepts a bundled Node runtime with the expected version", () => {
+  assert.doesNotThrow(() =>
+    smokeTestNodeRuntime("/tmp/node", "v22.0.0", {
+      runNode: () => ({
+        status: 0,
+        stdout: "v22.0.0\n",
+        stderr: "",
+      }),
+    })
+  );
+});
+
+test("rejects a bundled Node runtime that cannot start", () => {
+  assert.throws(
+    () =>
+      smokeTestNodeRuntime("/tmp/node", "v22.0.0", {
+        runNode: () => ({
+          status: 134,
+          stdout: "",
+          stderr: "dyld: Library not loaded: @rpath/libnode.127.dylib",
+        }),
+      }),
+    /\[sidecar_node_smoke_failed\].*dyld: Library not loaded/
+  );
+});
+
+test("rejects an unexpected bundled Node version", () => {
+  assert.throws(
+    () =>
+      smokeTestNodeRuntime("/tmp/node", "v22.0.0", {
+        runNode: () => ({
+          status: 0,
+          stdout: "v20.0.0\n",
+          stderr: "",
+        }),
+      }),
+    /\[sidecar_node_smoke_failed\].*expected=v22\.0\.0.*actual=v20\.0\.0/
+  );
+});

--- a/scripts/prepare-desktop-sidecar.mjs
+++ b/scripts/prepare-desktop-sidecar.mjs
@@ -22,6 +22,10 @@ import {
   computeDesktopSidecarFingerprint,
   SIDECAR_FINGERPRINT_VERSION,
 } from "./desktop-sidecar-fingerprint.mjs";
+import {
+  assertNodeRuntimePortable,
+  smokeTestNodeRuntime,
+} from "./desktop-sidecar-runtime.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -130,8 +134,12 @@ const sidecarNodePath = path.join(
   sidecarNodeDir,
   targetTriple.includes("windows") ? "node.exe" : "node"
 );
+const nodeSource = realpathSync(process.execPath);
 
 try {
+  console.log("[sidecar] Validating node runtime portability...");
+  assertNodeRuntimePortable(nodeSource);
+
   console.log("[sidecar] Building server dist...");
   rmForce(serverDistDir);
   run("pnpm", ["-C", "apps/server", "build"]);
@@ -173,13 +181,13 @@ try {
   rmForce(path.join(bundledServerDir, ".env.production"));
 
   console.log("[sidecar] Copying node runtime...");
-  const nodeSource = realpathSync(process.execPath);
   rmForce(sidecarNodeDir);
   ensureDir(sidecarNodeDir);
   copyFileSync(nodeSource, sidecarNodePath);
   if (!targetTriple.includes("windows")) {
     chmodSync(sidecarNodePath, 0o755);
   }
+  smokeTestNodeRuntime(sidecarNodePath, process.version);
 
   const serverEntryCandidates = [
     "resources/server/dist/index.js",


### PR DESCRIPTION
## Summary

- inspect macOS Node dependencies with `otool -L` before sidecar preparation
- reject Homebrew-linked or other non-system runtime dependencies with `[sidecar_node_not_portable]` and recovery guidance
- run the copied Node binary with `--version` before writing the sidecar manifest
- add regression tests, CI coverage, fingerprint tracking, and synchronized documentation

## Root cause

`prepare:desktop-sidecar` copied only `process.execPath` and assumed that executable was self-contained. Homebrew Node 22 links to `@rpath/libnode.*.dylib` and libraries under `/opt/homebrew`, so the copied executable failed immediately inside the `.app`.

## User impact

On macOS, unsupported dynamically linked Node builds now fail before the server build with a clear instruction to use a self-contained Node distribution. Existing self-contained Node builds continue through preparation and are startup-smoked after copying.

## Validation

- Homebrew Node 22.22.0 on Apple Silicon: rejected before build with `[sidecar_node_not_portable]`
- official Node 22.22.0 arm64: `prepare:desktop-sidecar` passed
- release `.app` build and artifact verification passed on Apple Silicon
- `pnpm smoke:desktop-distribution` passed (`/healthz`, `comment_ok`, and negative path)
- `pnpm test:desktop-sidecar-runtime`
- `node --test ./scripts/check-doc-sync.test.mjs`
- `pnpm check:doc-sync`
- `pnpm -r test`
- server typecheck, web build/lint, and `actionlint`

Closes #342