### PR TITLE
docs: clarify recommended LLM configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,17 @@ INPUT_MODE=file INPUT_FILE=./ci-output.log pnpm dev:server
 | `gemini` | Google Gemini API（要: `GOOGLE_API_KEY`） |
 | `anthropic` | Anthropic API（要: `ANTHROPIC_API_KEY`） |
 
+**推奨構成（2026-07-26決裁）:** 実況と解説の両方でLLMプロバイダーを
+明示的に選び、失敗時はルール版へ自動フォールバックさせる。プロファイルで
+`ルール版のみ（LLMを使わない）` を選ぶか、`LLM_PROVIDER=disabled` を設定すれば
+ルール版だけに固定できる。コードの既定値は `disabled` のままとし、利用者が
+プロファイルごとに明示的に選ぶ方式を維持する。
+
+判断時の実測では、`gemini-3.5-flash` が14/14件で
+`COMMENT_TIMEOUT_MS=3000` 以内に成功し、レイテンシ中央値は約1.1秒だった。
+この結果は `thinkingConfig.thinkingBudget=0` を適用した構成（PR #351）が前提。
+方針決裁と比較結果は Issue #331 に記録している。
+
 ### プロバイダー別環境変数
 
 #### OpenAI (`LLM_PROVIDER=openai`)

--- a/apps/web/src/components/ProfileEditor.tsx
+++ b/apps/web/src/components/ProfileEditor.tsx
@@ -42,8 +42,8 @@ const INPUT_MODES: { value: InputMode; label: string }[] = [
 ];
 
 const LLM_PROVIDERS: { value: ProviderName | ""; label: string }[] = [
-  { value: "", label: "（未設定）" },
-  { value: "disabled", label: "無効" },
+  { value: "", label: "（既定の設定に従う）" },
+  { value: "disabled", label: "ルール版のみ（LLMを使わない）" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Gemini" },


### PR DESCRIPTION
## Summary

- rename the empty profile option to `（既定の設定に従う）`
- rename `disabled` to `ルール版のみ（LLMを使わない）` for both narration and explanation
- document the approved LLM-first configuration, rule fallback, opt-in default, and Gemini measurement

## Why

The previous labels `（未設定）` and `無効` did not explain whether the environment default or the rule-based engine would be used. Issue #331 established the recommended configuration and Issue #349 asks that decision to be visible in UI and docs.

## User impact

Profile users can now distinguish inheriting the default configuration from explicitly disabling LLM generation. The code default remains `LLM_PROVIDER=disabled`.

## Validation

- `pnpm -C apps/web lint`
- `pnpm -C apps/web test` (10 files, 78 tests)
- `pnpm -C apps/web build`
- `pnpm check:doc-sync`

Closes #349
Refs #331, #351