### PR TITLE
fix: explain why the connection is down and what to do next

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -67,6 +67,18 @@
   background-color: var(--status-disconnected);
 }
 
+/* Why the connection is down and what to do next (see lib/connection-guidance) */
+.connection-hint {
+  margin: calc(var(--space-2) * -1) 0 var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-fg-secondary);
+  background-color: var(--color-bg-secondary);
+  border-left: 2px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+}
+
 /* Panel (border is full shorthand token) */
 .panel {
   background-color: var(--panel-bg);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import {
   type LaunchDraft,
   type LaunchPresetId,
 } from "./lib/session-launcher";
+import type { DesktopServerState } from "./lib/recovery";
 import { copyWithFallback, getTauriCore, type ServerStatusDetail } from "./lib/tauri";
 import { normalizeSuggestion } from "./lib/text";
 import type {
@@ -68,6 +69,7 @@ export default function App() {
   const [launchDraft, setLaunchDraft] = useState<LaunchDraft>(() => buildLaunchDraft("claude", "kansai"));
   const [currentSessionLabel, setCurrentSessionLabel] = useState("bash");
   const [tauriServerPort, setTauriServerPort] = useState<number | null>(null);
+  const [desktopServerState, setDesktopServerState] = useState<DesktopServerState | null>(null);
   const [skin, setSkin] = useState<Skin>(() => {
     const saved = localStorage.getItem("cli-commentator-skin");
     return isSkin(saved) ? saved : "standard";
@@ -157,6 +159,7 @@ export default function App() {
 
   const handleDesktopStatusChange = useCallback((status: ServerStatusDetail | null) => {
     setTauriServerPort(status?.port ?? null);
+    setDesktopServerState(status?.state ?? null);
   }, []);
 
   const wsUrl = useMemo(() => {
@@ -347,7 +350,13 @@ export default function App() {
         copyState={copyState}
         onCopySuggestion={handleCopySuggestion}
       />
-      <AppHeader skin={skin} connectionStatus={connectionStatus} onSkinChange={setSkin} />
+      <AppHeader
+        skin={skin}
+        connectionStatus={connectionStatus}
+        isDesktopRuntime={isTauriRuntime}
+        desktopServerState={desktopServerState}
+        onSkinChange={setSkin}
+      />
       <div className="workspace-layout">
         <WorkspaceLeft
           launchDraft={launchDraft}

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -1,10 +1,14 @@
 import type { ConnectionStatus } from "../hooks/useCommentatorSocket";
+import { getConnectionGuidance } from "../lib/connection-guidance";
+import type { DesktopServerState } from "../lib/recovery";
 
 export type Skin = "standard" | "cli";
 
 type AppHeaderProps = {
   skin: Skin;
   connectionStatus: ConnectionStatus;
+  isDesktopRuntime: boolean;
+  desktopServerState: DesktopServerState | null;
   onSkinChange: (skin: Skin) => void;
 };
 
@@ -20,7 +24,19 @@ function getStatusIndicatorClass(connectionStatus: ConnectionStatus): string {
   }
 }
 
-export function AppHeader({ skin, connectionStatus, onSkinChange }: AppHeaderProps) {
+export function AppHeader({
+  skin,
+  connectionStatus,
+  isDesktopRuntime,
+  desktopServerState,
+  onSkinChange,
+}: AppHeaderProps) {
+  const guidance = getConnectionGuidance({
+    connectionStatus,
+    isDesktopRuntime,
+    desktopServerState,
+  });
+
   return (
     <>
       <h1>CLI 実況（MVP）</h1>
@@ -35,13 +51,14 @@ export function AppHeader({ skin, connectionStatus, onSkinChange }: AppHeaderPro
 
       <div className="control-row" style={{ fontSize: "var(--text-sm)" }}>
         <span className={getStatusIndicatorClass(connectionStatus)} />
-        <span style={{ color: "var(--color-fg-secondary)" }}>
-          {connectionStatus === "connected" && "接続中"}
-          {connectionStatus === "connecting" && "接続しています..."}
-          {connectionStatus === "reconnecting" && "再接続しています..."}
-          {connectionStatus === "disconnected" && "切断"}
-        </span>
+        <span style={{ color: "var(--color-fg-secondary)" }}>{guidance.label}</span>
       </div>
+
+      {guidance.hint && (
+        <p className="connection-hint" role="status">
+          {guidance.hint}
+        </p>
+      )}
     </>
   );
 }

--- a/apps/web/src/lib/connection-guidance.test.ts
+++ b/apps/web/src/lib/connection-guidance.test.ts
@@ -135,5 +135,24 @@ describe("getConnectionGuidance", () => {
         expect(guidance.hint ?? "").not.toContain("pnpm dev:server");
       }
     });
+
+    it.each([
+      ["stopped", "切断（サーバー停止中）", "Start"],
+      ["starting", "サーバーの起動を待っています", "running"],
+      ["failed", "切断（サーバーの起動に失敗）", "復旧カード"],
+      ["running", "切断（サーバーは動作中）", "ポート"],
+      ["stopping", "サーバーを停止しています", null],
+    ] as const)(
+      "keeps the %s guidance visible while the WebSocket reconnects",
+      (desktopServerState, label, hint) => {
+        expect(
+          getConnectionGuidance({
+            connectionStatus: "reconnecting",
+            ...desktop,
+            desktopServerState,
+          })
+        ).toEqual({ label, hint: hint === null ? null : expect.stringContaining(hint) });
+      }
+    );
   });
 });

--- a/apps/web/src/lib/connection-guidance.test.ts
+++ b/apps/web/src/lib/connection-guidance.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { getConnectionGuidance } from "./connection-guidance";
+
+const web = { isDesktopRuntime: false, desktopServerState: null } as const;
+const desktop = { isDesktopRuntime: true } as const;
+
+describe("getConnectionGuidance", () => {
+  it("says nothing extra while connected", () => {
+    expect(
+      getConnectionGuidance({ connectionStatus: "connected", ...web })
+    ).toEqual({ label: "接続中", hint: null });
+  });
+
+  it("says nothing extra during the first connection attempt", () => {
+    expect(
+      getConnectionGuidance({ connectionStatus: "connecting", ...web }).hint
+    ).toBeNull();
+  });
+
+  it("explains that reconnection is automatic", () => {
+    const guidance = getConnectionGuidance({
+      connectionStatus: "reconnecting",
+      ...web,
+    });
+
+    expect(guidance.label).toContain("再接続");
+    expect(guidance.hint).toContain("自動");
+  });
+
+  describe("web UI running on its own", () => {
+    it("names the missing server and the command that starts it", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...web,
+      });
+
+      expect(guidance.label).toBe("切断（サーバー未接続）");
+      expect(guidance.hint).toContain("pnpm dev:server");
+    });
+
+    it("does not mention the desktop panel", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...web,
+      });
+
+      expect(guidance.hint).not.toContain("Start");
+      expect(guidance.hint).not.toContain("Desktop Server");
+    });
+  });
+
+  describe("desktop managed mode", () => {
+    it("points at Start when the server is stopped", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: "stopped",
+      });
+
+      expect(guidance.label).toBe("切断（サーバー停止中）");
+      expect(guidance.hint).toContain("Start");
+    });
+
+    it("points at Start when the desktop state is not known yet", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: null,
+      });
+
+      expect(guidance.hint).toContain("Start");
+    });
+
+    it("asks the user to wait while the server is starting", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: "starting",
+      });
+
+      expect(guidance.label).toContain("起動を待っています");
+      expect(guidance.hint).toContain("running");
+    });
+
+    it("routes to the recovery card when startup failed", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: "failed",
+      });
+
+      expect(guidance.label).toContain("失敗");
+      expect(guidance.hint).toContain("復旧カード");
+    });
+
+    it("suspects a port mismatch when the server is running but unreachable", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: "running",
+      });
+
+      expect(guidance.label).toBe("切断（サーバーは動作中）");
+      expect(guidance.hint).toContain("ポート");
+    });
+
+    it("stays quiet during an intentional stop", () => {
+      const guidance = getConnectionGuidance({
+        connectionStatus: "disconnected",
+        ...desktop,
+        desktopServerState: "stopping",
+      });
+
+      expect(guidance.hint).toBeNull();
+    });
+
+    it("never tells a desktop user to run pnpm dev:server", () => {
+      const states = [
+        "stopped",
+        "starting",
+        "running",
+        "stopping",
+        "failed",
+        null,
+      ] as const;
+
+      for (const desktopServerState of states) {
+        const guidance = getConnectionGuidance({
+          connectionStatus: "disconnected",
+          ...desktop,
+          desktopServerState,
+        });
+
+        expect(guidance.hint ?? "").not.toContain("pnpm dev:server");
+      }
+    });
+  });
+});

--- a/apps/web/src/lib/connection-guidance.ts
+++ b/apps/web/src/lib/connection-guidance.ts
@@ -39,14 +39,13 @@ export function getConnectionGuidance({
     return { label: "接続しています...", hint: null };
   }
 
-  if (connectionStatus === "reconnecting") {
-    return {
-      label: "再接続しています...",
-      hint: "サーバーとの通信が切れました。自動で再接続を試しています。",
-    };
-  }
-
   if (!isDesktopRuntime) {
+    if (connectionStatus === "reconnecting") {
+      return {
+        label: "再接続しています...",
+        hint: "サーバーとの通信が切れました。自動で再接続を試しています。",
+      };
+    }
     return { label: "切断（サーバー未接続）", hint: WEB_STANDALONE_HINT };
   }
 

--- a/apps/web/src/lib/connection-guidance.ts
+++ b/apps/web/src/lib/connection-guidance.ts
@@ -1,0 +1,79 @@
+import type { ConnectionStatus } from "../hooks/useCommentatorSocket";
+import type { DesktopServerState } from "./recovery";
+
+export type ConnectionGuidance = {
+  /** ヘッダーに出す短いラベル。 */
+  label: string;
+  /** 次に何をすればよいか。何もすることがなければ null。 */
+  hint: string | null;
+};
+
+export type ConnectionGuidanceInput = {
+  connectionStatus: ConnectionStatus;
+  /** Desktop（Tauri）で動いているか。false なら Web UI 単体。 */
+  isDesktopRuntime: boolean;
+  /** Desktop Server パネルが報告する状態。未取得なら null。 */
+  desktopServerState: DesktopServerState | null;
+};
+
+const WEB_STANDALONE_HINT =
+  "サーバーが起動していません。別のターミナルで `pnpm dev:server` を実行してください（`pnpm dev` ならサーバーとWeb UIを同時に起動します）。";
+
+/**
+ * 接続状態を、そのまま画面に出せるラベルと次の一手に変換する。
+ *
+ * 「切断」とだけ出すと、Web UI単体で起動しているのか、Desktop managed で
+ * まだ Start を押していないのかが利用者に区別できない。実行環境と
+ * Desktop Server の状態まで見て、理由と次の一手を出し分ける。
+ */
+export function getConnectionGuidance({
+  connectionStatus,
+  isDesktopRuntime,
+  desktopServerState,
+}: ConnectionGuidanceInput): ConnectionGuidance {
+  if (connectionStatus === "connected") {
+    return { label: "接続中", hint: null };
+  }
+
+  if (connectionStatus === "connecting") {
+    return { label: "接続しています...", hint: null };
+  }
+
+  if (connectionStatus === "reconnecting") {
+    return {
+      label: "再接続しています...",
+      hint: "サーバーとの通信が切れました。自動で再接続を試しています。",
+    };
+  }
+
+  if (!isDesktopRuntime) {
+    return { label: "切断（サーバー未接続）", hint: WEB_STANDALONE_HINT };
+  }
+
+  switch (desktopServerState) {
+    case "starting":
+      return {
+        label: "サーバーの起動を待っています",
+        hint: "Desktop Server パネルの状態が running になるまで待ってください。",
+      };
+    case "stopping":
+      return { label: "サーバーを停止しています", hint: null };
+    case "failed":
+      return {
+        label: "切断（サーバーの起動に失敗）",
+        hint: "Desktop Server パネルの復旧カードに表示されたコマンドを、上から順に確認してください。",
+      };
+    case "running":
+      // サーバーは動いているのに繋がらない = ポート不一致の可能性が高い。
+      return {
+        label: "切断（サーバーは動作中）",
+        hint: "サーバーは running です。接続先ポートがずれている可能性があるため、Desktop Server パネルに表示されているポートを確認してください。",
+      };
+    case "stopped":
+    default:
+      return {
+        label: "切断（サーバー停止中）",
+        hint: "Desktop Server パネルの Start を押してサーバーを起動してください。",
+      };
+  }
+}

--- a/docs/ROADMAP.en.md
+++ b/docs/ROADMAP.en.md
@@ -154,6 +154,7 @@ Supervision and entertaining commentary share one event-detection result; only t
 - Because we are not issuing an Apple Developer ID certificate for now, `#138` is treated as Deferred. Signed distribution readiness remains important, but we will return to it when certificate issuance and external distribution preparation resume
 - Keep local desktop app polish / local readiness as the launch path for real supervision-event checks
 - Added `pnpm check:local-readiness` as the local verification entrypoint: sidecar preparation → web lint/build → server test/typecheck → desktop cargo test, reported as a PASS/FAIL/SKIP summary
+- Disconnected-state header text now varies by runtime (standalone web vs desktop managed) and desktop server state: standalone web names the start command, while desktop managed points to Start, the recovery card, or a port mismatch
 
 **Next**
 - Improve Japanese explanations and summarization, with separate serious and play-by-play presentation layers (Phase B). Confirm priorities with HUMAN/Gino before implementation

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -159,6 +159,7 @@ CLI Commentator は、非エンジニアで英語に不慣れな人が、CLI上�
 - Apple Developer ID 証明書は当面発行しない方針のため、`#138` は Deferred / 保留扱いにする。signed/notarized release readiness は重要項目として残すが、証明書発行と外部配布準備を再開する段階で再着手する
 - local desktop app polish / local readiness は、監督イベントの実機確認へ入るための起動導線として維持する
 - ローカル検証の入口を `pnpm check:local-readiness` として追加。sidecar準備 → web lint/build → server test/typecheck → desktop cargo test を順に実行し、PASS/FAIL/SKIPで一覧表示する
+- 切断時のヘッダー表示を、実行環境（Web単体 / Desktop managed）とDesktop Serverの状態で出し分けるようにした。Web単体では起動コマンド、Desktop managedでは Start・復旧カード・ポート確認へ案内する
 
 **Next**
 - 日本語解説・要約と、真面目トーン／実況トーンを分けた提示層を改善する（Phase B）。着手前にHUMAN/Ginoと優先順位を確認する


### PR DESCRIPTION
## 目的

Web UI単体とDesktop managedで、切断理由と次の一手を区別して表示する。特にDesktopでは、WebSocket再接続中でも実際のDesktop Server状態に対応するStart・待機・復旧・ポート確認の案内を維持する。

## 変更

実行環境とDesktop Server状態から、ヘッダーのラベルと案内を出し分ける。

| 状況 | ラベル | 次の一手 |
|---|---|---|
| Web単体 / disconnected | 切断（サーバー未接続） | `pnpm dev:server`を実行 |
| Web単体 / reconnecting | 再接続しています... | 自動再試行中であることを伝える |
| Desktop / stopped・未取得 | 切断（サーバー停止中） | Desktop ServerパネルのStartを押す |
| Desktop / starting | サーバーの起動を待っています | runningになるまで待つ |
| Desktop / failed | 切断（サーバーの起動に失敗） | 復旧カードのコマンドを確認 |
| Desktop / runningだが未接続 | 切断（サーバーは動作中） | パネルの表示ポートを確認 |
| Desktop / stopping | サーバーを停止しています | 停止完了を待つ |

Desktopの5状態は、`connectionStatus`が`disconnected`だけでなく`reconnecting`でも同じ案内を返す。

## 実装の要点

1. 判定は`apps/web/src/lib/connection-guidance.ts`の純関数に分離。
2. `App.tsx`は既存の`server_status` polling結果から`state`を保持するだけで、新しいIPCや購読は追加しない。
3. Web単体では従来どおり`reconnecting`の自動再試行案内を優先する。
4. Desktopでは`reconnecting`より`server_status`を優先し、復帰に必要な具体的案内を隠さない。
5. CSSは既存デザイントークンのみ使用。

## 2026-07-30 Gino follow-up

head `92052ef`では、`reconnecting`がDesktop stateより先に評価されていたため、`stopped` / `starting` / `failed` / `running` / `stopping`の全状態で同じ自動再接続案内になった。WebSocketは切断後の大部分を`reconnecting`として過ごすため、Start・復旧・ポート案内が短時間しか見えない可能性があった。

head `2586800`で判定順を修正し、`reconnecting × stopped / starting / failed / running / stopping`の組み合わせテスト5件を追加した。

## 検証

- `pnpm -C apps/web test` — 11 files / 98 tests passed
- connection guidance対象テスト — 17 tests passed（うちreconnecting組み合わせ5件）
- `pnpm -C apps/web lint` — passed
- `pnpm -C apps/web build` — passed
- `pnpm check:doc-sync` — passed
- `git diff --check` — passed
- latest `origin/main`とのmerge-tree — CLEAN
- GitHub Actions — 9/9 passed（head `2586800`）

## Desktop視覚確認

自己完結型Node v20.20.2をコマンド実行時のPATHにだけ追加し、専用worktree `/Users/home/AION_Project/repos/cli-commentator-pr365` から最新head `2586800`を起動した。既定PATH、Homebrew Node、n8nは変更していない。

2026-07-30、HUMANが最新headのDesktop画面を正式確認した。

- Start前：`切断（サーバー停止中）`と「Desktop Server パネルの Start を押してサーバーを起動してください。」を確認。Desktop Serverパネルも`停止中 / HEALTH NG`でStartが有効。
- 起動待ち：Start直後に「サーバーの起動を待っています」が表示されることを確認。遷移が速いため表示は一瞬だが、状態案内は確認できた。
- 接続後：メイン画面の緑点と`接続中`、Desktop Serverパネルの`稼働中 / HEALTH OK`、`3. Claude Codeを起動`を確認。

重大な迷い、誤案内、起動不能はなく、CIと正式なDesktop視覚確認の条件を満たしたため、**マージ候補としてHUMAN判断待ち**。

## 注意

- HUMANの承認なしにmergeしない
- merge操作はHUMANのみが行う

🤖 Updated by Gino / Codex