### PR TITLE
feat(commentary): say what failed instead of that something failed

### DIFF
--- a/apps/server/src/commentary/beginner-lines.ts
+++ b/apps/server/src/commentary/beginner-lines.ts
@@ -1,3 +1,4 @@
+import { classifyFailure, type FailureKind } from "@cli-commentator/shared";
 import type { Event, EventType } from "../types.js";
 import { describeBashMeaning, detailCommand, extractReadTarget, extractSearchTerm, extractWriteTarget } from "./bash-meaning.js";
 import { describeNarrationSubject } from "./narration-subject.js";
@@ -39,6 +40,17 @@ function onDetail(re: RegExp) {
 function fixed(text: string) {
   return () => text;
 }
+
+/** Display wording per failure kind; the classification itself is shared. */
+const FAILURE_EXPLANATIONS: Record<FailureKind, string> = {
+  "type-error": "TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。",
+  "port-in-use":
+    "使おうとしたポートが既に別のプロセスに使われています。先に動いているものを止めるか、別のポートを使う場面です。",
+  permission: "権限が足りず操作が拒否されました。書き込み先や実行権限を確認する場面です。",
+  "module-not-found": "参照している部品が見つかりません。依存の導入漏れか、参照先の誤りが疑われます。",
+  "command-not-found": "必要なコマンドが見つかりません。導入漏れか、パスの設定を確認する場面です。",
+  "exit-code": "実行したコマンドが失敗して終了しました。原因は直前の出力に出ていることが多いです。",
+};
 
 const RULES: ReadonlyArray<ExplanationRule> = [
   // --- stdout: classify what the raw output actually is -------------------
@@ -287,41 +299,17 @@ const RULES: ReadonlyArray<ExplanationRule> = [
   },
 
   // --- failures: name the class of problem, then the next thing to check --
+  // Detection is shared with the spoken urgent line so the two cannot drift;
+  // only the wording differs, since display has room to explain and speech
+  // has to fit one interrupting breath.
   {
-    id: "error.typescript",
-    types: ["error"],
-    when: onDetail(/\bTS\d{4,5}\b/u),
-    line: fixed("TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。"),
-  },
-  {
-    id: "error.command-not-found",
+    id: "error.classified",
     types: ["error", "stderr"],
-    when: onDetail(/command not found|: not found\b/iu),
-    line: fixed("必要なコマンドが見つかりません。導入漏れか、パスの設定を確認する場面です。"),
-  },
-  {
-    id: "error.module-not-found",
-    types: ["error", "stderr"],
-    when: onDetail(/Cannot find module|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND/iu),
-    line: fixed("参照している部品が見つかりません。依存の導入漏れか、参照先の誤りが疑われます。"),
-  },
-  {
-    id: "error.port-in-use",
-    types: ["error", "stderr"],
-    when: onDetail(/EADDRINUSE|address already in use/iu),
-    line: fixed("使おうとしたポートが既に別のプロセスに使われています。先に動いているものを止めるか、別のポートを使う場面です。"),
-  },
-  {
-    id: "error.permission",
-    types: ["error", "stderr"],
-    when: onDetail(/EACCES|permission denied/iu),
-    line: fixed("権限が足りず操作が拒否されました。書き込み先や実行権限を確認する場面です。"),
-  },
-  {
-    id: "error.exit-code",
-    types: ["error", "stderr"],
-    when: onDetail(/ELIFECYCLE|exited with code|exit code|failed with exit code/iu),
-    line: fixed("実行したコマンドが失敗して終了しました。原因は直前の出力に出ていることが多いです。"),
+    when: ({ detail }) => classifyFailure(detail) !== null,
+    line: ({ detail }) => {
+      const kind = classifyFailure(detail);
+      return kind ? FAILURE_EXPLANATIONS[kind] : null;
+    },
   },
 
   // --- generic tool call: last resort before the type-level table ---------

--- a/apps/server/src/commentary/beginner-lines.ts
+++ b/apps/server/src/commentary/beginner-lines.ts
@@ -1,4 +1,8 @@
-import { classifyFailure, type FailureKind } from "@cli-commentator/shared";
+// Import through the subpath, not the package root: the bundled desktop
+// sidecar runs on plain Node, and the root entry is a `.ts` file that only
+// resolves for type-only imports. This mirrors how `speech-policy` imports
+// `urgent-speech`.
+import { classifyFailure, type FailureKind } from "@cli-commentator/shared/failure-classification";
 import type { Event, EventType } from "../types.js";
 import { describeBashMeaning, detailCommand, extractReadTarget, extractSearchTerm, extractWriteTarget } from "./bash-meaning.js";
 import { describeNarrationSubject } from "./narration-subject.js";

--- a/apps/server/src/commentary/failure-speech.test.ts
+++ b/apps/server/src/commentary/failure-speech.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { classifyFailure } from "@cli-commentator/shared";
+import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
+import { beginnerOneLine } from "./beginner-lines.js";
+import type { Event } from "../types.js";
+
+const SAMPLES = [
+  ["TS2554: Expected 1 arguments, but got 2.", "type-error"],
+  ["listen EADDRINUSE: address already in use :::8787", "port-in-use"],
+  ["EACCES: permission denied, open '/etc/hosts'", "permission"],
+  ["Error: Cannot find module 'zod'", "module-not-found"],
+  ["zsh: command not found: pnpm", "command-not-found"],
+  ["ELIFECYCLE  Command failed with exit code 1.", "exit-code"],
+] as const;
+
+describe("classifyFailure", () => {
+  it.each(SAMPLES)("recognises %s", (detail, kind) => {
+    expect(classifyFailure(detail)).toBe(kind);
+  });
+
+  it("returns null when the log says nothing recognisable", () => {
+    expect(classifyFailure("something went wrong")).toBeNull();
+    expect(classifyFailure(undefined)).toBeNull();
+  });
+
+  // The port message also contains "listen", and an exit-code line often
+  // accompanies a more specific cause; the specific pattern has to win.
+  it("prefers the specific cause over a trailing exit code", () => {
+    expect(
+      classifyFailure("Error: listen EADDRINUSE: address already in use\nELIFECYCLE exit code 1")
+    ).toBe("port-in-use");
+  });
+});
+
+describe("urgent speech for failures", () => {
+  function failure(detail: string): Event {
+    // Every ruleset collapses failures to this summary, which is why the spoken
+    // line used to be "要対応です：エラーが出ている。" no matter what broke.
+    return { ts: 1, type: "error", summary: "エラーが出ている", detail };
+  }
+
+  it.each([
+    ["listen EADDRINUSE: address already in use :::8787", "要対応です：使用中のポートで起動できません。"],
+    ["zsh: command not found: pnpm", "要対応です：コマンドが見つかりません。"],
+    ["Error: Cannot find module 'zod'", "要対応です：参照先の部品が見つかりません。"],
+    ["EACCES: permission denied", "要対応です：権限が足りず実行できません。"],
+    ["TS2554: Expected 1 arguments", "要対応です：型の不一致が出ています。"],
+    ["ELIFECYCLE  Command failed with exit code 1.", "要対応です：コマンドが失敗して終了しました。"],
+  ])("names what failed: %s", (detail, expected) => {
+    expect(buildUrgentSpeechText(failure(detail))).toBe(expected);
+  });
+
+  it("keeps the summary when the log identifies no known failure", () => {
+    expect(buildUrgentSpeechText(failure("something went wrong"))).toBe(
+      "要対応です：エラーが出ている。"
+    );
+  });
+
+  // Approval and question prompts are more urgent than any failure text that
+  // happens to be scrolled into the same excerpt.
+  it("still prioritises an approval prompt", () => {
+    const event: Event = {
+      ts: 1,
+      type: "error",
+      summary: "コマンド実行の確認待ち",
+      detail: "would you like to run the following command?\n  pnpm test\nexit code 1",
+    };
+    expect(buildUrgentSpeechText(event)).toBe("要対応です：「テスト」の実行許可を求めています。");
+  });
+});
+
+describe("failure wording stays split between speech and display", () => {
+  it.each(SAMPLES)("explains %s at more length than it speaks it", (detail) => {
+    const event: Event = { ts: 1, type: "error", summary: "エラーが出ている", detail };
+    const spoken = buildUrgentSpeechText(event);
+    const displayed = beginnerOneLine(event);
+    expect(displayed.length).toBeGreaterThan(spoken.length);
+  });
+});

--- a/apps/server/src/commentary/failure-speech.test.ts
+++ b/apps/server/src/commentary/failure-speech.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyFailure } from "@cli-commentator/shared";
+import { classifyFailure } from "@cli-commentator/shared/failure-classification";
 import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
 import { beginnerOneLine } from "./beginner-lines.js";
 import type { Event } from "../types.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     "./urgent-speech": {
       "types": "./src/urgent-speech.d.ts",
       "default": "./src/urgent-speech.js"
+    },
+    "./failure-classification": {
+      "types": "./src/failure-classification.d.ts",
+      "default": "./src/failure-classification.js"
     }
   }
 }

--- a/packages/shared/src/failure-classification.d.ts
+++ b/packages/shared/src/failure-classification.d.ts
@@ -1,0 +1,9 @@
+export type FailureKind =
+  | "type-error"
+  | "port-in-use"
+  | "permission"
+  | "module-not-found"
+  | "command-not-found"
+  | "exit-code";
+
+export declare function classifyFailure(detail?: string): FailureKind | null;

--- a/packages/shared/src/failure-classification.js
+++ b/packages/shared/src/failure-classification.js
@@ -1,0 +1,23 @@
+/**
+ * Recognises what kind of failure a log excerpt describes.
+ *
+ * Rulesets collapse every failure into a single summary ("エラーが出ている"), so
+ * both the spoken urgent line and the displayed explanation would otherwise say
+ * only that something failed. Detection lives here, shared, while each layer
+ * keeps its own wording: speech needs one short clause, display can explain.
+ *
+ * Patterns are ordered from specific to general, and the first match wins.
+ */
+const FAILURE_PATTERNS = [
+  ["type-error", /\bTS\d{4,5}\b/u],
+  ["port-in-use", /EADDRINUSE|address already in use/iu],
+  ["permission", /\bEACCES\b|\bEPERM\b|permission denied/iu],
+  ["module-not-found", /Cannot find module|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND|Module not found/iu],
+  ["command-not-found", /command not found|:\s*not found\b/iu],
+  ["exit-code", /ELIFECYCLE|exited with code|exit code|failed with exit code|non-zero exit/iu],
+];
+
+export function classifyFailure(detail) {
+  if (!detail) return null;
+  return FAILURE_PATTERNS.find(([, pattern]) => pattern.test(detail))?.[0] ?? null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./protocol.js";
 export * from "./parse-server-message.js";
 export * from "./urgent-speech.js";
+export * from "./failure-classification.js";
 export * from "./speech-repetition.js";

--- a/packages/shared/src/urgent-speech.js
+++ b/packages/shared/src/urgent-speech.js
@@ -1,4 +1,20 @@
+import { classifyFailure } from "./failure-classification.js";
+
 const APPROVAL_PROMPT_RE = /would you like to run the following command\?/iu;
+
+/**
+ * One short clause per failure kind. The urgent line interrupts whatever is
+ * being spoken, so it has to name the problem in a single breath; the detailed
+ * version belongs to the on-screen explanation.
+ */
+const FAILURE_SPEECH = {
+  "type-error": "型の不一致が出ています",
+  "port-in-use": "使用中のポートで起動できません",
+  permission: "権限が足りず実行できません",
+  "module-not-found": "参照先の部品が見つかりません",
+  "command-not-found": "コマンドが見つかりません",
+  "exit-code": "コマンドが失敗して終了しました",
+};
 const QUESTION_RE = /Question\s+(\d+)\/\d+\s+\((?:[1-9]\d*) unanswered\)/iu;
 const COMMAND_START_RE =
   /^(?:(?:sudo|command|env)\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:pnpm|npm|yarn|bun|npx|node|git|gh|cargo|docker|make|go|python\d*|deno|rm|mv|cp|mkdir|chmod|curl)\b/iu;
@@ -94,6 +110,11 @@ export function buildUrgentSpeechText(event) {
       ? `要対応です：質問${questionNumber}への回答を求めています。`
       : "要対応です：質問への回答を求めています。";
   }
+
+  // Every failure shares one ruleset summary ("エラーが出ている"), so fall back to
+  // the summary only when the log says nothing more specific.
+  const failure = classifyFailure(detail);
+  if (failure) return `要対応です：${FAILURE_SPEECH[failure]}。`;
 
   return `要対応です：${withoutTrailingSentencePunctuation(event.summary)}。`;
 }


### PR DESCRIPTION
> **base は `feat/narration-detail-aware`（[#373](https://github.com/gatyoukatyou/cli-commentator/pull/373)）**。#373 で入れた解説側のエラー分類を共通化して読み上げにも効かせるため、#373 の後にマージする前提。#373 が main に入ったら base を main に切り替える。

## 問題

失敗イベントは urgent 優先度なので、`applySpeechContract` は冒頭で `buildUrgentSpeechText` に分岐し、**実況を一切読まない**。

```ts
if (getEventPriority(event) === "urgent") {
  return buildUrgentSpeechText(event);
}
```

その `buildUrgentSpeechText` には失敗用の分岐が無く、承認待ち・質問待ち以外はルールセットの summary をそのまま読んでいた。そしてルールセットは失敗をすべて1つの summary に潰す（`generic.error` / `claude.error` / `codex.error` すべて「エラーが出ている」）。

結果、**ポート衝突も依存の不足も権限エラーも、全部これ**：

```
要対応です：エラーが出ている。
```

`stderr` 型なら実況を通るが、production のどのルールセットも入力経路もこの型を生成していないため、失敗は必ずこの経路に来る。

## やったこと

`packages/shared/src/failure-classification.js` に `classifyFailure` を追加。型エラー / ポート使用中 / 権限不足 / 部品不明 / コマンド不明 / 異常終了を判定する。順序は具体的なものが先で、末尾に付く exit-code 行が本当の原因を隠さないようにしてある。

**判定は共有、文言は共有しない。** 読み上げは再生中の発話に割り込むので一息で言える1句、画面の解説は「次に何を確認するか」まで書ける長さ、と役割が違う。`beginner-lines` は #373 で書いた5つの正規表現を捨てて同じ関数を通すようにしたので、両者がずれることはない。

承認待ち・質問待ちは、同じ抜粋にエラー文字列が混ざっていても優先されるまま。

## 効果（読み上げテキスト）

| ログ | before | after |
|---|---|---|
| `listen EADDRINUSE: address already in use :::8787` | 要対応です：エラーが出ている。 | 要対応です：使用中のポートで起動できません。 |
| `zsh: command not found: pnpm` | 〃 | 要対応です：コマンドが見つかりません。 |
| `Error: Cannot find module 'zod'` | 〃 | 要対応です：参照先の部品が見つかりません。 |
| `EACCES: permission denied` | 〃 | 要対応です：権限が足りず実行できません。 |
| `TS2554: Expected 1 arguments` | 〃 | 要対応です：型の不一致が出ています。 |
| `ELIFECYCLE Command failed with exit code 1.` | 〃 | 要対応です：コマンドが失敗して終了しました。 |

判定できないログでは従来どおり summary を読む。

## 途中で踏んだ罠（2つ目のcommit）

最初の実装は `@cli-commentator/shared`（パッケージroot）から値をインポートしていた。root の entry は `./src/index.ts` で、**バンドル版デスクトップの sidecar は素の Node で動く**ため `ERR_UNKNOWN_FILE_EXTENSION` で起動できず、`desktop_distribution_smoke` が落ちた。

既存の root インポートはすべて型のみ（コンパイル時に消える）で、これが初の実行時 root インポートだった。`./urgent-speech` と同じく実体 `.js` を指すサブパスを切って解決。

**vitest も vite も root を解決してしまうので、この失敗を捕まえたのは配布スモークだけ**だった。

関連して、`apps/server/dist/evaluation/phase-b-replay.js` にも root からの値インポート（`countRepeatedSpeechWithinWindow`）が残っている。sidecar の import グラフに入らないため現状は顕在化していないが、同じ罠。本PRの範囲外として触っていない。

## 検証

- `pnpm -C apps/server exec vitest run` — 812 passed
- `pnpm -C apps/web exec vitest run` — 102 passed
- 両 workspace の `tsc --noEmit`、`pnpm build:server`、`pnpm -C apps/web build`
- `pnpm eval:phase-b` — Snapshot: MATCH（差分なし）
- ビルド後の `apps/server/dist/commentary/beginner-lines.js` がサブパスを import していることを確認
- CI 7/7 pass（`desktop_distribution_smoke` を含む）

新規テスト `failure-speech.test.ts`：分類6種、判定不能時のフォールバック、原因と exit-code が混在した場合の優先順位、承認プロンプトの優先、読み上げ文が解説文より短いことの検査。

## レビュー観点

- 分類パターンの過不足（特に `command-not-found` の `:\s*not found\b` が広すぎないか）
- 読み上げ6文の言い回し
- 判定を `packages/shared` に置いた判断（web の `event-notify.ts` も同じ経路を使うため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)