### PR TITLE
fix: suppress TUI rendering noise (#354)

### DIFF
--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -68,6 +68,17 @@ describe("extractEvents fixtures", () => {
     expect(events).toEqual([]);
   });
 
+  it("keeps short numeric output from an explicit generic log source", () => {
+    expect(extractEvents("35", "generic")).toEqual([
+      {
+        ts: new Date("2025-01-01T00:00:00.000Z").getTime(),
+        type: "stdout",
+        summary: "ログ更新",
+        detail: "35",
+      },
+    ]);
+  });
+
   it("extracts a Codex question as waiting for a HUMAN response", () => {
     expect(extractEvents("Question 1/1 (1 unanswered)", "codex")).toEqual([
       {

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,8 +1,20 @@
 import type { Event } from "./types.js";
 import { rulesForLine } from "./rulesets/index.js";
-import { isCodexProgressNoise } from "./progress-noise.js";
+import { isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
 import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
+
+// Legacy X10 mouse reports include three coordinate bytes after CSI M. Strip
+// them before the generic CSI matcher consumes only the introducer.
+const LEGACY_MOUSE_REPORT_RE =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: terminal mouse reports contain ESC.
+  /\u001B\[M[\u0020-\u00ff]{3}/g;
+
+// Character-set designation sequences such as ESC ( B otherwise leave "(B"
+// behind after ordinary ANSI stripping.
+const CHARSET_DESIGNATION_RE =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+  /\u001B[()*+][0-2A-Z]/g;
 
 // Remove ANSI/VT control sequences so TUI apps like Claude Code still match rules.
 const ANSI_ESCAPE_RE =
@@ -10,7 +22,12 @@ const ANSI_ESCAPE_RE =
   /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
 
 function normalizeLine(line: string): string {
-  return line.replace(ANSI_ESCAPE_RE, "").trim();
+  return line
+    .replace(LEGACY_MOUSE_REPORT_RE, "")
+    .replace(CHARSET_DESIGNATION_RE, "")
+    .replace(ANSI_ESCAPE_RE, "")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim();
 }
 
 function extractJsonObject(text: string): string | null {
@@ -375,6 +392,9 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
   if (!normalized) return null;
 
   const source = (sourceEnv ?? "").trim().toLowerCase();
+  if (source !== "generic" && isTerminalRenderingNoise(normalized)) {
+    return null;
+  }
   if (source === "codex" && isCodexProgressNoise(normalized)) {
     return null;
   }

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -26,7 +26,8 @@ function normalizeLine(line: string): string {
     .replace(LEGACY_MOUSE_REPORT_RE, "")
     .replace(CHARSET_DESIGNATION_RE, "")
     .replace(ANSI_ESCAPE_RE, "")
-    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/\t/g, " ")
+    .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "")
     .trim();
 }
 

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -27,7 +27,8 @@ function normalizeLine(line: string): string {
     .replace(CHARSET_DESIGNATION_RE, "")
     .replace(ANSI_ESCAPE_RE, "")
     .replace(/\t/g, " ")
-    .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "")
+    // Tab (0x09) was normalized above; remove the remaining C0 controls, including LF.
+    .replace(/[\u0000-\u0008\u000a-\u001f\u007f]/g, "")
     .trim();
 }
 

--- a/apps/server/src/progress-noise.ts
+++ b/apps/server/src/progress-noise.ts
@@ -1,3 +1,17 @@
+export function isTerminalRenderingNoise(text: string): boolean {
+  const compact = text.replace(/\s+/gu, "").trim();
+  if (!compact) return true;
+
+  return (
+    /^\([A-Z0-2]$/u.test(compact) ||
+    /^\d{1,3}[A-Z]?$/u.test(compact) ||
+    /^[A-Za-z]\d{2,3}$/u.test(compact) ||
+    /^[.•·]+\d*$/u.test(compact) ||
+    /^[A-Za-z][A-Za-z ]{1,24}(?:…|\.{3})\d+$/u.test(compact) ||
+    !/[\p{L}\p{N}]/u.test(compact)
+  );
+}
+
 export function isCodexProgressNoise(text: string): boolean {
   return (
     /^working\s*\(\d+s\s*[•·]\s*esc to interrupt\)$/i.test(text) ||

--- a/apps/server/src/progress-noise.ts
+++ b/apps/server/src/progress-noise.ts
@@ -3,11 +3,14 @@ export function isTerminalRenderingNoise(text: string): boolean {
   if (!compact) return true;
 
   return (
+    /^(?:\(B|\d{1,3}[A-Z]?|[A-Za-z]\d{2,3})(?:\s+(?:\(B|\d{1,3}[A-Z]?|[A-Za-z]\d{2,3}))+$/u.test(
+      text.trim()
+    ) ||
     /^\([A-Z0-2]$/u.test(compact) ||
     /^\d{1,3}[A-Z]?$/u.test(compact) ||
     /^[A-Za-z]\d{2,3}$/u.test(compact) ||
     /^[.•·]+\d*$/u.test(compact) ||
-    /^[A-Za-z][A-Za-z ]{1,24}(?:…|\.{3})\d+$/u.test(compact) ||
+    /^[A-Za-z][A-Za-z]{1,24}(?:…|\.{3})\d+s?$/u.test(compact) ||
     !/[\p{L}\p{N}]/u.test(compact)
   );
 }

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -12,6 +12,18 @@ function loadChunks(name: string): string {
   return fixture.chunks.join("");
 }
 
+function loadRenderingFixture(): {
+  noiseChunks: string[];
+  meaningfulChunks: string[];
+} {
+  return JSON.parse(
+    fs.readFileSync(path.join(fixtureDir, "render-noise.json"), "utf8")
+  ) as {
+    noiseChunks: string[];
+    meaningfulChunks: string[];
+  };
+}
+
 describe("Claude TUI supervision detection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -53,5 +65,21 @@ describe("Claude TUI supervision detection", () => {
         expect.objectContaining({ summary: expect.stringMatching(/許可を待っている|質問への回答を待っている|エラーが発生している|作業が完了した/) }),
       ])
     );
+  });
+
+  it("suppresses terminal rendering noise from a Claude Code source", () => {
+    const { noiseChunks } = loadRenderingFixture();
+
+    for (const chunk of noiseChunks) {
+      expect(extractEvents(chunk, "claude"), chunk).toEqual([]);
+    }
+  });
+
+  it("keeps meaningful Claude Code redraw content", () => {
+    const { meaningfulChunks } = loadRenderingFixture();
+
+    for (const chunk of meaningfulChunks) {
+      expect(extractEvents(chunk, "claude"), chunk).not.toEqual([]);
+    }
   });
 });

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -82,4 +82,12 @@ describe("Claude TUI supervision detection", () => {
       expect(extractEvents(chunk, "claude"), chunk).not.toEqual([]);
     }
   });
+
+  it("preserves a separator when normalizing tab-delimited output", () => {
+    expect(extractEvents("apps/server/src/extract.ts\t42", "claude")).toEqual([
+      expect.objectContaining({
+        detail: "apps/server/src/extract.ts 42",
+      }),
+    ]);
+  });
 });

--- a/apps/server/test/fixtures/claude-tui/render-noise.json
+++ b/apps/server/test/fixtures/claude-tui/render-noise.json
@@ -1,0 +1,21 @@
+{
+  "noiseChunks": [
+    "\u001b(B",
+    "\u001b[Mo66",
+    "\u001b[<35;17;4M",
+    "\u001b[35m\u001b[17m",
+    "\u001b[2J\u001b[H",
+    "\u001b[?1000h",
+    "\u001b[1;35H",
+    "Sublimating…46",
+    "(B",
+    "o66",
+    "35",
+    "17M"
+  ],
+  "meaningfulChunks": [
+    "handoff/status-2026-07-26.md の内容を確認しています",
+    "F1 F2 F3 の実行結果: thinkingBudget=0",
+    "着手待ち3件はすべてクローズ済み"
+  ]
+}

--- a/apps/server/test/fixtures/claude-tui/render-noise.json
+++ b/apps/server/test/fixtures/claude-tui/render-noise.json
@@ -1,19 +1,12 @@
 {
   "noiseChunks": [
-    "\u001b(B",
-    "\u001b[Mo66",
-    "\u001b[<35;17;4M",
-    "\u001b[35m\u001b[17m",
-    "\u001b[2J\u001b[H",
-    "\u001b[?1000h",
-    "\u001b[1;35H",
-    "Sublimating…46",
-    "(B",
-    "o66",
-    "35",
-    "17M"
+    "\u001b[35m35\u001b[0m 17M o66",
+    "35 17M",
+    "(B 35 17M o66",
+    "Sublimating… 46s"
   ],
   "meaningfulChunks": [
+    "apps/server/src/extract.ts\t42",
     "handoff/status-2026-07-26.md の内容を確認しています",
     "F1 F2 F3 の実行結果: thinkingBudget=0",
     "着手待ち3件はすべてクローズ済み"


### PR DESCRIPTION
## Summary

- strip complete X10 mouse reports and ANSI charset-designation sequences before ordinary ANSI normalization
- suppress short terminal-rendering fragments independently of the Codex-only progress rules
- add a Claude Code fixture with 12 rendering-noise samples and 3 meaningful redraw samples
- preserve short numeric output when the source is explicitly `generic`

## Why

The extractor previously applied progress-noise suppression only when `source === "codex"`. Claude Code TUI redraws could therefore leave fragments such as `(B`, mouse-coordinate bytes, and cursor parameters that were sent to the LLM as commentary events.

## User impact

Claude Code and Codex TUI rendering artifacts are stopped in the extraction layer before an LLM call. Ordinary generic shell output and meaningful Claude redraw content remain observable.

## Fixture result

- rendering noise suppressed: 12/12
- meaningful redraw samples preserved: 3/3

## Validation

- server: 41 files, 481 tests passed
- web: 10 files, 78 tests passed
- server and web TypeScript checks passed
- Phase B F1/F2/F3: Snapshot MATCH
- docs drift guard: PASS

Closes #354