### PR TITLE
fix: summarize urgent speech targets (#355)

### DIFF
--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -83,6 +83,22 @@ describe("extractEvents fixtures", () => {
     expect(extractEvents("Question 1/1 (0 unanswered)", "codex")).toEqual([]);
   });
 
+  it("attaches the displayed command to a Codex approval request without treating it as executed", () => {
+    expect(
+      extractEvents(
+        "Would you like to run the following command?\npnpm test -- --runInBand",
+        "codex"
+      )
+    ).toEqual([
+      {
+        ts: new Date("2025-01-01T00:00:00.000Z").getTime(),
+        type: "stdout",
+        summary: "コマンド実行の確認待ち",
+        detail: "Would you like to run the following command?\npnpm test -- --runInBand",
+      },
+    ]);
+  });
+
   it("extracts current Codex exec tool calls without surfacing routine plugin logs", async () => {
     const content = await fs.readFile(path.join(fixturesDir, "codex-current-toolcall.log"), "utf8");
     const events = extractEvents(content, "codex");

--- a/apps/server/src/commentary/speech-policy.test.ts
+++ b/apps/server/src/commentary/speech-policy.test.ts
@@ -46,6 +46,36 @@ describe("commentary speech policy", () => {
     expect(result.speech?.text).not.toContain("|");
   });
 
+  it("summarizes an urgent approval command without speaking the full command", () => {
+    const event: Event = {
+      ts: 1,
+      type: "stdout",
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?\npnpm test -- --runInBand",
+    };
+    const result = applySpeechContract(
+      { narration: "HUMANの入力を待っています。" },
+      event,
+      observed(event)
+    );
+
+    expect(result.speech?.text).toBe("要対応です：「テスト」の実行許可を求めています。");
+    expect(result.speech?.text).not.toContain("pnpm");
+    expect(result.speech?.text).not.toContain("--runInBand");
+  });
+
+  it("uses a spoken fallback when an urgent approval target cannot be extracted", () => {
+    const event: Event = {
+      ts: 1,
+      type: "stdout",
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?",
+    };
+    const result = applySpeechContract({}, event, observed(event));
+
+    expect(result.speech?.text).toBe("要対応です：コマンドの実行許可を求めています。");
+  });
+
   it.each([
     "git status を確認しています。",
     "pnpm test を実行しています。",

--- a/apps/server/src/commentary/speech-policy.ts
+++ b/apps/server/src/commentary/speech-policy.ts
@@ -1,5 +1,5 @@
 import { SESSION_PHASE_LABELS, type SessionContextSnapshot } from "../session-context.js";
-import { buildUrgentSpeechText } from "@cli-commentator/shared";
+import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
 import { getEventPriority } from "../event-priority.js";
 import type { CommentaryPayload, Event } from "../types.js";
 

--- a/apps/server/src/commentary/speech-policy.ts
+++ b/apps/server/src/commentary/speech-policy.ts
@@ -1,4 +1,6 @@
 import { SESSION_PHASE_LABELS, type SessionContextSnapshot } from "../session-context.js";
+import { buildUrgentSpeechText } from "@cli-commentator/shared";
+import { getEventPriority } from "../event-priority.js";
 import type { CommentaryPayload, Event } from "../types.js";
 
 const RAW_COMMAND_RE =
@@ -50,6 +52,9 @@ function speechSentence(
   event: Event,
   context: SessionContextSnapshot
 ): string {
+  if (getEventPriority(event) === "urgent") {
+    return buildUrgentSpeechText(event);
+  }
   if (event.type === "done") {
     return safeFallback(event, context);
   }

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -432,8 +432,10 @@ export function extractEvents(chunk: string, sourceEnv: string | undefined = pro
     if (supervisionEvents.length > 0) return supervisionEvents;
   }
 
+  const rawLines = chunk.split(/\r?\n/);
   const events: Event[] = [];
-  for (const rawLine of chunk.split(/\r?\n/)) {
+  for (let index = 0; index < rawLines.length; index += 1) {
+    const rawLine = rawLines[index];
     const sourceLine = normalizeLine(rawLine);
     if (!sourceLine) continue;
 
@@ -442,8 +444,28 @@ export function extractEvents(chunk: string, sourceEnv: string | undefined = pro
 
     const rules = rulesForLine(sourceLine, sourceEnv);
     const hit = rules.find((rule) => rule.match ? rule.match(line) : rule.re.test(line));
-    if (hit) events.push({ ts, type: hit.type, summary: hit.summary, detail: line });
-    else events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
+    if (hit) {
+      let detail = line;
+      if (hit.id === "codex.approval.ask") {
+        for (
+          let commandIndex = index + 1;
+          commandIndex < Math.min(rawLines.length, index + 6);
+          commandIndex += 1
+        ) {
+          const command = normalizeLine(rawLines[commandIndex])
+            .replace(/^(?:[$›❯>]\s*)+/u, "")
+            .trim();
+          if (
+            /^(?:(?:sudo|command|env)\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:pnpm|npm|yarn|bun|npx|node|git|gh|cargo|docker|make|go|python\d*|deno|rm|mv|cp|mkdir|chmod|curl)\b/iu.test(command)
+          ) {
+            detail = `${line}\n${command}`;
+            index = commandIndex;
+            break;
+          }
+        }
+      }
+      events.push({ ts, type: hit.type, summary: hit.summary, detail });
+    } else events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
   }
   return events;
 }

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -181,20 +181,16 @@ describe("Phase B evaluation replay", () => {
     expect(artifacts.blindSpeech[0]?.speechText).toBe(
       result.commentaryComparisons[0].withContext.speech?.text
     );
-    expect(artifacts.blindSpeech[0]?.speechText).toContain(
-      SESSION_PHASE_LABELS.waiting
-    );
+    expect(artifacts.blindSpeech[0]?.speechText).toContain("テスト");
     expect(artifacts.blindSpeech[1]?.speechText).toContain(
       SESSION_PHASE_LABELS.editing
     );
-    expect(artifacts.blindSpeech[2]?.speechText).toContain(
-      SESSION_PHASE_LABELS.waiting
-    );
+    expect(artifacts.blindSpeech[2]?.speechText).toContain("質問1");
     expect(JSON.stringify(artifacts.blindSpeech)).not.toMatch(
       /narration|explanation|humanRequired|phase|provider|withoutContext|withContext/u
     );
     expect(result.commentaryComparisons[0].withContext.speech?.text).toContain(
-      SESSION_PHASE_LABELS.waiting
+      "実行許可"
     );
   });
 

--- a/apps/server/test/fixtures/phase-b-codex-approval.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-approval.expected.json
@@ -13,7 +13,7 @@
         "ts": 0,
         "type": "stdout",
         "summary": "コマンド実行の確認待ち",
-        "detail": "Would you like to run the following command?",
+        "detail": "Would you like to run the following command?\npnpm test -- --runInBand",
         "priority": "urgent"
       }
     },
@@ -24,12 +24,14 @@
         "ts": 0,
         "type": "stdout",
         "summary": "コマンド実行の確認待ち",
-        "detail": "Would you like to run the following command?",
+        "detail": "Would you like to run the following command?\npnpm test -- --runInBand",
         "priority": "urgent"
       },
-      "narration": "待機段階に入り、HUMANの入力を待っています。 今見えている出力は「Would you like to run the following command?」です。",
+      "narration": "待機段階に入り、HUMANの入力を待っています。 今見えている出力は「Would you like to run the following command? pnpm test -- --runInBand」です。",
       "explanation": "目的「依存関係を準備し、対象ファイルへ必要な修正を反映する」に向けた待機段階です。",
-      "glossaryNotes": [],
+      "glossaryNotes": [
+        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う"
+      ],
       "meta": {
         "narrationProvider": "rules",
         "explanationProvider": "rules",
@@ -38,7 +40,7 @@
       "speech": {
         "disposition": "speak",
         "reason": "human_required",
-        "text": "待機段階に入り、HUMANの入力を待っています。"
+        "text": "要対応です：「テスト」の実行許可を求めています。"
       }
     },
     {
@@ -47,7 +49,7 @@
         "ts": 1000,
         "type": "stdout",
         "summary": "コマンド実行が承認された",
-        "detail": "You approved codex to run: pnpm install",
+        "detail": "You approved codex to run: pnpm test -- --runInBand",
         "priority": "progress"
       }
     },
@@ -58,14 +60,12 @@
         "ts": 1000,
         "type": "stdout",
         "summary": "コマンド実行が承認された",
-        "detail": "You approved codex to run: pnpm install",
+        "detail": "You approved codex to run: pnpm test -- --runInBand",
         "priority": "progress"
       },
-      "narration": "未判定段階に入り、対象を扱っています。 今見えている出力は「You approved codex to run: pnpm install」です。",
+      "narration": "未判定段階に入り、対象を扱っています。 今見えている出力は「You approved codex to run: pnpm test -- --runInBand」です。",
       "explanation": "コマンドの通常出力を確認しています。",
-      "glossaryNotes": [
-        "補足: pnpm/npm/yarn は依存関係やスクリプト実行に使う"
-      ],
+      "glossaryNotes": [],
       "meta": {
         "narrationProvider": "rules",
         "explanationProvider": "rules",
@@ -162,7 +162,7 @@
       "speech": {
         "disposition": "speak",
         "reason": "human_required",
-        "text": "待機段階に入り、HUMANの入力を待っています。"
+        "text": "要対応です：質問1への回答を求めています。"
       }
     }
   ],
@@ -257,16 +257,16 @@
       "offsetMs": 0,
       "eventType": "stdout",
       "withoutContext": {
-        "narration": "今見えている出力は「Would you like to run the following command?」です。",
+        "narration": "今見えている出力は「Would you like to run the following command? pnpm test -- --runInBand」です。",
         "explanation": "コマンドの通常出力を確認しています。"
       },
       "withContext": {
-        "narration": "待機段階に入り、HUMANの入力を待っています。 今見えている出力は「Would you like to run the following command?」です。",
+        "narration": "待機段階に入り、HUMANの入力を待っています。 今見えている出力は「Would you like to run the following command? pnpm test -- --runInBand」です。",
         "explanation": "目的「依存関係を準備し、対象ファイルへ必要な修正を反映する」に向けた待機段階です。",
         "speech": {
           "disposition": "speak",
           "reason": "human_required",
-          "text": "待機段階に入り、HUMANの入力を待っています。"
+          "text": "要対応です：「テスト」の実行許可を求めています。"
         }
       }
     },
@@ -274,11 +274,11 @@
       "offsetMs": 1000,
       "eventType": "stdout",
       "withoutContext": {
-        "narration": "今見えている出力は「You approved codex to run: pnpm install」です。",
+        "narration": "今見えている出力は「You approved codex to run: pnpm test -- --runInBand」です。",
         "explanation": "コマンドの通常出力を確認しています。"
       },
       "withContext": {
-        "narration": "未判定段階に入り、対象を扱っています。 今見えている出力は「You approved codex to run: pnpm install」です。",
+        "narration": "未判定段階に入り、対象を扱っています。 今見えている出力は「You approved codex to run: pnpm test -- --runInBand」です。",
         "explanation": "コマンドの通常出力を確認しています。",
         "speech": {
           "disposition": "speak",
@@ -317,7 +317,7 @@
         "speech": {
           "disposition": "speak",
           "reason": "human_required",
-          "text": "待機段階に入り、HUMANの入力を待っています。"
+          "text": "要対応です：質問1への回答を求めています。"
         }
       }
     }

--- a/apps/server/test/fixtures/phase-b-codex-approval.json
+++ b/apps/server/test/fixtures/phase-b-codex-approval.json
@@ -12,8 +12,8 @@
   },
   "commentaryIntervalMs": 2000,
   "lines": [
-    { "offsetMs": 0, "line": "Would you like to run the following command?" },
-    { "offsetMs": 1000, "line": "You approved codex to run: pnpm install" },
+    { "offsetMs": 0, "line": "Would you like to run the following command?\npnpm test -- --runInBand" },
+    { "offsetMs": 1000, "line": "You approved codex to run: pnpm test -- --runInBand" },
     { "offsetMs": 3500, "line": "apply_patch" },
     { "offsetMs": 4000, "line": "⏺ Read(/Users/demo/project/src/index.ts)" },
     { "offsetMs": 4500, "line": "⏺ Bash(pnpm install)" },

--- a/apps/server/test/fixtures/phase-b-codex-lifecycle-error.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-lifecycle-error.expected.json
@@ -108,7 +108,7 @@
       "speech": {
         "disposition": "speak",
         "reason": "urgent",
-        "text": "エラーが出ています。"
+        "text": "要対応です：スクリプトが異常終了している。"
       }
     },
     {
@@ -142,7 +142,7 @@
       "speech": {
         "disposition": "speak",
         "reason": "urgent",
-        "text": "エラーが出ています。"
+        "text": "要対応です：終了コードで失敗している。"
       }
     },
     {
@@ -176,7 +176,7 @@
       "speech": {
         "disposition": "speak",
         "reason": "urgent",
-        "text": "エラーが出ています。"
+        "text": "要対応です：エラーが出ている。"
       }
     }
   ],
@@ -300,7 +300,7 @@
         "speech": {
           "disposition": "speak",
           "reason": "urgent",
-          "text": "エラーが出ています。"
+          "text": "要対応です：スクリプトが異常終了している。"
         }
       }
     },
@@ -317,7 +317,7 @@
         "speech": {
           "disposition": "speak",
           "reason": "urgent",
-          "text": "エラーが出ています。"
+          "text": "要対応です：終了コードで失敗している。"
         }
       }
     },
@@ -334,7 +334,7 @@
         "speech": {
           "disposition": "speak",
           "reason": "urgent",
-          "text": "エラーが出ています。"
+          "text": "要対応です：エラーが出ている。"
         }
       }
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -126,7 +126,7 @@ export default function App() {
       setAttention(toAttentionNotice(ev));
       if (speakUrgentNow(buildUrgentEventSpeechText(ev))) {
         // 読み上げ済みを記録し、同一イベントのcommentary読み上げをスキップする
-        spokenEventsRef.current.add(eventSpeechKey(ev.ts, ev.type));
+        spokenEventsRef.current.add(eventSpeechKey(ev));
       }
     },
     [speakUrgentNow]
@@ -139,7 +139,12 @@ export default function App() {
   // 即時イベントで読み上げ済みのcommentaryはTTSしない（表示はする）
   const queueSpeechDeduped = useCallback(
     (item: CommentaryItem) => {
-      if (spokenEventsRef.current.has(eventSpeechKey(item.ts, item.eventType))) return;
+      if (spokenEventsRef.current.has(eventSpeechKey({
+        ts: item.ts,
+        type: item.eventType,
+        summary: item.summary ?? "",
+        detail: item.detail,
+      }))) return;
       queueSpeech(item);
     },
     [queueSpeech]

--- a/apps/web/src/lib/event-notify.test.ts
+++ b/apps/web/src/lib/event-notify.test.ts
@@ -25,14 +25,53 @@ describe("event-notify", () => {
   });
 
   it("同一イベントを ts と type で相関づけるキーを作る", () => {
-    expect(eventSpeechKey(1234, "stdout")).toBe("1234:stdout");
-    expect(eventSpeechKey(1234, "error")).not.toBe(eventSpeechKey(1234, "stdout"));
+    const first: Event = {
+      ts: 1234,
+      type: "stdout",
+      summary: "コマンド実行の確認待ち",
+      detail: "pnpm test",
+    };
+    expect(eventSpeechKey(first)).toBe(eventSpeechKey({ ...first }));
+    expect(eventSpeechKey({ ...first, type: "error" })).not.toBe(eventSpeechKey(first));
+    expect(eventSpeechKey({ ...first, detail: "git push" })).not.toBe(eventSpeechKey(first));
   });
 
   it("urgentイベントの定型読み上げ文を作る", () => {
     expect(buildUrgentEventSpeechText({ summary: "許可を待っている" })).toBe(
-      "要対応です。許可を待っている。"
+      "要対応です：許可を待っている。"
     );
+  });
+
+  it("許可対象を短く要約し、コマンド全文は読み上げない", () => {
+    const spoken = buildUrgentEventSpeechText({
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?\npnpm test -- --runInBand",
+    });
+    expect(spoken).toBe("要対応です：「テスト」の実行許可を求めています。");
+    expect(spoken).not.toContain("pnpm");
+    expect(spoken).not.toContain("--runInBand");
+  });
+
+  it("質問待ちは質問番号を含む別の文にする", () => {
+    expect(buildUrgentEventSpeechText({
+      summary: "質問への回答を待っている",
+      detail: "Question 1/1 (1 unanswered)",
+    })).toBe("要対応です：質問1への回答を求めています。");
+  });
+
+  it("内容が異なる連続した許可要求は別の文にする", () => {
+    const testRequest = buildUrgentEventSpeechText({
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?\npnpm test",
+    });
+    const pushRequest = buildUrgentEventSpeechText({
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?\ngit push origin topic",
+    });
+
+    expect(testRequest).toContain("テスト");
+    expect(pushRequest).toContain("変更の共有");
+    expect(testRequest).not.toBe(pushRequest);
   });
 
   describe("createSpokenEventRegistry", () => {

--- a/apps/web/src/lib/event-notify.test.ts
+++ b/apps/web/src/lib/event-notify.test.ts
@@ -40,6 +40,9 @@ describe("event-notify", () => {
     expect(buildUrgentEventSpeechText({ summary: "許可を待っている" })).toBe(
       "要対応です：許可を待っている。"
     );
+    expect(buildUrgentEventSpeechText({ summary: "エラー発生!!" })).toBe(
+      "要対応です：エラー発生。"
+    );
   });
 
   it("許可対象を短く要約し、コマンド全文は読み上げない", () => {

--- a/apps/web/src/lib/event-notify.ts
+++ b/apps/web/src/lib/event-notify.ts
@@ -1,5 +1,5 @@
 import type { Event, EventType } from "../types";
-import { buildUrgentSpeechText } from "@cli-commentator/shared";
+import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
 
 /**
  * 即時イベント（kind: "event"）の要対応表示・定型読み上げと、

--- a/apps/web/src/lib/event-notify.ts
+++ b/apps/web/src/lib/event-notify.ts
@@ -1,4 +1,5 @@
 import type { Event, EventType } from "../types";
+import { buildUrgentSpeechText } from "@cli-commentator/shared";
 
 /**
  * 即時イベント（kind: "event"）の要対応表示・定型読み上げと、
@@ -23,13 +24,23 @@ export function toAttentionNotice(ev: Event): AttentionNotice {
 }
 
 /** 同一イベントの即時TTSとcommentary TTSを相関づけるキー */
-export function eventSpeechKey(ts: number, eventType: EventType): string {
-  return `${ts}:${eventType}`;
+export function eventSpeechKey(
+  event: Pick<Event, "ts" | "type" | "summary" | "detail">
+): string {
+  const content = `${event.summary}\u0000${event.detail ?? ""}`;
+  let hash = 2166136261;
+  for (let index = 0; index < content.length; index += 1) {
+    hash ^= content.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${event.ts}:${event.type}:${(hash >>> 0).toString(36)}`;
 }
 
 /** urgentイベントの定型読み上げ文 */
-export function buildUrgentEventSpeechText(ev: Pick<Event, "summary">): string {
-  return `要対応です。${ev.summary}。`;
+export function buildUrgentEventSpeechText(
+  ev: Pick<Event, "summary" | "detail">
+): string {
+  return buildUrgentSpeechText(ev);
 }
 
 export type SpokenEventRegistry = {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./urgent-speech": {
+      "types": "./src/urgent-speech.d.ts",
+      "default": "./src/urgent-speech.js"
+    }
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./protocol.js";
 export * from "./parse-server-message.js";
+export * from "./urgent-speech.js";

--- a/packages/shared/src/urgent-speech.d.ts
+++ b/packages/shared/src/urgent-speech.d.ts
@@ -1,0 +1,5 @@
+import type { Event } from "./protocol.js";
+
+export declare function buildUrgentSpeechText(
+  event: Pick<Event, "summary" | "detail">
+): string;

--- a/packages/shared/src/urgent-speech.js
+++ b/packages/shared/src/urgent-speech.js
@@ -1,17 +1,13 @@
-import type { Event } from "./protocol.js";
-
-type UrgentEvent = Pick<Event, "summary" | "detail">;
-
 const APPROVAL_PROMPT_RE = /would you like to run the following command\?/iu;
 const QUESTION_RE = /Question\s+(\d+)\/\d+\s+\((?:[1-9]\d*) unanswered\)/iu;
 const COMMAND_START_RE =
   /^(?:(?:sudo|command|env)\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:pnpm|npm|yarn|bun|npx|node|git|gh|cargo|docker|make|go|python\d*|deno|rm|mv|cp|mkdir|chmod|curl)\b/iu;
 
-function commandName(value: string): string {
+function commandName(value) {
   return value.replace(/\\/g, "/").split("/").at(-1)?.toLowerCase() ?? value.toLowerCase();
 }
 
-function commandLine(detail: string): string | null {
+function commandLine(detail) {
   const lines = detail.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const promptAt = lines.findIndex((line) => APPROVAL_PROMPT_RE.test(line));
   if (promptAt < 0) return null;
@@ -23,13 +19,13 @@ function commandLine(detail: string): string | null {
   return null;
 }
 
-function tokenizeCommand(command: string): string[] {
+function tokenizeCommand(command) {
   return command.match(/(?:[^\s"'`]+|["'`][^"'`]*["'`])/gu)?.map((token) =>
     token.replace(/^(["'`])|(["'`])$/gu, "")
   ) ?? [];
 }
 
-function commandSummary(command: string): string | null {
+function commandSummary(command) {
   const tokens = tokenizeCommand(command);
   let index = 0;
   while (index < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/u.test(tokens[index])) index += 1;
@@ -76,13 +72,13 @@ function commandSummary(command: string): string | null {
   return "コマンド操作";
 }
 
-function withoutTrailingSentencePunctuation(text: string): string {
+function withoutTrailingSentencePunctuation(text) {
   let end = text.length;
   while (end > 0 && "。.!！".includes(text[end - 1])) end -= 1;
   return text.slice(0, end);
 }
 
-export function buildUrgentSpeechText(event: UrgentEvent): string {
+export function buildUrgentSpeechText(event) {
   const detail = event.detail ?? "";
   if (event.summary === "コマンド実行の確認待ち" || APPROVAL_PROMPT_RE.test(detail)) {
     const command = commandLine(detail);

--- a/packages/shared/src/urgent-speech.ts
+++ b/packages/shared/src/urgent-speech.ts
@@ -76,6 +76,12 @@ function commandSummary(command: string): string | null {
   return "コマンド操作";
 }
 
+function withoutTrailingSentencePunctuation(text: string): string {
+  let end = text.length;
+  while (end > 0 && "。.!！".includes(text[end - 1])) end -= 1;
+  return text.slice(0, end);
+}
+
 export function buildUrgentSpeechText(event: UrgentEvent): string {
   const detail = event.detail ?? "";
   if (event.summary === "コマンド実行の確認待ち" || APPROVAL_PROMPT_RE.test(detail)) {
@@ -93,5 +99,5 @@ export function buildUrgentSpeechText(event: UrgentEvent): string {
       : "要対応です：質問への回答を求めています。";
   }
 
-  return `要対応です：${event.summary.replace(/[。.!！]+$/u, "")}。`;
+  return `要対応です：${withoutTrailingSentencePunctuation(event.summary)}。`;
 }

--- a/packages/shared/src/urgent-speech.ts
+++ b/packages/shared/src/urgent-speech.ts
@@ -1,0 +1,97 @@
+import type { Event } from "./protocol.js";
+
+type UrgentEvent = Pick<Event, "summary" | "detail">;
+
+const APPROVAL_PROMPT_RE = /would you like to run the following command\?/iu;
+const QUESTION_RE = /Question\s+(\d+)\/\d+\s+\((?:[1-9]\d*) unanswered\)/iu;
+const COMMAND_START_RE =
+  /^(?:(?:sudo|command|env)\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:pnpm|npm|yarn|bun|npx|node|git|gh|cargo|docker|make|go|python\d*|deno|rm|mv|cp|mkdir|chmod|curl)\b/iu;
+
+function commandName(value: string): string {
+  return value.replace(/\\/g, "/").split("/").at(-1)?.toLowerCase() ?? value.toLowerCase();
+}
+
+function commandLine(detail: string): string | null {
+  const lines = detail.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const promptAt = lines.findIndex((line) => APPROVAL_PROMPT_RE.test(line));
+  if (promptAt < 0) return null;
+
+  for (const line of lines.slice(promptAt + 1, promptAt + 6)) {
+    const candidate = line.replace(/^(?:[$›❯>]\s*)+/u, "").trim();
+    if (COMMAND_START_RE.test(candidate)) return candidate;
+  }
+  return null;
+}
+
+function tokenizeCommand(command: string): string[] {
+  return command.match(/(?:[^\s"'`]+|["'`][^"'`]*["'`])/gu)?.map((token) =>
+    token.replace(/^(["'`])|(["'`])$/gu, "")
+  ) ?? [];
+}
+
+function commandSummary(command: string): string | null {
+  const tokens = tokenizeCommand(command);
+  let index = 0;
+  while (index < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/u.test(tokens[index])) index += 1;
+  if (["sudo", "command", "env"].includes(commandName(tokens[index] ?? ""))) index += 1;
+
+  const executable = commandName(tokens[index] ?? "");
+  if (!executable) return null;
+  index += 1;
+
+  const valueOptions = new Set(["-C", "--dir", "--filter", "-w", "--workspace", "--prefix", "--cwd"]);
+  while (index < tokens.length && tokens[index].startsWith("-")) {
+    const option = tokens[index];
+    index += 1;
+    if (valueOptions.has(option)) index += 1;
+  }
+
+  let action = tokens[index]?.toLowerCase();
+  if (["pnpm", "npm", "yarn", "bun"].includes(executable) && action === "run") {
+    action = tokens[index + 1]?.toLowerCase();
+  } else if (["pnpm", "npm", "yarn", "bun"].includes(executable) && action === "exec") {
+    action = commandName(tokens[index + 1] ?? "");
+  }
+
+  if (["pnpm", "npm", "yarn", "bun", "npx"].includes(executable)) {
+    if (action && /^test(?::|$)|^(?:vitest|jest|playwright)$/iu.test(action)) return "テスト";
+    if (action && /^(?:typecheck|tsc)$/iu.test(action)) return "型チェック";
+    if (action && /^lint(?::|$)/iu.test(action)) return "リント";
+    if (action && /^build(?::|$)/iu.test(action)) return "ビルド";
+    if (action && /^(?:add|install|i)$/iu.test(action)) return "依存関係の準備";
+  }
+  if (executable === "git") {
+    if (action === "push") return "変更の共有";
+    if (action === "commit") return "変更の記録";
+    return "Git操作";
+  }
+  if (executable === "gh") return "GitHub操作";
+  if (["rm", "rmdir"].includes(executable)) return "ファイル削除";
+  if (["mv", "cp"].includes(executable)) return "ファイル整理";
+  if (executable === "mkdir") return "フォルダ作成";
+  if (executable === "chmod") return "権限変更";
+  if (action && /^[a-z0-9][a-z0-9:._-]*$/iu.test(action)) {
+    return `${executable}操作`;
+  }
+  return "コマンド操作";
+}
+
+export function buildUrgentSpeechText(event: UrgentEvent): string {
+  const detail = event.detail ?? "";
+  if (event.summary === "コマンド実行の確認待ち" || APPROVAL_PROMPT_RE.test(detail)) {
+    const command = commandLine(detail);
+    const summary = command ? commandSummary(command) : null;
+    return summary
+      ? `要対応です：「${summary}」の実行許可を求めています。`
+      : "要対応です：コマンドの実行許可を求めています。";
+  }
+
+  if (event.summary === "質問への回答を待っている") {
+    const questionNumber = detail.match(QUESTION_RE)?.[1];
+    return questionNumber
+      ? `要対応です：質問${questionNumber}への回答を求めています。`
+      : "要対応です：質問への回答を求めています。";
+  }
+
+  return `要対応です：${event.summary.replace(/[。.!！]+$/u, "")}。`;
+}


### PR DESCRIPTION
Closes #355

## Summary
- capture the command displayed directly after a Codex approval prompt without treating it as already executed
- summarize urgent command and question targets in Japanese through one shared server/Web helper
- keep the full raw command out of speech and retain a spoken fallback when extraction fails
- include event content in the immediate/commentary deduplication key so distinct urgent events remain distinct
- expose the shared helper through a runtime-safe JavaScript subpath for packaged desktop servers
- update F3 and lifecycle-error expected outputs for the intentional urgent speech change

## Validation
- server: 40 files passed, 1 skipped; 476 tests passed, 5 skipped
- web: 10 files passed; 81 tests passed
- server/web TypeScript checks passed
- production server/web builds passed
- packaged runtime subpath import passed
- web lint passed
- doc-sync passed
- Phase B default, lifecycle-error, and approval snapshots: MATCH
- F3 metrics: `urgentMisses=0`, `rawCommandSpeech=0`, `multiSentenceSpeech=0`
- all 9 GitHub checks passed, including CodeQL and desktop distribution smoke
- `git diff --check`: passed
- public-content scan: no local absolute path, credential, or email additions

## Key-design note
The previous `ts:type` key could collide for multiple same-type urgent events in one timestamp. The key now adds a deterministic hash of summary and detail, while the matching commentary carries the same event fields.

## Why the shared runtime helper is handwritten JavaScript

The packaged desktop server runs its emitted `apps/server/dist` entry with plain Node. The server build uses TypeScript `NodeNext`, so the emitted import of `@cli-commentator/shared/urgent-speech` remains a package subpath import. The sidecar preparation then uses `pnpm deploy` to copy production dependencies into `resources/server`; it does not build `packages/shared` into a JavaScript `dist`, and the shared package currently has no independent build output.

Keeping this runtime-imported helper as source `.ts` would therefore leave plain Node resolving a TypeScript source file in the packaged sidecar. This PR exposes only the helper needed at runtime as an explicit JavaScript subpath and provides `urgent-speech.d.ts` for TypeScript consumers.

The alternative is to add a shared-package build/bundle step, export compiled `dist` files, and integrate that artifact into the sidecar deployment. That is a broader packaging change than Issue #355, so it is not introduced here. The handwritten `.d.ts` can drift from the JavaScript implementation; this is an intentional, narrow tradeoff until the shared package gains a compiled runtime artifact.