### PR TITLE
fix: update Gemini adapter for current API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ INPUT_MODE=file INPUT_FILE=./ci-output.log pnpm dev:server
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GOOGLE_API_KEY` | (required) | Google AI APIキー |
-| `GEMINI_MODEL` | gemini-2.0-flash | 使用モデル |
+| `GEMINI_MODEL` | gemini-3.5-flash | 使用モデル（短文実況向けに思考を無効化） |
 
 #### Anthropic (`LLM_PROVIDER=anthropic`)
 | Variable | Default | Description |

--- a/apps/server/src/llm/providers/gemini.ts
+++ b/apps/server/src/llm/providers/gemini.ts
@@ -2,7 +2,7 @@ import type { LLMAdapter } from "../adapter.js";
 import type { GenerateTextRequest, GenerateTextResponse } from "../types.js";
 import { CommentError } from "../../errors.js";
 
-const DEFAULT_MODEL = "gemini-2.0-flash";
+export const DEFAULT_GEMINI_MODEL = "gemini-3.5-flash";
 const API_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
 
 interface GeminiContent {
@@ -15,6 +15,9 @@ interface GeminiRequest {
   generationConfig?: {
     temperature?: number;
     maxOutputTokens?: number;
+    thinkingConfig?: {
+      thinkingBudget: number;
+    };
   };
 }
 
@@ -40,7 +43,7 @@ interface GeminiResponse {
  *
  * Environment variables:
  * - GOOGLE_API_KEY (required)
- * - GEMINI_MODEL (optional, defaults to gemini-2.0-flash)
+ * - GEMINI_MODEL (optional, defaults to gemini-3.5-flash)
  */
 export function createGeminiAdapter(
   env: Record<string, string | undefined> = process.env
@@ -51,7 +54,7 @@ export function createGeminiAdapter(
     throw new Error("GOOGLE_API_KEY is required for Gemini provider");
   }
 
-  const model = env.GEMINI_MODEL || DEFAULT_MODEL;
+  const model = env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
 
   return {
     name: "gemini",
@@ -61,7 +64,7 @@ export function createGeminiAdapter(
         throw new CommentError("comment_aborted");
       }
 
-      const endpoint = `${API_BASE}/${model}:generateContent?key=${apiKey}`;
+      const endpoint = `${API_BASE}/${model}:generateContent`;
 
       // Convert OpenAI-style messages to Gemini format
       const contents: GeminiContent[] = req.messages.map((m) => ({
@@ -74,6 +77,9 @@ export function createGeminiAdapter(
         generationConfig: {
           temperature: req.temperature ?? 0.7,
           maxOutputTokens: req.maxTokens ?? 256,
+          ...(supportsZeroThinkingBudget(model)
+            ? { thinkingConfig: { thinkingBudget: 0 } }
+            : {}),
         },
       };
 
@@ -83,6 +89,7 @@ export function createGeminiAdapter(
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            "x-goog-api-key": apiKey,
           },
           body: JSON.stringify(body),
           signal: req.signal,
@@ -138,4 +145,10 @@ export function createGeminiAdapter(
       };
     },
   };
+}
+
+function supportsZeroThinkingBudget(model: string): boolean {
+  return /^gemini-(?:2\.5-(?:flash|flash-lite)|3\.5-(?:flash|flash-lite))(?:$|-)/u.test(
+    model
+  );
 }

--- a/apps/server/src/tests/gemini.provider.test.ts
+++ b/apps/server/src/tests/gemini.provider.test.ts
@@ -57,7 +57,7 @@ describe("createGeminiAdapter", () => {
     });
   });
 
-  it("uses default model gemini-2.0-flash", async () => {
+  it("uses default model gemini-3.5-flash", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
@@ -72,7 +72,7 @@ describe("createGeminiAdapter", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("gemini-2.0-flash:generateContent"),
+      expect.stringContaining("gemini-3.5-flash:generateContent"),
       expect.anything()
     );
   });
@@ -100,7 +100,7 @@ describe("createGeminiAdapter", () => {
     );
   });
 
-  it("includes API key in URL query parameter", async () => {
+  it("sends API key in x-goog-api-key header", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
@@ -115,9 +115,58 @@ describe("createGeminiAdapter", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("key=my-api-key"),
-      expect.anything()
+      expect.not.stringContaining("key=my-api-key"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-goog-api-key": "my-api-key",
+        }),
+      })
     );
+  });
+
+  it("disables thinking for the default short-commentary model", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          candidates: [{ content: { parts: [{ text: "OK" }] } }],
+        }),
+    });
+
+    const adapter = createGeminiAdapter({ GOOGLE_API_KEY: "test-key" });
+    await adapter.generateText({
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse(fetchCall[1]?.body as string);
+
+    expect(body.generationConfig.thinkingConfig).toEqual({
+      thinkingBudget: 0,
+    });
+  });
+
+  it("does not send thinkingConfig to legacy custom models", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          candidates: [{ content: { parts: [{ text: "OK" }] } }],
+        }),
+    });
+
+    const adapter = createGeminiAdapter({
+      GOOGLE_API_KEY: "test-key",
+      GEMINI_MODEL: "gemini-1.5-pro",
+    });
+    await adapter.generateText({
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse(fetchCall[1]?.body as string);
+
+    expect(body.generationConfig.thinkingConfig).toBeUndefined();
   });
 
   it("converts messages to Gemini format", async () => {

--- a/docs/LLM_ADAPTER.ja.md
+++ b/docs/LLM_ADAPTER.ja.md
@@ -7,13 +7,18 @@ LLMプロバイダーを差し替え可能にするAdapter層。
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLM_PROVIDER` | disabled | 使用するプロバイダー (disabled/mock/openai/anthropic/gemini) |
+| `LLM_PROVIDER` | disabled | 使用するプロバイダー (disabled/mock/openai/groq/local/anthropic/gemini) |
 | `MOCK_LLM_MODE` | (empty) | `error` でmockがエラーを投げる（テスト用） |
+| `GOOGLE_API_KEY` | (required) | Gemini APIキー（`x-goog-api-key` ヘッダーで送信） |
+| `GEMINI_MODEL` | gemini-3.5-flash | Geminiの使用モデル |
 
 ## 現状
-- **統合はまだ行っていない**
-- factory + mock + disabled のみ実装
-- openai/anthropic/gemini は未実装（呼ぶとエラー）
+- factory と実況生成への統合は完了
+- disabled / mock / OpenAI / Groq / local / Anthropic / Gemini を実装済み
+- LLM呼び出しが失敗した場合は、文脈付きルールベース実況へフォールバック
+- Geminiの既定モデルは、短文実況のレイテンシと出力完結性を優先して
+  `thinkingConfig.thinkingBudget=0` を送信する
+- 旧カスタムモデルとの互換性のため、思考無効化設定は対応モデルだけに送信する
 
 ## ファイル構成
 
@@ -24,8 +29,11 @@ apps/server/src/llm/
 ├── factory.ts         # createLLMAdapter(env)
 ├── index.ts           # re-export
 └── providers/
-    ├── mock.ts        # 決定論的mock（テスト用）
-    └── disabled.ts    # 未設定時の明示的エラー
+    ├── mock.ts          # 決定論的mock（テスト用）
+    ├── disabled.ts      # 未設定時の明示的エラー
+    ├── openai_compat.ts # OpenAI / Groq / local
+    ├── anthropic.ts     # Anthropic
+    └── gemini.ts        # Gemini
 ```
 
 ## 使い方
@@ -36,15 +44,16 @@ import { createLLMAdapter } from "./llm/index.js";
 const adapter = createLLMAdapter();
 // LLM_PROVIDER 未設定 → disabledAdapter (呼ぶとエラー)
 // LLM_PROVIDER=mock → mockAdapter (決定論的レスポンス)
+// LLM_PROVIDER=gemini → createGeminiAdapter (GOOGLE_API_KEY が必要)
 
 const response = await adapter.generateText({
   messages: [{ role: "user", content: "Hello" }],
 });
 ```
 
-## 将来の統合ポイント
-`apps/server/src/styles/index.ts` の `comment()` 関数で、
-ルールベース実況の代わりにLLMを呼ぶ分岐を追加予定。
+## 統合ポイント
+`apps/server/src/commentary/orchestrator.ts` がLLM実況を呼び出し、失敗時は
+ルールベース実況へフォールバックする。
 
 ## テスト
 

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -9,6 +9,7 @@ import {
   type PhaseBReplayResult,
 } from "../apps/server/src/evaluation/phase-b-replay.js";
 import { buildPhaseBEvaluationArtifacts } from "../apps/server/src/evaluation/phase-b-artifacts.js";
+import { DEFAULT_GEMINI_MODEL } from "../apps/server/src/llm/providers/gemini.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), "..");
@@ -38,7 +39,7 @@ function inferredBaselinePath(fixturePath: string): string {
 }
 
 function configuredModel(provider: string): string {
-  if (provider === "gemini") return process.env.GEMINI_MODEL || "gemini-2.0-flash";
+  if (provider === "gemini") return process.env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
   if (provider === "anthropic") return process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-20240620";
   if (provider === "openai") return process.env.OPENAI_MODEL || "gpt-4o-mini";
   if (provider === "groq") return process.env.GROQ_MODEL || "llama-3.3-70b-versatile";


### PR DESCRIPTION
## Summary

- update the default Gemini model from retired `gemini-2.0-flash` to `gemini-3.5-flash`
- disable thinking for supported short-commentary models so the 256-token output budget is available to the spoken sentence
- move API-key authentication from the URL query to the `x-goog-api-key` header
- share the adapter default with the Phase B evaluator and update LLM documentation

## Why

Gemini 3.x consumed most of the current 256-token output budget as thinking tokens, which produced truncated commentary. The previous default model is no longer available, and the current Gemini API documents header-based API-key authentication.

## User impact

Selecting Gemini without an explicit model now uses a current model and returns a complete short commentary within the existing timeout/fallback design. Legacy custom models do not receive the new thinking configuration.

## Validation

- `pnpm -C apps/server exec vitest run --exclude '**/dist/**'` (41 files, 478 tests)
- `pnpm -C apps/server build`
- `pnpm check:doc-sync`
- `pnpm eval:phase-b --output-dir /tmp/cli-commentator-phase-b-348` (Snapshot: MATCH)

Closes #348