### PR TITLE
fix: improve TTS pronunciation and commentary quality

### DIFF
--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -55,6 +55,23 @@ describe("extractEvents fixtures", () => {
     ]);
   });
 
+  it("does not mistake TypeScript Readonly types for a read-only CLI", () => {
+    process.env.LOG_SOURCE = "claude";
+
+    expect(
+      extractEvents(
+        "const replacements: ReadonlyArray<readonly [RegExp, string]> = [];"
+      )
+    ).toEqual([
+      {
+        ts: new Date("2025-01-01T00:00:00.000Z").getTime(),
+        type: "stdout",
+        summary: "ログ更新",
+        detail: "const replacements: ReadonlyArray<readonly [RegExp, string]> = [];",
+      },
+    ]);
+  });
+
   it("drops Codex progress-noise lines from extraction", () => {
     process.env.LOG_SOURCE = "codex";
     const chunk = ["Working (14s • esc to interrupt)", "w", "•2", "10s • esc to interrupt)"].join("\n");

--- a/apps/server/src/commentary/beginner-lines.test.ts
+++ b/apps/server/src/commentary/beginner-lines.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { beginnerOneLine } from "./beginner-lines.js";
+
+describe("beginnerOneLine stdout explanations", () => {
+  it("omits an explanation for a shell prompt or unknown stdout", () => {
+    expect(
+      beginnerOneLine({ ts: 1, type: "stdout", summary: "ログ更新", detail: "bash-5.3$" }, "standard")
+    ).toBe("");
+    expect(
+      beginnerOneLine({ ts: 1, type: "stdout", summary: "ログ更新", detail: "arbitrary output" }, "kansai")
+    ).toBe("");
+  });
+
+  it("describes source code, file paths, and test results when identifiable", () => {
+    expect(
+      beginnerOneLine({ ts: 1, type: "stdout", summary: "ログ更新", detail: "const value = 1;" }, "standard")
+    ).toContain("ソースコードの一部");
+    expect(
+      beginnerOneLine({ ts: 1, type: "stdout", summary: "ログ更新", detail: "apps/web/src/lib/tts.ts" }, "kansai")
+    ).toContain("ファイルやフォルダの一覧");
+    expect(
+      beginnerOneLine({ ts: 1, type: "stdout", summary: "ログ更新", detail: "Tests 5 passed" }, "zundamon")
+    ).toContain("テスト結果");
+  });
+
+  it("distinguishes reading a file from listing files", () => {
+    expect(
+      beginnerOneLine(
+        { ts: 1, type: "stdout", summary: "ログ更新", detail: "sed -n '1p' apps/server/src/index.ts" },
+        "standard"
+      )
+    ).toContain("ファイルの内容を読み");
+    expect(
+      beginnerOneLine(
+        { ts: 1, type: "stdout", summary: "ログ更新", detail: "rg --files apps/server/src" },
+        "kansai"
+      )
+    ).toContain("一覧を見て");
+  });
+});

--- a/apps/server/src/commentary/beginner-lines.ts
+++ b/apps/server/src/commentary/beginner-lines.ts
@@ -5,6 +5,47 @@ function contextualBeginnerLine(ev: Event, style: Style): string | null {
   const detail = ev.detail?.trim();
   const command = detailCommand(detail);
 
+  if (ev.type === "stdout" && detail) {
+    if (/^(?:bash|zsh|sh)(?:-[\d.]+)?[$%#]\s*$/iu.test(detail)) {
+      return "";
+    }
+    if (/^(?:cat|head|tail)\b|^sed\s+(?:-[^\s]+\s+)*/iu.test(command)) {
+      return say(style, {
+        standard: "1行メモ: 指定したファイルの内容を読み、現在の実装を確認しています。",
+        kansai: "1行メモ: 指定したファイルの中身を読んで、今の実装を確認してるで。",
+        zundamon: "1行メモ: 指定したファイルの中身を読んで、今の実装を確認してるのだ。",
+      });
+    }
+    if (/^(?:ls\b|find\b|fd\b|rg\s+--files\b)/iu.test(command)) {
+      return say(style, {
+        standard: "1行メモ: ファイルやフォルダの一覧を見て、確認対象を絞っています。",
+        kansai: "1行メモ: ファイルやフォルダの一覧を見て、確認対象をしぼってるで。",
+        zundamon: "1行メモ: ファイルやフォルダの一覧を見て、確認対象をしぼってるのだ。",
+      });
+    }
+    if (/^(?:export\s+)?(?:const|let|var|function|class|interface|type|import)\b/iu.test(detail)) {
+      return say(style, {
+        standard: "1行メモ: ソースコードの一部を表示し、実装内容を確認しています。",
+        kansai: "1行メモ: ソースコードの一部を見て、実装内容を確認してるで。",
+        zundamon: "1行メモ: ソースコードの一部を見て、実装内容を確認してるのだ。",
+      });
+    }
+    if (/(?:Test Files|Tests?|passed|failed|PASS|FAIL)/u.test(detail)) {
+      return say(style, {
+        standard: "1行メモ: テスト結果を見て、変更後も正常に動くか確認しています。",
+        kansai: "1行メモ: テスト結果を見て、変更後も動くか確認してるで。",
+        zundamon: "1行メモ: テスト結果を見て、変更後も動くか確認してるのだ。",
+      });
+    }
+    if (/(?:^|\s)(?:[\w@+.-]+\/)+[\w@+.-]+(?:\s|$)/iu.test(detail)) {
+      return say(style, {
+        standard: "1行メモ: ファイルやフォルダの一覧を見て、確認対象を絞っています。",
+        kansai: "1行メモ: ファイルやフォルダの一覧を見て、確認対象をしぼってるで。",
+        zundamon: "1行メモ: ファイルやフォルダの一覧を見て、確認対象をしぼってるのだ。",
+      });
+    }
+  }
+
   if (detail && /^[⏺•]\s*Read\(/.test(detail)) {
     const target = extractReadTarget(detail) ?? "対象ファイル";
     const isDoc = /\.(md|txt|rst|adoc)$/i.test(target) || /readme|docs?/i.test(target);
@@ -101,7 +142,7 @@ type BeginnerLineTable = Record<Event["type"] | "default", Record<Style, string>
 
 const BEGINNER_LINES: BeginnerLineTable = {
   read: { standard: "1行メモ: 現状を把握して次の修正方針を決めています。", kansai: "1行メモ: 今の状況つかんで次の手を決めてるとこや。", zundamon: "1行メモ: 今の状況をつかんで次の手を決めてるのだ。" },
-  stdout: { standard: "1行メモ: コマンドの通常出力を確認しています。", kansai: "1行メモ: コマンドの通常出力を確認してるで。", zundamon: "1行メモ: コマンドの通常出力を確認してるのだ。" },
+  stdout: { standard: "", kansai: "", zundamon: "" },
   stderr: { standard: "1行メモ: エラー出力を確認して原因を絞っています。", kansai: "1行メモ: エラー出力を見て原因しぼってるで。", zundamon: "1行メモ: エラー出力を見て原因をしぼってるのだ。" },
   write: { standard: "1行メモ: 問題を直すために内容を更新しています。", kansai: "1行メモ: 問題直すために中身を更新してるで。", zundamon: "1行メモ: 問題を直すために中身を更新してるのだ。" },
   search: { standard: "1行メモ: 手がかりを探して調査範囲を絞っています。", kansai: "1行メモ: 手がかり探して調査範囲しぼってるで。", zundamon: "1行メモ: 手がかりを探して調査範囲をしぼってるのだ。" },
@@ -120,6 +161,6 @@ const BEGINNER_LINES: BeginnerLineTable = {
 
 export function beginnerOneLine(ev: Event, style: Style): string {
   const contextual = contextualBeginnerLine(ev, style);
-  if (contextual) return contextual;
+  if (contextual !== null) return contextual;
   return (BEGINNER_LINES[ev.type] ?? BEGINNER_LINES.default)[style];
 }

--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -25,7 +25,7 @@ export const claudeRuleset: RuleSet = {
 
     { id: "claude.install", priority: 20, re: /\b(pnpm|npm|yarn)\s+(add|install|i|run)\b/i, type: "install", summary: "依存関係/スクリプトを処理している" },
 
-    { id: "claude.readonly", priority: 12, re: /read[-\s]?only|write is disabled/i, type: "error", summary: "書き込みが制限されている" },
+    { id: "claude.readonly", priority: 12, re: /\bread[-\s]?only mode\b|\bwrite is disabled\b/i, type: "error", summary: "書き込みが制限されている" },
     { id: "claude.error", priority: 10, re: /execution error|error|failed|exception|TS\d{5}/i, type: "error", summary: "エラーが出ている" }
   ]
 };

--- a/apps/server/src/styles/prompt.ts
+++ b/apps/server/src/styles/prompt.ts
@@ -212,7 +212,10 @@ export function normalizeGeneratedCommentaryText(
   text: string,
   role: CommentaryRole
 ): string {
-  const compact = text.replace(/\s+/g, " ").trim();
+  const repaired = text
+    .replace(/今見えていてる(?=で(?:[、。！？!?]|$))/gu, "今見えてる")
+    .replace(/今見えていてる/gu, "今見えている");
+  const compact = repaired.replace(/\s+/g, " ").trim();
   const stripped = compact.replace(/^(実況|解説|補足|1行メモ)[:：]\s*/u, "").trim();
   const firstSentence = stripped.match(/^.+?[。！？!?]/u)?.[0] ?? stripped;
 

--- a/apps/server/src/tests/comment.prompt.test.ts
+++ b/apps/server/src/tests/comment.prompt.test.ts
@@ -202,6 +202,12 @@ describe("normalizeGeneratedCommentaryText", () => {
       normalizeGeneratedCommentaryText("1行メモ: 設定の前提を確認しています。補足を続けます。", "explanation")
     ).toBe("設定の前提を確認しています。");
   });
+
+  it("repairs malformed visible-state phrasing without losing Kansai style", () => {
+    expect(
+      normalizeGeneratedCommentaryText("今見えていてるで、設定を確認中や。", "narration")
+    ).toBe("今見えてるで、設定を確認中や。");
+  });
 });
 
 describe("comment() quality fallback", () => {
@@ -242,7 +248,7 @@ describe("comment() quality fallback", () => {
     expect(out.meta?.narrationProvider).toBe("rules");
     expect(out.meta?.explanationProvider).toBe("rules");
     expect(out.narration).not.toContain("[mock-");
-    expect(out.explanation).toBeTruthy();
+    expect(out.explanation).toBeUndefined();
 
     vi.doUnmock("../llm/factory.js");
   });

--- a/apps/server/src/tests/comment.timeout.test.ts
+++ b/apps/server/src/tests/comment.timeout.test.ts
@@ -45,7 +45,7 @@ describe("comment() timeout behavior", () => {
     // comment() は abort されてルールベースにフォールバック
     const result = await comment(ev, "standard");
 
-    expect(result.explanation).toBeTruthy();
+    expect(result.explanation).toBeUndefined();
     expect(result.narration).not.toBe("should not reach here");
   });
 

--- a/apps/web/src/lib/speech-scheduler.test.ts
+++ b/apps/web/src/lib/speech-scheduler.test.ts
@@ -81,6 +81,35 @@ describe("createSpeechScheduler", () => {
     ]);
   });
 
+  it("120秒以内の同じprogressはスタイル違いでも間引く", () => {
+    const fake = createFakeSink();
+    const dropped: string[] = [];
+    let current = 1_000;
+    const scheduler = createSpeechScheduler(fake.sink, {
+      now: () => current,
+      onDropped: (_request, reason) => dropped.push(reason),
+    });
+
+    expect(scheduler.speak("progress", "『設定』を確認しています。", undefined)).toBe(true);
+    current += 60_000;
+    expect(scheduler.speak("progress", "『設定』を確認しているで。", undefined)).toBe(false);
+    expect(dropped).toEqual(["repeated_progress"]);
+    expect(fake.calls.filter((call) => call.kind === "speak")).toHaveLength(1);
+  });
+
+  it("反復抑止はurgent/noticeに適用せず、cancel後はprogress履歴をリセットする", () => {
+    const fake = createFakeSink();
+    let current = 1_000;
+    const scheduler = createSpeechScheduler(fake.sink, { now: () => current });
+
+    expect(scheduler.speak("progress", "状況を確認しています。", undefined)).toBe(true);
+    expect(scheduler.speak("notice", "状況を確認しています。", undefined)).toBe(true);
+    expect(scheduler.speak("urgent", "状況を確認しています。", undefined)).toBe(true);
+    scheduler.cancel();
+    current += 1;
+    expect(scheduler.speak("progress", "状況を確認しています。", undefined)).toBe(true);
+  });
+
   it("urgent/notice が未消化の間、progress は間引かれる", () => {
     const fake = createFakeSink();
     const scheduler = createSpeechScheduler(fake.sink);

--- a/apps/web/src/lib/speech-scheduler.ts
+++ b/apps/web/src/lib/speech-scheduler.ts
@@ -1,4 +1,8 @@
 import type { EventPriority } from "../types";
+import {
+  normalizeSpeechRepetitionKey,
+  REPEATED_PROGRESS_SPEECH_WINDOW_MS,
+} from "@cli-commentator/shared";
 
 /**
  * 優先度つき読み上げスケジューラ
@@ -18,7 +22,7 @@ export type SpeechSink<Opts> = {
 };
 
 export type SpeechCancellationReason = "urgent_interrupt" | "progress_replace" | "manual_stop";
-export type SpeechDropReason = "high_priority_pending";
+export type SpeechDropReason = "high_priority_pending" | "repeated_progress";
 export type SpeechQueueReason = "urgent_interrupt" | "notice_append" | "progress_latest";
 
 export type ScheduledSpeech<Opts> = {
@@ -32,6 +36,7 @@ export type ScheduledSpeech<Opts> = {
 
 type SpeechSchedulerOptions<Opts> = {
   nextId?: () => string;
+  now?: () => number;
   onDropped?: (request: ScheduledSpeech<Opts>, reason: SpeechDropReason) => void;
 };
 
@@ -53,6 +58,8 @@ export function createSpeechScheduler<Opts>(
   let pendingHighCount = 0;
   let pendingTotalCount = 0;
   let fallbackId = 0;
+  let lastProgressAtByKey = new Map<string, number>();
+  const now = options.now ?? Date.now;
 
   const submit = (
     request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">,
@@ -73,6 +80,18 @@ export function createSpeechScheduler<Opts>(
     generation += 1;
     pendingHighCount = 0;
     pendingTotalCount = 0;
+  };
+
+  const drop = (
+    request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">,
+    reason: SpeechDropReason
+  ): false => {
+    options.onDropped?.({
+      ...request,
+      queueDepth: pendingTotalCount,
+      queueReason: "progress_latest",
+    }, reason);
+    return false;
   };
 
   return {
@@ -97,13 +116,20 @@ export function createSpeechScheduler<Opts>(
 
       // progress: 高優先の発話が残っている間は間引く
       if (pendingHighCount > 0) {
-        options.onDropped?.({
-          ...request,
-          queueDepth: pendingTotalCount,
-          queueReason: "progress_latest",
-        }, "high_priority_pending");
-        return false;
+        return drop(request, "high_priority_pending");
       }
+
+      const repetitionKey = normalizeSpeechRepetitionKey(text);
+      const current = now();
+      const lastProgressAt = lastProgressAtByKey.get(repetitionKey);
+      if (
+        lastProgressAt !== undefined &&
+        current - lastProgressAt >= 0 &&
+        current - lastProgressAt <= REPEATED_PROGRESS_SPEECH_WINDOW_MS
+      ) {
+        return drop(request, "repeated_progress");
+      }
+      lastProgressAtByKey.set(repetitionKey, current);
       sink.cancel("progress_replace", request.id);
       reset();
       submit(request, false, "progress_latest");
@@ -112,6 +138,7 @@ export function createSpeechScheduler<Opts>(
     cancel() {
       sink.cancel("manual_stop");
       reset();
+      lastProgressAtByKey = new Map();
     },
     hasPendingHighPriority() {
       return pendingHighCount > 0;

--- a/apps/web/src/lib/tts.test.ts
+++ b/apps/web/src/lib/tts.test.ts
@@ -4,6 +4,7 @@ import {
   TTS_PRESETS,
   applyTTSPreset,
   detectTTSPreset,
+  normalizeForSpeech,
   type TTSSettings,
 } from "./tts";
 
@@ -53,5 +54,16 @@ describe("TTS presets", () => {
       includeRawDetail: false,
     };
     expect(detectTTSPreset(custom)).toBeNull();
+  });
+});
+
+describe("normalizeForSpeech", () => {
+  it("表示用テキストを変更せずTTS向けの要語を読み補正する", () => {
+    const displayText = "要確認です。要対応です：設定を見直します。";
+
+    expect(normalizeForSpeech(displayText)).toBe(
+      "ようかくにんです。ようたいおうです：設定を見直します。"
+    );
+    expect(displayText).toBe("要確認です。要対応です：設定を見直します。");
   });
 });

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -92,6 +92,10 @@ const ANSI_COLOR_CODE_RE = /\[(?:\d{1,3};)*\d{1,3}m/g;
 const BOX_DRAWING_CHARS_RE = /[─│┌┐└┘├┤┬┴┼╔╗╚╝╠╣╦╩╬═║]+/g;
 const CLI_DECORATIVE_SYMBOLS_RE =
   /(?:⏺|⎿|✅|✓|✔|✗|✘|➜|➤|●|○|◉|◎|■|□|▪|▫|►|▶|◀|◁|★|☆|❯|❮|⚡|⚠️|🔴|🟢|🟡|⬛|⬜)+/gu;
+const TTS_PRONUNCIATION_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/要確認/gu, "ようかくにん"],
+  [/要対応/gu, "ようたいおう"],
+];
 
 function stripControlChars(s: string): string {
   let out = "";
@@ -176,12 +180,15 @@ export function waitForVoices(timeoutMs = 3000): Promise<SpeechSynthesisVoice[]>
  * テキスト正規化（ログ記号除去、長さ制限）
  */
 export function normalizeForSpeech(text: string, maxLength = 500): string {
-  const cleaned = stripControlChars(text)
-    .replace(ANSI_COLOR_CODE_RE, "") // ANSI color payload remnants after ESC stripping
-    .replace(BOX_DRAWING_CHARS_RE, "") // Box drawing characters
-    .replace(CLI_DECORATIVE_SYMBOLS_RE, "") // CLI decorative symbols
-    .replace(/\n{2,}/g, "\n") // 連続改行
-    .trim();
+  const cleaned = TTS_PRONUNCIATION_REPLACEMENTS.reduce(
+    (value, [pattern, replacement]) => value.replace(pattern, replacement),
+    stripControlChars(text)
+      .replace(ANSI_COLOR_CODE_RE, "") // ANSI color payload remnants after ESC stripping
+      .replace(BOX_DRAWING_CHARS_RE, "") // Box drawing characters
+      .replace(CLI_DECORATIVE_SYMBOLS_RE, "") // CLI decorative symbols
+      .replace(/\n{2,}/g, "\n") // 連続改行
+      .trim()
+  );
 
   return cleaned.length > maxLength ? cleaned.slice(0, maxLength) + "..." : cleaned;
 }


### PR DESCRIPTION
## 何をしたか

Issue #367で確認されたTTS・実況品質の問題を修正します。

- 「要確認」「要対応」のTTS読みをそれぞれ「ようかくにん」「ようたいおう」に補正（表示文字列は維持）
- 120秒以内の同一progress読み上げを抑止
- `ReadonlyArray` をread-onlyエラーと誤判定しないようClaude rulesetを限定
- 「今見えていてるで」を自然な表現へ補正
- 対象不明な「通常出力を確認しています」を廃止
- 判別できる出力だけ、ファイル内容・一覧・ソースコード・テスト結果として具体的に解説

## 原因

TTS用の読み補正がなく、進捗発話の重複判定も不足していました。また、ルールベース解説がstdoutを一律に説明し、read-only判定がTypeScriptの型名にも広く一致していました。

## 影響

APIを使用しないルールベース実況でも、意味の薄い解説と反復を減らし、読み上げと表示の理解しやすさを改善します。

## 確認

- server: 49 suites / 597 tests passed
- web: 11 suites / 102 tests passed
- server build passed
- web build passed
- git diff --check passed
- macOS検証版で「要確認」「要対応」の読みをHUMAN確認
- `sed`による読み取りを「指定したファイルの内容を読み、現在の実装を確認しています」と表示することを実機確認
- 検証用ビルド生成物と評価JSONは含めていません

Closes #367