### PR TITLE
feat: compare context-aware rules with LLM provider in phase-b replay

### DIFF
--- a/apps/server/src/commentary/orchestrator.ts
+++ b/apps/server/src/commentary/orchestrator.ts
@@ -11,7 +11,7 @@ import { commentByRules, isSuppressedCommentaryEvent, withCommentaryMode } from 
 import type { SessionContextSnapshot } from "../session-context.js";
 import { applySpeechContract } from "./speech-policy.js";
 
-const COMMENT_TIMEOUT_MS = parseInt(process.env.COMMENT_TIMEOUT_MS ?? "3000", 10);
+export const COMMENT_TIMEOUT_MS = parseInt(process.env.COMMENT_TIMEOUT_MS ?? "3000", 10);
 const adapterCache = new Map<ProviderName, LLMAdapter | null>();
 
 // --- Logging ---
@@ -21,18 +21,43 @@ type CommentLogMeta = {
   eventType: string;
 };
 
+export type CommentMeasurement = {
+  result: "comment_ok" | "comment_timeout" | "comment_aborted" | "comment_llm_error";
+  durationMs: number;
+  provider: string;
+  style: string;
+  eventType: string;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type CommentMeasurementObserver = (measurement: CommentMeasurement) => void;
+
 function logComment(
   result: "ok" | "timeout" | "aborted" | "llm_error",
   durationMs: number,
-  meta: CommentLogMeta
+  meta: CommentLogMeta,
+  usage: { inputTokens?: number; outputTokens?: number } = {},
+  observe?: CommentMeasurementObserver
 ): void {
-  const msg = `comment_${result} duration_ms=${durationMs} provider=${meta.provider} style=${meta.style} event=${meta.eventType}`;
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const resultName = `comment_${result}` as CommentMeasurement["result"];
+  const msg = `${resultName} duration_ms=${durationMs} provider=${meta.provider} style=${meta.style} event=${meta.eventType} input_tokens=${inputTokens} output_tokens=${outputTokens}`;
   if (result === "ok") {
     if (process.env.DEBUG) console.log(msg);
   } else {
     console.warn(msg);
   }
-
+  observe?.({
+    result: resultName,
+    durationMs,
+    provider: meta.provider,
+    style: meta.style,
+    eventType: meta.eventType,
+    inputTokens,
+    outputTokens,
+  });
 }
 
 function resolveCommentaryProviders(providers: ProfileLLMProviders = {}): {
@@ -76,7 +101,7 @@ async function generateLLMText(
   adapter: LLMAdapter,
   prompt: string,
   signal?: AbortSignal
-): Promise<string> {
+): Promise<{ text: string; usage?: { inputTokens?: number; outputTokens?: number } }> {
   const res = await adapter.generateText({
     messages: [{ role: "user", content: prompt }],
     signal,
@@ -87,7 +112,7 @@ async function generateLLMText(
     throw new CommentError("comment_llm_error", "Empty LLM response");
   }
 
-  return text;
+  return { text, usage: res.usage };
 }
 
 function providerLabel(narrationProvider?: ProviderName, explanationProvider?: ProviderName): string {
@@ -100,9 +125,15 @@ async function commentInternal(
   providers: ProfileLLMProviders = {},
   signal?: AbortSignal,
   context?: SessionContextSnapshot
-): Promise<CommentaryPayload> {
+): Promise<{
+  payload: CommentaryPayload;
+  usage: { inputTokens: number; outputTokens: number };
+}> {
   if (isSuppressedCommentaryEvent(ev)) {
-    return commentByRules(ev, style, context);
+    return {
+      payload: commentByRules(ev, style, context),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
   }
 
   const rules = commentByRules(ev, style, context);
@@ -111,23 +142,28 @@ async function commentInternal(
   const explanationAdapter = getAdapter(resolvedProviders.explanationProvider);
 
   if (!narrationAdapter && !explanationAdapter) {
-    return rules;
+    return {
+      payload: rules,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
   }
 
   const [narration, explanation] = await Promise.all([
     narrationAdapter
       ? generateLLMText(narrationAdapter, buildNarrationPrompt(ev, style, context), signal)
-          .then((text) => ({
-            text: normalizeGeneratedCommentaryText(text, "narration"),
+          .then((response) => ({
+            text: normalizeGeneratedCommentaryText(response.text, "narration"),
             provider: narrationAdapter.name,
+            usage: response.usage,
           }))
           .catch(() => null)
       : Promise.resolve(null),
     explanationAdapter
       ? generateLLMText(explanationAdapter, buildExplanationPrompt(ev, style, context), signal)
-          .then((text) => ({
-            text: normalizeGeneratedCommentaryText(text, "explanation"),
+          .then((response) => ({
+            text: normalizeGeneratedCommentaryText(response.text, "explanation"),
             provider: explanationAdapter.name,
+            usage: response.usage,
           }))
           .catch(() => null)
       : Promise.resolve(null),
@@ -137,15 +173,23 @@ async function commentInternal(
     throw new CommentError("comment_llm_error", "All configured commentary providers failed");
   }
 
-  return withCommentaryMode({
-    narration: narration?.text ?? rules.narration,
-    explanation: explanation?.text ?? rules.explanation,
-    glossaryNotes: rules.glossaryNotes,
-    meta: {
-      narrationProvider: narration?.provider ?? rules.meta?.narrationProvider ?? "rules",
-      explanationProvider: explanation?.provider ?? rules.meta?.explanationProvider ?? "rules",
+  return {
+    payload: withCommentaryMode({
+      narration: narration?.text ?? rules.narration,
+      explanation: explanation?.text ?? rules.explanation,
+      glossaryNotes: rules.glossaryNotes,
+      meta: {
+        narrationProvider: narration?.provider ?? rules.meta?.narrationProvider ?? "rules",
+        explanationProvider: explanation?.provider ?? rules.meta?.explanationProvider ?? "rules",
+      },
+    }),
+    usage: {
+      inputTokens:
+        (narration?.usage?.inputTokens ?? 0) + (explanation?.usage?.inputTokens ?? 0),
+      outputTokens:
+        (narration?.usage?.outputTokens ?? 0) + (explanation?.usage?.outputTokens ?? 0),
     },
-  });
+  };
 }
 
 /**
@@ -156,7 +200,8 @@ export async function comment(
   ev: Event,
   style: Style,
   providers: ProfileLLMProviders = {},
-  context?: SessionContextSnapshot
+  context?: SessionContextSnapshot,
+  observe?: CommentMeasurementObserver
 ): Promise<CommentaryPayload> {
   const resolvedProviders = resolveCommentaryProviders(providers);
   const narrationAdapter = getAdapter(resolvedProviders.narrationProvider);
@@ -187,15 +232,15 @@ export async function comment(
         onTimeout: () => controller.abort(),
       }
     );
-    logComment("ok", Date.now() - start, meta);
-    return applySpeechContract(result, ev, context);
+    logComment("ok", Date.now() - start, meta, result.usage, observe);
+    return applySpeechContract(result.payload, ev, context);
   } catch (err) {
     const duration = Date.now() - start;
     if (err instanceof CommentError) {
       const resultType = err.code.replace("comment_", "") as "timeout" | "aborted" | "llm_error";
-      logComment(resultType, duration, meta);
+      logComment(resultType, duration, meta, {}, observe);
     } else {
-      logComment("llm_error", duration, meta);
+      logComment("llm_error", duration, meta, {}, observe);
     }
     return applySpeechContract(commentByRules(ev, style, context), ev, context);
   }

--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -1,4 +1,8 @@
-import { comment } from "../commentary/orchestrator.js";
+import {
+  COMMENT_TIMEOUT_MS,
+  comment,
+  type CommentMeasurement,
+} from "../commentary/orchestrator.js";
 import { withEventPriority, createCommentaryGate } from "../event-priority.js";
 import { extractEvents } from "../extract.js";
 import { redact } from "../redact.js";
@@ -6,6 +10,9 @@ import { createRepeatedErrorDetector } from "../repeated-error-detector.js";
 import type { CommentaryPayload, Event, SourceMode, Style, WsOutgoing } from "../types.js";
 import { createSessionContext, type SessionPhase } from "../session-context.js";
 import { hasRawCommandText } from "../commentary/speech-policy.js";
+import { commentByRules } from "../commentary/rule-based.js";
+import { applySpeechContract } from "../commentary/speech-policy.js";
+import type { ProviderName } from "../llm/types.js";
 
 export type PhaseBReplayFixture = {
   notice: string[];
@@ -73,8 +80,33 @@ export type PhaseBReplayResult = {
     withoutContext: Pick<CommentaryPayload, "narration" | "explanation" | "speech">;
     withContext: Pick<CommentaryPayload, "narration" | "explanation" | "speech">;
   }>;
+  providerComparisons?: Array<{
+    offsetMs: number;
+    eventType: Event["type"];
+    rules: Pick<CommentaryPayload, "narration" | "explanation" | "speech">;
+    llm: Pick<CommentaryPayload, "narration" | "explanation" | "speech">;
+    measurement: CommentMeasurement;
+  }>;
+  providerMetrics?: PhaseBProviderMetrics;
   suppressions: PhaseBSuppression[];
   metrics: PhaseBReplayMetrics;
+};
+
+export type PhaseBProviderMetrics = {
+  provider: ProviderName;
+  model: string;
+  timeoutMs: number;
+  attempted: number;
+  withinTimeoutSuccesses: number;
+  withinTimeoutSuccessRate: number;
+  results: Record<CommentMeasurement["result"], number>;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type PhaseBReplayOptions = {
+  llmProvider?: ProviderName;
+  llmModel?: string;
 };
 
 export type PhaseBEventTypeComparison = {
@@ -195,7 +227,41 @@ function buildMetrics(
   };
 }
 
-export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise<PhaseBReplayResult> {
+function buildProviderMetrics(
+  provider: ProviderName,
+  model: string,
+  measurements: CommentMeasurement[]
+): PhaseBProviderMetrics {
+  const results: PhaseBProviderMetrics["results"] = {
+    comment_ok: 0,
+    comment_timeout: 0,
+    comment_aborted: 0,
+    comment_llm_error: 0,
+  };
+  for (const measurement of measurements) {
+    results[measurement.result] += 1;
+  }
+  const withinTimeoutSuccesses = measurements.filter(
+    ({ result, durationMs }) => result === "comment_ok" && durationMs <= COMMENT_TIMEOUT_MS
+  ).length;
+  return {
+    provider,
+    model,
+    timeoutMs: COMMENT_TIMEOUT_MS,
+    attempted: measurements.length,
+    withinTimeoutSuccesses,
+    withinTimeoutSuccessRate:
+      measurements.length === 0 ? 0 : withinTimeoutSuccesses / measurements.length,
+    results,
+    inputTokens: measurements.reduce((total, item) => total + item.inputTokens, 0),
+    outputTokens: measurements.reduce((total, item) => total + item.outputTokens, 0),
+  };
+}
+
+export async function replayPhaseBFixture(
+  fixture: PhaseBReplayFixture,
+  options: PhaseBReplayOptions = {}
+): Promise<PhaseBReplayResult> {
   let currentOffsetMs = 0;
   const gate = createCommentaryGate({
     intervalMs: fixture.commentaryIntervalMs,
@@ -205,6 +271,8 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
   const messages: PhaseBReplayResult["messages"] = [];
   const contextTimeline: PhaseBReplayResult["contextTimeline"] = [];
   const commentaryComparisons: PhaseBReplayResult["commentaryComparisons"] = [];
+  const providerComparisons: NonNullable<PhaseBReplayResult["providerComparisons"]> = [];
+  const providerMeasurements: CommentMeasurement[] = [];
   const suppressions: PhaseBSuppression[] = [];
   const sessionContext = createSessionContext({ now: () => currentOffsetMs });
   sessionContext.setTaskContext({ ...fixture.taskContext, source: "fixture" });
@@ -261,11 +329,50 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
           speech: payload.speech,
         },
       });
+      if (options.llmProvider && options.llmProvider !== "disabled") {
+        const rules = applySpeechContract(
+          commentByRules(event, fixture.style, context),
+          event,
+          context
+        );
+        let measurement: CommentMeasurement | undefined;
+        const llm = await comment(
+          event,
+          fixture.style,
+          {
+            narrationProvider: options.llmProvider,
+            explanationProvider: options.llmProvider,
+          },
+          context,
+          (item) => {
+            measurement = item;
+            providerMeasurements.push(item);
+          }
+        );
+        if (!measurement) {
+          throw new Error("LLM commentary completed without a measurement");
+        }
+        providerComparisons.push({
+          offsetMs: currentOffsetMs,
+          eventType: event.type,
+          rules: {
+            narration: rules.narration,
+            explanation: rules.explanation,
+            speech: rules.speech,
+          },
+          llm: {
+            narration: llm.narration,
+            explanation: llm.explanation,
+            speech: llm.speech,
+          },
+          measurement,
+        });
+      }
       messages.push({ kind: "commentary", ts: currentOffsetMs, ev: event, ...payload });
     }
   }
 
-  return {
+  const result: PhaseBReplayResult = {
     fixtureId: fixture.id,
     source: fixture.source,
     style: fixture.style,
@@ -276,4 +383,13 @@ export async function replayPhaseBFixture(fixture: PhaseBReplayFixture): Promise
     suppressions,
     metrics: buildMetrics(messages, suppressions),
   };
+  if (options.llmProvider && options.llmProvider !== "disabled") {
+    result.providerComparisons = providerComparisons;
+    result.providerMetrics = buildProviderMetrics(
+      options.llmProvider,
+      options.llmModel ?? "unknown",
+      providerMeasurements
+    );
+  }
+  return result;
 }

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -75,6 +75,49 @@ describe("Phase B evaluation replay", () => {
     expect(result).toMatchSnapshot();
   });
 
+  it("compares context-aware rules with an LLM provider and aggregates measurements", async () => {
+    const fixture = await loadFixture();
+    const result = await replayPhaseBFixture(fixture, {
+      llmProvider: "mock",
+      llmModel: "mock",
+    });
+
+    expect(result.providerComparisons).toHaveLength(4);
+    expect(result.providerComparisons?.[0]).toMatchObject({
+      eventType: "search",
+      rules: {
+        narration: expect.any(String),
+        explanation: expect.any(String),
+      },
+      llm: {
+        narration: expect.stringContaining("[mock-"),
+        explanation: expect.stringContaining("[mock-"),
+      },
+      measurement: {
+        result: "comment_ok",
+        provider: "mock/mock",
+        inputTokens: 20,
+        outputTokens: 40,
+      },
+    });
+    expect(result.providerMetrics).toEqual({
+      provider: "mock",
+      model: "mock",
+      timeoutMs: 3000,
+      attempted: 4,
+      withinTimeoutSuccesses: 4,
+      withinTimeoutSuccessRate: 1,
+      results: {
+        comment_ok: 4,
+        comment_timeout: 0,
+        comment_aborted: 0,
+        comment_llm_error: 0,
+      },
+      inputTokens: 80,
+      outputTokens: 160,
+    });
+  });
+
   it("compares event classifications in a stable order", () => {
     expect(comparePhaseBEventTypes(
       {

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -19,7 +19,32 @@ function getArg(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayResult, matches: boolean): string {
+function configuredModel(provider: string): string {
+  if (provider === "gemini") return process.env.GEMINI_MODEL || "gemini-2.0-flash";
+  if (provider === "anthropic") return process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-20240620";
+  if (provider === "openai") return process.env.OPENAI_MODEL || "gpt-4o-mini";
+  if (provider === "groq") return process.env.GROQ_MODEL || "llama-3.3-70b-versatile";
+  if (provider === "local") return process.env.LOCAL_MODEL || "llama3.2";
+  return provider === "mock" ? "mock" : "unknown";
+}
+
+function missingProviderCredential(provider: string): string | undefined {
+  const required: Record<string, string> = {
+    gemini: "GOOGLE_API_KEY",
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    groq: "GROQ_API_KEY",
+  };
+  const name = required[provider];
+  return name && !process.env[name] ? name : undefined;
+}
+
+function markdownReport(
+  baseline: PhaseBReplayResult,
+  candidate: PhaseBReplayResult,
+  matches: boolean,
+  llmStatus: string
+): string {
   const rows = [
     ["events", baseline.metrics.events, candidate.metrics.events],
     ["commentaries", baseline.metrics.commentaries, candidate.metrics.commentaries],
@@ -52,12 +77,32 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     withContext.narration ?? "-",
     withContext.speech?.text ?? "-",
   ]);
+  const providerRows = (candidate.providerComparisons ?? []).map(
+    ({ offsetMs, rules, llm, measurement }) => [
+      offsetMs,
+      rules.narration ?? "-",
+      llm.narration ?? "-",
+      measurement.result,
+      measurement.durationMs,
+      measurement.inputTokens,
+      measurement.outputTokens,
+    ]
+  );
+  const providerMetrics = candidate.providerMetrics;
   return [
     "# Phase B fixture replay report",
     "",
     `- fixture: \`${candidate.fixtureId}\``,
     `- snapshot: ${matches ? "MATCH" : "DIFF"}`,
     "- scope: 28 sanitized lines / 5 extracted events",
+    `- LLM measurement: ${llmStatus}`,
+    ...(providerMetrics
+      ? [
+          `- provider: \`${providerMetrics.provider}\``,
+          `- model: \`${providerMetrics.model}\``,
+          `- COMMENT_TIMEOUT_MS: ${providerMetrics.timeoutMs}`,
+        ]
+      : []),
     "",
     "| metric | baseline | candidate |",
     "|---|---:|---:|",
@@ -84,11 +129,44 @@ function markdownReport(baseline: PhaseBReplayResult, candidate: PhaseBReplayRes
     "|---:|---|---|---|",
     ...commentaryRows.map((row) => `| ${row.join(" | ")} |`),
     "",
+    ...(providerMetrics
+      ? [
+          "## Context-aware rules / LLM provider comparison",
+          "",
+          `- successes within timeout: ${providerMetrics.withinTimeoutSuccesses}/${providerMetrics.attempted} (${(providerMetrics.withinTimeoutSuccessRate * 100).toFixed(1)}%)`,
+          `- results: \`${JSON.stringify(providerMetrics.results)}\``,
+          `- tokens: input=${providerMetrics.inputTokens}, output=${providerMetrics.outputTokens}`,
+          "",
+          "| offset (ms) | rules | LLM | result | duration (ms) | input tokens | output tokens |",
+          "|---:|---|---|---|---:|---:|---:|",
+          ...providerRows.map((row) => `| ${row.join(" | ")} |`),
+          "",
+        ]
+      : []),
   ].join("\n");
 }
 
 const fixture = JSON.parse(await fs.readFile(fixturePath, "utf8")) as PhaseBReplayFixture;
-const candidate = await replayPhaseBFixture(fixture);
+const withLlm = process.argv.includes("--with-llm");
+const llmProvider = process.env.LLM_PROVIDER ?? "disabled";
+const missingCredential = withLlm ? missingProviderCredential(llmProvider) : undefined;
+const llmEnabled = withLlm && llmProvider !== "disabled" && !missingCredential;
+const llmModel = configuredModel(llmProvider);
+if (withLlm && missingCredential) {
+  console.warn(`Skipping LLM measurement: ${missingCredential} is not set`);
+}
+if (withLlm && llmProvider === "disabled") {
+  console.warn("Skipping LLM measurement: LLM_PROVIDER is not set");
+}
+const candidate = await replayPhaseBFixture(
+  fixture,
+  llmEnabled
+    ? {
+        llmProvider: llmProvider as NonNullable<Parameters<typeof replayPhaseBFixture>[1]>["llmProvider"],
+        llmModel,
+      }
+    : {}
+);
 
 if (process.argv.includes("--update-baseline")) {
   await fs.writeFile(baselinePath, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
@@ -97,13 +175,21 @@ if (process.argv.includes("--update-baseline")) {
 }
 
 const baseline = JSON.parse(await fs.readFile(baselinePath, "utf8")) as PhaseBReplayResult;
-const matches = JSON.stringify(baseline) === JSON.stringify(candidate);
+const snapshotCandidate = { ...candidate };
+delete snapshotCandidate.providerComparisons;
+delete snapshotCandidate.providerMetrics;
+const matches = JSON.stringify(baseline) === JSON.stringify(snapshotCandidate);
 const outputDir = path.resolve(getArg("--output-dir") ?? path.join(os.tmpdir(), "cli-commentator-phase-b-eval"));
 await fs.mkdir(outputDir, { recursive: true });
 const candidatePath = path.join(outputDir, "candidate.json");
 const reportPath = path.join(outputDir, "report.md");
 await fs.writeFile(candidatePath, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
-await fs.writeFile(reportPath, markdownReport(baseline, candidate, matches), "utf8");
+const llmStatus = llmEnabled
+  ? "enabled"
+  : withLlm
+    ? `skipped (${missingCredential ? `${missingCredential} is not set` : "LLM_PROVIDER is not set"})`
+    : "disabled";
+await fs.writeFile(reportPath, markdownReport(baseline, candidate, matches, llmStatus), "utf8");
 
 console.log(`Candidate: ${candidatePath}`);
 console.log(`Report: ${reportPath}`);

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -167,17 +167,17 @@ const candidate = await replayPhaseBFixture(
       }
     : {}
 );
+const snapshotCandidate = { ...candidate };
+delete snapshotCandidate.providerComparisons;
+delete snapshotCandidate.providerMetrics;
 
 if (process.argv.includes("--update-baseline")) {
-  await fs.writeFile(baselinePath, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
+  await fs.writeFile(baselinePath, `${JSON.stringify(snapshotCandidate, null, 2)}\n`, "utf8");
   console.log(`Updated baseline: ${baselinePath}`);
   process.exit(0);
 }
 
 const baseline = JSON.parse(await fs.readFile(baselinePath, "utf8")) as PhaseBReplayResult;
-const snapshotCandidate = { ...candidate };
-delete snapshotCandidate.providerComparisons;
-delete snapshotCandidate.providerMetrics;
 const matches = JSON.stringify(baseline) === JSON.stringify(snapshotCandidate);
 const outputDir = path.resolve(getArg("--output-dir") ?? path.join(os.tmpdir(), "cli-commentator-phase-b-eval"));
 await fs.mkdir(outputDir, { recursive: true });


### PR DESCRIPTION
## 目的

#331（文脈付きルール版とLLM版の盲検比較）の**土台部分のみ**を実装します。
同一fixtureを「文脈付きルール版」と「文脈付きLLM版」で再生し、
その際のレイテンシとトークン使用量を記録できるようにします。

盲検そのもの（fixture作成・中立ラベル出力・AI評価者）は**HUMAN決裁待ちのため未着手**です。

## 変更点

- `orchestrator.ts`: 呼び出しごとの計測値（result / duration / provider / トークン数）を
  observer で取り出せるようにし、`COMMENT_TIMEOUT_MS` を export
  - **Geminiアダプタが返していた `usageMetadata` を従来は捨てていた**ため、拾うように修正
- `phase-b-replay.ts`: `providerComparisons` / `providerMetrics` を追加（ルール版 vs LLM版の新軸）
- `run-phase-b-evaluation.mts`: `--with-llm` フラグ、プロバイダ別の既定モデル表示、
  タイムアウト内成功率・トークン数のレポート出力
- `phase-b-evaluation.test.ts`: mock プロバイダで新軸の回帰テストを追加

## 互換性

- 既存の `withoutContext` / `withContext` 軸は**未変更**（#329 の回帰検知を維持）
- スナップショット比較から provider 系フィールドを除外しているため、既存baselineはそのまま
- 認証情報が未設定なら LLM 測定をスキップして従来どおり動作するので、**CIに影響しません**

## 検証

- `pnpm -C apps/server test` → 558 passed / 47 files
- `LLM_PROVIDER=gemini pnpm eval:phase-b --with-llm`（鍵なし）
  → `Skipping LLM measurement: GOOGLE_API_KEY is not set` / `Snapshot: MATCH`
- 実APIでの疎通は**未実施**（`GOOGLE_API_KEY` が環境にないため）

## レビュー時の指摘事項

1. **既定モデル名が二重管理になっています** — `run-phase-b-evaluation.mts` の `configuredModel()` が
   各アダプタの `DEFAULT_MODEL` をコピーしています。現時点では全プロバイダで一致していますが、
   アダプタ側を更新するとレポートに実際と異なるモデル名が載ります
2. `anthropic` の既定は `claude-3-5-sonnet-20240620` です。#331 の採点側にこのプロバイダを使う場合、
   `ANTHROPIC_MODEL` の明示指定を推奨します
3. LLM版の出力はセッション文脈の更新に反映していません（文脈を両版で同一に保つ意図として妥当ですが、
   LLM版の「反復」系メトリクスは今のままでは測れません）

## 補足

実装は Codex、レビューと検証は KURO が担当しました。merge は HUMAN のみ。

Refs #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)