### PR TITLE
fix: measure normalized progress speech repeats (#356)

### DIFF
--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -13,6 +13,7 @@ import { hasRawCommandText } from "../commentary/speech-policy.js";
 import { commentByRules } from "../commentary/rule-based.js";
 import { applySpeechContract } from "../commentary/speech-policy.js";
 import type { ProviderName } from "../llm/types.js";
+import { countRepeatedSpeechWithinWindow } from "@cli-commentator/shared";
 
 export type PhaseBReplayFixture = {
   notice: string[];
@@ -48,7 +49,7 @@ export type PhaseBReplayMetrics = {
   maxSpeechSentences: number;
   multiSentenceSpeech: number;
   rawCommandSpeech: number;
-  repeatedProgressSpeechWithin30s: number;
+  repeatedProgressSpeechWithin120s: number;
   glossaryRedisplays: number;
   urgentMisses: number;
   falseUrgent: number;
@@ -185,17 +186,14 @@ function buildMetrics(
       glossaryCounts.set(note, (glossaryCounts.get(note) ?? 0) + 1);
     }
   }
-  let repeatedProgressSpeechWithin30s = 0;
-  const lastProgressSpeech = new Map<string, number>();
-  for (const message of spoken) {
-    const text = message.speech?.text;
-    if (!text || message.ev.priority !== "progress") continue;
-    const lastAt = lastProgressSpeech.get(text);
-    if (lastAt !== undefined && message.ts - lastAt < 30_000) {
-      repeatedProgressSpeechWithin30s += 1;
-    }
-    lastProgressSpeech.set(text, message.ts);
-  }
+  const repeatedProgressSpeechWithin120s = countRepeatedSpeechWithinWindow(
+    spoken.flatMap((message) => {
+      const text = message.speech?.text;
+      return text && message.ev.priority === "progress"
+        ? [{ timestampMs: message.ts, text }]
+        : [];
+    })
+  );
   const commentaryByEvent = new Map(
     commentaryMessages.map((message) => [`${message.ev.ts}:${message.ev.type}`, message])
   );
@@ -217,7 +215,7 @@ function buildMetrics(
     maxSpeechSentences: Math.max(0, ...spoken.map((message) => speechSentenceCount(message.speech?.text))),
     multiSentenceSpeech: spoken.filter((message) => speechSentenceCount(message.speech?.text) > 1).length,
     rawCommandSpeech: spoken.filter((message) => hasRawCommandSpeech(message.speech?.text)).length,
-    repeatedProgressSpeechWithin30s,
+    repeatedProgressSpeechWithin120s,
     glossaryRedisplays: Array.from(glossaryCounts.values())
       .reduce((total, count) => total + Math.max(0, count - 1), 0),
     urgentMisses: urgentEvents.filter((message) =>

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -383,7 +383,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
     "maxSpeechSentences": 1,
     "multiSentenceSpeech": 0,
     "rawCommandSpeech": 0,
-    "repeatedProgressSpeechWithin30s": 0,
+    "repeatedProgressSpeechWithin120s": 0,
     "speechSuppressionsByReason": {},
     "spokenCommentaries": 5,
     "suppressed": 1,

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -104,6 +104,54 @@ describe("Phase B evaluation replay", () => {
     )).toBe(4);
   });
 
+  it("normalizes quoted progress style without collapsing different facts", () => {
+    const confirmationStyles = [
+      "「orchestrator.ts」を確認しています。",
+      "「orchestrator.ts」を確認しとるで。",
+      "「orchestrator.ts」を確認しているのだ。",
+    ];
+    expect(
+      new Set(confirmationStyles.map(normalizeSpeechRepetitionKey))
+    ).toHaveLength(1);
+    expect(countRepeatedSpeechWithinWindow(
+      confirmationStyles.map((text, index) => ({
+        timestampMs: index * 1_000,
+        text,
+      }))
+    )).toBe(2);
+
+    const differentQuotedFacts = [
+      "「handoff の最新ステータスを見せて」っちゅうログが出てきたで！",
+      "「handoff の最新ステータスを見せて」っちゅう入力があって、最新の…中身が表示されたで！",
+    ];
+    expect(
+      new Set(differentQuotedFacts.map(normalizeSpeechRepetitionKey))
+    ).toHaveLength(2);
+    expect(countRepeatedSpeechWithinWindow(
+      differentQuotedFacts.map((text, index) => ({
+        timestampMs: index * 1_000,
+        text,
+      }))
+    )).toBe(0);
+  });
+
+  it("keeps distinct unquoted progress reports on the text key path", () => {
+    const unquotedFacts = [
+      "画面に謎の制御コードみたいな文字列がずらっと並んで出てきとるな。",
+      "画面にマウスのドラッグ操作の座標データらしき文字列がずらっと並んどるな。",
+    ];
+    const keys = unquotedFacts.map(normalizeSpeechRepetitionKey);
+    expect(keys).toHaveLength(2);
+    expect(keys.every((key) => key.startsWith("text:"))).toBe(true);
+    expect(new Set(keys)).toHaveLength(2);
+    expect(countRepeatedSpeechWithinWindow(
+      unquotedFacts.map((text, index) => ({
+        timestampMs: index * 1_000,
+        text,
+      }))
+    )).toBe(0);
+  });
+
   it("compares context-aware rules with an LLM provider and aggregates measurements", async () => {
     const fixture = await loadFixture();
     const result = await replayPhaseBFixture(fixture, {

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -9,6 +9,10 @@ import {
   type PhaseBReplayFixture,
 } from "../evaluation/phase-b-replay.js";
 import {
+  countRepeatedSpeechWithinWindow,
+  normalizeSpeechRepetitionKey,
+} from "@cli-commentator/shared";
+import {
   buildPhaseBEvaluationArtifacts,
   evaluatedPhaseOptions,
 } from "../evaluation/phase-b-artifacts.js";
@@ -58,7 +62,7 @@ describe("Phase B evaluation replay", () => {
       maxSpeechSentences: 1,
       multiSentenceSpeech: 0,
       rawCommandSpeech: 0,
-      repeatedProgressSpeechWithin30s: 0,
+      repeatedProgressSpeechWithin120s: 0,
       glossaryRedisplays: 0,
       urgentMisses: 0,
       falseUrgent: 0,
@@ -83,6 +87,21 @@ describe("Phase B evaluation replay", () => {
       withoutContext.narration !== withContext.narration
     )).toBe(true);
     expect(result).toMatchSnapshot();
+  });
+
+  it("counts four normalized repeats in the sanitized observed-session fixture", async () => {
+    const fixture = JSON.parse(
+      await fs.readFile(
+        path.join(fixturesDir, "repeated-progress-speech.json"),
+        "utf8"
+      )
+    ) as { samples: Array<{ offsetMs: number; text: string }> };
+    expect(new Set(fixture.samples.map(({ text }) =>
+      normalizeSpeechRepetitionKey(text)
+    ))).toHaveLength(1);
+    expect(countRepeatedSpeechWithinWindow(
+      fixture.samples.map(({ offsetMs, text }) => ({ timestampMs: offsetMs, text }))
+    )).toBe(4);
   });
 
   it("compares context-aware rules with an LLM provider and aggregates measurements", async () => {
@@ -241,7 +260,7 @@ describe("Phase B evaluation replay", () => {
         maxSpeechSentences: 0,
         multiSentenceSpeech: 0,
         rawCommandSpeech: 0,
-        repeatedProgressSpeechWithin30s: 0,
+        repeatedProgressSpeechWithin120s: 0,
         glossaryRedisplays: 0,
         urgentMisses: 0,
         falseUrgent: 0,
@@ -259,7 +278,7 @@ describe("Phase B evaluation replay", () => {
         maxSpeechSentences: 0,
         multiSentenceSpeech: 0,
         rawCommandSpeech: 0,
-        repeatedProgressSpeechWithin30s: 0,
+        repeatedProgressSpeechWithin120s: 0,
         glossaryRedisplays: 0,
         urgentMisses: 0,
         falseUrgent: 0,

--- a/apps/server/test/fixtures/phase-b-codex-approval.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-approval.expected.json
@@ -364,7 +364,7 @@
     "maxSpeechSentences": 1,
     "multiSentenceSpeech": 0,
     "rawCommandSpeech": 0,
-    "repeatedProgressSpeechWithin30s": 0,
+    "repeatedProgressSpeechWithin120s": 0,
     "glossaryRedisplays": 0,
     "urgentMisses": 0,
     "falseUrgent": 0

--- a/apps/server/test/fixtures/phase-b-codex-lifecycle-error.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-lifecycle-error.expected.json
@@ -357,7 +357,7 @@
     "maxSpeechSentences": 1,
     "multiSentenceSpeech": 0,
     "rawCommandSpeech": 0,
-    "repeatedProgressSpeechWithin30s": 0,
+    "repeatedProgressSpeechWithin120s": 1,
     "glossaryRedisplays": 0,
     "urgentMisses": 0,
     "falseUrgent": 0

--- a/apps/server/test/fixtures/phase-b-codex-session.expected.json
+++ b/apps/server/test/fixtures/phase-b-codex-session.expected.json
@@ -395,7 +395,7 @@
     "maxSpeechSentences": 1,
     "multiSentenceSpeech": 0,
     "rawCommandSpeech": 0,
-    "repeatedProgressSpeechWithin30s": 0,
+    "repeatedProgressSpeechWithin120s": 0,
     "glossaryRedisplays": 0,
     "urgentMisses": 0,
     "falseUrgent": 0

--- a/apps/server/test/fixtures/repeated-progress-speech.json
+++ b/apps/server/test/fixtures/repeated-progress-speech.json
@@ -1,0 +1,28 @@
+{
+  "notice": [
+    "This fixture is a sanitized reconstruction of repeated speech observed in a real session.",
+    "The quoted target is synthetic."
+  ],
+  "samples": [
+    {
+      "offsetMs": 53000,
+      "text": "お、画面に「Navigate to cli-commentator repository」っちゅうログが出てきたで！"
+    },
+    {
+      "offsetMs": 143000,
+      "text": "お、画面に「Navigate to cli-commentator repository」っちゅう文字が出てきたで！"
+    },
+    {
+      "offsetMs": 156000,
+      "text": "画面に「Navigate to cli-commentator repository」っちゅうログが出てきたで！"
+    },
+    {
+      "offsetMs": 244000,
+      "text": "お、画面に「Navigate to cli-commentator repository」っちゅう文字が出てきたで！"
+    },
+    {
+      "offsetMs": 270000,
+      "text": "画面に「Navigate to cli-commentator repository」っちゅうログが表示されたで！"
+    }
+  ]
+}

--- a/apps/web/src/lib/speech-lifecycle.test.ts
+++ b/apps/web/src/lib/speech-lifecycle.test.ts
@@ -97,20 +97,24 @@ describe("speech lifecycle recorder", () => {
     ]);
   });
 
-  it("detects repeated progress starts within 30 seconds and urgent misses", () => {
+  it("detects style-varied repeated progress within 120 seconds and urgent misses", () => {
     let now = 0;
     const recorder = createSpeechLifecycleRecorder({ now: () => now, wallNow: () => now, sessionId: () => "s" });
     const queueAndStart = (speechId: string, priority: "progress" | "urgent", text: string) => {
       recorder.record({ kind: "queued", speechId, priority, text, queueDepth: 1 });
       recorder.record({ kind: "started", speechId, priority, text });
     };
-    queueAndStart("p1", "progress", "同じ進捗です。");
-    now = 29_999;
-    queueAndStart("p2", "progress", "同じ進捗です。");
+    queueAndStart("p1", "progress", "画面に「対象ファイル」が表示されました。");
+    now = 119_999;
+    queueAndStart("p2", "progress", "お、画面に「対象ファイル」が出てきたで！");
+    now = 120_000;
+    queueAndStart("p3", "progress", "画面に「対象ファイル」が出てきたのだ！");
+    now = 240_001;
+    queueAndStart("p4", "progress", "画面に「対象ファイル」が表示されました。");
     recorder.record({ kind: "queued", speechId: "u1", priority: "urgent", text: "許可待ちです。", queueDepth: 2 });
 
     expect(recorder.export().metrics).toMatchObject({
-      repeatedProgressStartsWithin30s: 1,
+      repeatedProgressSpeechWithin120s: 2,
       urgentMisses: 1,
     });
   });

--- a/apps/web/src/lib/speech-lifecycle.ts
+++ b/apps/web/src/lib/speech-lifecycle.ts
@@ -1,4 +1,8 @@
 import type { EventPriority } from "../types";
+import {
+  normalizeSpeechRepetitionKey,
+  REPEATED_PROGRESS_SPEECH_WINDOW_MS,
+} from "@cli-commentator/shared";
 
 export type SpeechLifecycleKind = "queued" | "started" | "ended" | "cancelled" | "dropped";
 
@@ -28,7 +32,7 @@ export type SpeechLifecycleMetrics = {
   noticeQueued: number;
   progressDropped: number;
   urgentMisses: number;
-  repeatedProgressStartsWithin30s: number;
+  repeatedProgressSpeechWithin120s: number;
   totalSpeechMs: number;
   averageQueueWaitMs: number;
   maxQueueWaitMs: number;
@@ -65,7 +69,6 @@ type RecorderOptions = {
 };
 
 const DEFAULT_MAX_EVENTS = 2_000;
-const REPEATED_PROGRESS_WINDOW_MS = 30_000;
 
 function defaultSessionId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -91,7 +94,7 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
   let sessionStartedWall = wallNow();
   let session = { id: sessionId(), trigger: "page_load" };
   let tracked = new Map<string, TrackedSpeech>();
-  let lastProgressStartByText = new Map<string, number>();
+  let lastProgressStartByKey = new Map<string, number>();
   let queueWaitTotal = 0;
   let queueWaitSamples = 0;
   let metrics: Omit<SpeechLifecycleMetrics, "urgentMisses" | "averageQueueWaitMs" | "pendingAtExport"> = {
@@ -103,7 +106,7 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
     urgentInterruptions: 0,
     noticeQueued: 0,
     progressDropped: 0,
-    repeatedProgressStartsWithin30s: 0,
+    repeatedProgressSpeechWithin120s: 0,
     totalSpeechMs: 0,
     maxQueueWaitMs: 0,
     maxQueueDepth: 0,
@@ -120,7 +123,7 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
     sessionStartedWall = wallNow();
     session = { id: sessionId(), trigger };
     tracked = new Map();
-    lastProgressStartByText = new Map();
+    lastProgressStartByKey = new Map();
     queueWaitTotal = 0;
     queueWaitSamples = 0;
     urgentQueued = 0;
@@ -135,7 +138,7 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
       urgentInterruptions: 0,
       noticeQueued: 0,
       progressDropped: 0,
-      repeatedProgressStartsWithin30s: 0,
+      repeatedProgressSpeechWithin120s: 0,
       totalSpeechMs: 0,
       maxQueueWaitMs: 0,
       maxQueueDepth: 0,
@@ -190,11 +193,15 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
         metrics.maxQueueWaitMs = Math.max(metrics.maxQueueWaitMs, Math.round(wait));
       }
       if (input.priority === "progress") {
-        const lastStart = lastProgressStartByText.get(text);
-        if (lastStart !== undefined && current - lastStart < REPEATED_PROGRESS_WINDOW_MS) {
-          metrics.repeatedProgressStartsWithin30s += 1;
+        const key = normalizeSpeechRepetitionKey(text);
+        const lastStart = lastProgressStartByKey.get(key);
+        if (
+          lastStart !== undefined &&
+          current - lastStart <= REPEATED_PROGRESS_SPEECH_WINDOW_MS
+        ) {
+          metrics.repeatedProgressSpeechWithin120s += 1;
         }
-        lastProgressStartByText.set(text, current);
+        lastProgressStartByKey.set(key, current);
       }
       return;
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./protocol.js";
 export * from "./parse-server-message.js";
 export * from "./urgent-speech.js";
+export * from "./speech-repetition.js";

--- a/packages/shared/src/speech-repetition.ts
+++ b/packages/shared/src/speech-repetition.ts
@@ -3,6 +3,11 @@ export const REPEATED_PROGRESS_SPEECH_WINDOW_MS = 120_000;
 const QUOTED_TARGET_RE = /[「『“"]([^」』”"]{2,})[」』”"]/u;
 const STYLE_ENDING_RE =
   /(?:という|っちゅう)?(?:ログ|文字|出力)?(?:が)?(?:出てきた|表示された|表示されました|出ています|出た)?(?:で|ですわ|や|な|なのだ|のだ|です)?$/u;
+const QUOTED_OBSERVATION_CONTEXT_RE =
+  /^(?:お)?(?:画面に)?(?:という|っちゅう)?(?:ログ|文字|出力)?(?:が)?(?:出てきた|表示された|表示されました|出ています|出た)(?:で|ですわ|や|な|なのだ|のだ|です)?$/u;
+const QUOTED_CONFIRMATION_CONTEXT_RE =
+  /^を?確認(?:しています|しとる|している)(?:で|ですわ|や|な|なのだ|のだ|です)?$/u;
+const PUNCTUATION_RE = /[。、，,.!！?？:：;；「」『』“”"'`〜～…]/gu;
 
 function compact(value: string): string {
   return value
@@ -12,13 +17,32 @@ function compact(value: string): string {
     .trim();
 }
 
+function normalizeQuotedContext(value: string): string {
+  const withoutPunctuation = compact(value)
+    .replace(PUNCTUATION_RE, "")
+    .replace(/\s+/gu, "");
+  if (QUOTED_OBSERVATION_CONTEXT_RE.test(withoutPunctuation)) {
+    return "observation";
+  }
+  if (QUOTED_CONFIRMATION_CONTEXT_RE.test(withoutPunctuation)) {
+    return "confirmation";
+  }
+  return withoutPunctuation.replace(STYLE_ENDING_RE, "");
+}
+
 export function normalizeSpeechRepetitionKey(text: string): string {
   const normalized = compact(text);
-  const quotedTarget = normalized.match(QUOTED_TARGET_RE)?.[1];
-  if (quotedTarget) return `quoted:${compact(quotedTarget)}`;
+  const quotedTarget = normalized.match(QUOTED_TARGET_RE);
+  if (quotedTarget?.index !== undefined) {
+    const quotedContext = [
+      normalized.slice(0, quotedTarget.index),
+      normalized.slice(quotedTarget.index + quotedTarget[0].length),
+    ].join(" ");
+    return `quoted:${compact(quotedTarget[1])}|context:${normalizeQuotedContext(quotedContext)}`;
+  }
 
   const withoutPunctuation = normalized
-    .replace(/[。、，,.!！?？:：;；「」『』“”"'`〜～…]/gu, "")
+    .replace(PUNCTUATION_RE, "")
     .replace(/\s+/gu, "");
   return `text:${withoutPunctuation.replace(STYLE_ENDING_RE, "")}`;
 }

--- a/packages/shared/src/speech-repetition.ts
+++ b/packages/shared/src/speech-repetition.ts
@@ -1,0 +1,46 @@
+export const REPEATED_PROGRESS_SPEECH_WINDOW_MS = 120_000;
+
+const QUOTED_TARGET_RE = /[「『“"]([^」』”"]{2,})[」』”"]/u;
+const STYLE_ENDING_RE =
+  /(?:という|っちゅう)?(?:ログ|文字|出力)?(?:が)?(?:出てきた|表示された|表示されました|出ています|出た)?(?:で|ですわ|や|な|なのだ|のだ|です)?$/u;
+
+function compact(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("ja")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+export function normalizeSpeechRepetitionKey(text: string): string {
+  const normalized = compact(text);
+  const quotedTarget = normalized.match(QUOTED_TARGET_RE)?.[1];
+  if (quotedTarget) return `quoted:${compact(quotedTarget)}`;
+
+  const withoutPunctuation = normalized
+    .replace(/[。、，,.!！?？:：;；「」『』“”"'`〜～…]/gu, "")
+    .replace(/\s+/gu, "");
+  return `text:${withoutPunctuation.replace(STYLE_ENDING_RE, "")}`;
+}
+
+export function countRepeatedSpeechWithinWindow(
+  samples: ReadonlyArray<{ timestampMs: number; text: string }>
+): number {
+  const lastSeen = new Map<string, number>();
+  let repeats = 0;
+
+  for (const sample of samples) {
+    const key = normalizeSpeechRepetitionKey(sample.text);
+    const previous = lastSeen.get(key);
+    const elapsed = previous === undefined ? null : sample.timestampMs - previous;
+    if (
+      elapsed !== null &&
+      elapsed >= 0 &&
+      elapsed <= REPEATED_PROGRESS_SPEECH_WINDOW_MS
+    ) {
+      repeats += 1;
+    }
+    lastSeen.set(key, sample.timestampMs);
+  }
+  return repeats;
+}

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -75,7 +75,7 @@ function markdownReport(
     ["maxSpeechSentences", baseline.metrics.maxSpeechSentences ?? 0, candidate.metrics.maxSpeechSentences],
     ["multiSentenceSpeech", baseline.metrics.multiSentenceSpeech ?? 0, candidate.metrics.multiSentenceSpeech],
     ["rawCommandSpeech", baseline.metrics.rawCommandSpeech ?? 0, candidate.metrics.rawCommandSpeech],
-    ["repeatedProgressSpeechWithin30s", baseline.metrics.repeatedProgressSpeechWithin30s ?? 0, candidate.metrics.repeatedProgressSpeechWithin30s],
+    ["repeatedProgressSpeechWithin120s", baseline.metrics.repeatedProgressSpeechWithin120s ?? 0, candidate.metrics.repeatedProgressSpeechWithin120s],
     ["glossaryRedisplays", baseline.metrics.glossaryRedisplays ?? 0, candidate.metrics.glossaryRedisplays],
     ["urgentMisses", baseline.metrics.urgentMisses ?? 0, candidate.metrics.urgentMisses],
     ["falseUrgent", baseline.metrics.falseUrgent ?? 0, candidate.metrics.falseUrgent],


### PR DESCRIPTION
Closes #356

## Summary
- replace exact-text repeat comparison with a shared normalized speech key
- prioritize quoted target text so standard, Kansai, and Zundamon ending variations compare consistently
- widen the measurement window from 30 seconds to 120 seconds in both server evaluation and Web lifecycle metrics
- rename the metric to `repeatedProgressSpeechWithin120s`
- add a sanitized five-speech fixture that reports four repeat occurrences
- do not change speech scheduling or suppression behavior

## Validation
- observed-session fixture: 5 speeches, 4 repeated occurrences detected
- server: 40 files passed, 1 skipped; 474 tests passed, 5 skipped
- web: 10 files passed; 78 tests passed
- server/web TypeScript checks passed
- web lint passed
- doc-sync passed
- Phase B default, lifecycle-error, and approval snapshots: MATCH
- `git diff --check`: passed
- public-content scan: no local absolute path, credential, or email additions

## Baseline note
The Phase B unit snapshot and all three expected JSON files were regenerated for the metric rename from `repeatedProgressSpeechWithin30s` to `repeatedProgressSpeechWithin120s`. The default and approval expected values remain `0`. The lifecycle-error expected value changes from `0` to `1` because the shared normalized 120-second window now detects one repeated progress speech that the former exact-text 30-second metric did not count.