### PR TITLE
docs: add 2026-07-31 handoff

### DIFF
--- a/handoff/status-2026-07-31.md
+++ b/handoff/status-2026-07-31.md
@@ -1,0 +1,66 @@
+# handoff 2026-07-31 — cli-commentator / PR #358受け入れ確認と依存更新の整理
+
+## 1. HUMAN判断待ち（最初に読む）
+
+- **判断事項1**：次回セッションを、最新mainでの最終実使用受け入れ確認から開始するか
+  - 推奨：開始する。PR #368で読み上げ品質の修正は実機確認できたが、修正後の評価JSONをまだ保存できておらず、PR #358の数値基準による最終合否は未確定
+  - 選択肢：A. 5〜10分の通常CLI作業を再実施して最終測定する（推奨） / B. 定性的所見だけで完了扱いにする
+  - 期限・緊急度：次の通常開発を始める前 / 緊急度高
+  - 判断しない場合の影響：Todoistの実機確認カード3件を完了できず、受け入れ状態が未確定のまま残る
+- **判断事項2**：Issue #346のPhase-B計測改善へ進む順序
+  - 推奨：最終実使用受け入れ確認を完了してから着手する。今回のTTS受け入れとprovider計測の論点を混ぜないため
+  - 選択肢：A. 受け入れ完了後に#346へ着手（推奨） / B. #346を先行する
+  - 期限・緊急度：次の開発セッション開始時 / 緊急度中
+  - 判断しない場合の影響：未完了の受け入れ確認と新規実装が並行し、結果の切り分けが難しくなる
+- **判断事項3**：PR #278（tauri-action 1.0.0）を引き続き保留するか
+  - 推奨：実リリースsmokeを行うまで保留を継続する。通常CIだけではasset名・署名・latest.json・Updaterの互換性を判定できない
+  - 選択肢：A. Issue #292配下で保留継続（推奨） / B. 配布作業を再開してsmokeへ進む
+  - 期限・緊急度：外部配布再開時 / 緊急度低
+  - 判断しない場合の影響：OPENのまま残るだけで、現在のローカル利用には影響しない
+
+## 2. 現在地
+
+- main：`01735aba6912e1a9d13a1e09d10974e7383c212d`（PR #369）。push CIとCodeQLは成功
+- PR #358 / #360 / #361 / #363 / #365 / #366 / #368 / #369：MERGED
+- PR #362：DependabotがCLOSED。更新内容は最新main基点の後継PR #369へ置換され、HUMANがmerge済み
+- Issue #353 / #367：CLOSED
+- OPEN PR：#278のみ。MERGEABLE / CLEAN、既存CI 9件greenだがrelease workflowのメジャー更新なので保留
+- OPEN Issue：#346（Phase-B provider計測改善）、#292（#278の段階処理）、#138（Apple証明書待ち）
+- Todoist：実使用受け入れ確認の親カードと子カード2件は `ctx/waiting`。実装待ちではなく、最新mainでのHUMAN実機再測定待ち
+
+## 3. 今回やったこと
+
+- 最新mainのDesktop managedを自己完結型Nodeで起動し、通常のNode設定、n8n、`.codex/`を変更せずに実使用確認を実施
+- PTY起動失敗やCLIセッション不調を切り分けながら、ファイル検索・読み取り、複数回の進捗更新、状態確認、完了報告を含む通常作業を確認
+- HUMAN聴取で「要確認」「要対応」の誤読、汎用的な読み取り説明の反復、具体性不足を発見し、Issue #367とPR #368で改善
+- PR #368後、「要確認」→「ようかくにん」、「要対応」→「ようたいおう」と読むこと、ファイル名を含む具体的な解説、キャラクタースタイル維持をHUMANが実機確認
+- 依存更新PRを順番に整理。#361と#363を最新mainへリベースしてHUMANがmerge、#362は後継#369へ自動置換され、CI 9/9成功後にHUMANがmerge
+- PR #369 merge後のmain push CIとCodeQLが成功するまで確認
+
+## 4. 重要な発見・リスク
+
+- 修正後セッションの評価JSONをまだ保存できていないため、`pendingAtExport`、`speechCompletionRate`、`progress_replace / started`、`repeatedProgressSpeechWithin120s`の最終値は未確定
+- 初期サンプルでは「今見えているので」等の反復で作業内容が分かりにくい場面があった。PR #368後は改善したが、サンプル数が少ないため最終再測定が必要
+- PR #278はtauri-actionのメジャー更新。`latest.json`のURL形式変更により既存検証やUpdaterが影響を受ける可能性があり、rebaseと実リリースsmokeなしではmergeしない
+- Issue #138はApple Developer ProgramとDeveloper ID Application証明書が外部ブロッカー。公開向け署名・公証済み配布は引き続きNo-Go
+- ログ本文に機密情報が含まれる場合、GitHubやTodoistへ添付せず、測定値とHUMAN所見だけを記録する
+
+## 5. 次の一手（AI別）
+
+- HUMAN：次回、最新mainのDesktop managedでTTSを有効化し、評価ログをリセットして5〜10分の通常CLI作業を行う。読み上げ終了後に評価JSONを保存する
+- Gino：HUMANの実使用中に起動・セッション状態を支援し、JSONから合格基準の数値を集計する。合格時はTodoistの実機確認カード3件へ数値と所見を同期して完了する
+- KURO：不合格の場合のみ、症状・再現条件・改善候補を整理する。HUMAN判断前に追加Issueや修正実装を始めない
+- JEM：現時点では依頼なし
+- 受け入れ完了後：Issue #346の中優先度3件（実使用モデル記録、measurement欠落のskip、suppressedイベント除外）を先に設計・実装する
+
+## 6. 参照リンク
+
+- PR #358: https://github.com/gatyoukatyou/cli-commentator/pull/358
+- PR #368: https://github.com/gatyoukatyou/cli-commentator/pull/368
+- PR #369: https://github.com/gatyoukatyou/cli-commentator/pull/369
+- PR #278: https://github.com/gatyoukatyou/cli-commentator/pull/278
+- Issue #346: https://github.com/gatyoukatyou/cli-commentator/issues/346
+- Issue #292: https://github.com/gatyoukatyou/cli-commentator/issues/292
+- Issue #138: https://github.com/gatyoukatyou/cli-commentator/issues/138
+- Todoist親カード: `6h2V5wjc95g3ccQC`
+- Todoist実機確認カード: `6h2V62qvQ328Jg7j`, `6h3V6VxCCxpfjrvC`


### PR DESCRIPTION
## 何をしたか

2026-07-31時点の作業状況、HUMAN判断待ち、次回の再開点を `handoff/status-2026-07-31.md` に記録しました。

## 変更点

- PR #358受け入れ確認とPR #368の読み上げ改善結果を整理
- PR #361/#363/#369の依存更新とmain CI成功を反映
- 最終評価JSON未取得を残課題として明記
- Issue #346、PR #278 / Issue #292、Issue #138の実行順と保留理由を整理
- Todoistの実機確認カード3件と次回開始点を対応付け

## 影響

ドキュメントのみです。アプリのコードや設定は変更しません。

## 確認

- `git diff --check`
- `PATH="/Users/home/.local/node-v20.20.2-darwin-arm64/bin:$PATH" pnpm check:doc-sync`

## HUMANに確認してほしいこと

次回を最新mainでの5〜10分の最終実使用再測定から開始する方針でよいか確認してください。