### PR TITLE
fix(desktop): keep node-pty spawn-helper executable in the sidecar bundle

### DIFF
--- a/docs/desktop-release.en.md
+++ b/docs/desktop-release.en.md
@@ -26,6 +26,32 @@ distribution procedure, signing/notarization flow, updater configuration, or
 operator-facing release steps. Existing `desktop_check` and
 `desktop_distribution_smoke` CI jobs remain the validation path for this change.
 
+## Sidecar native helper permissions
+
+The sidecar bundles node-pty, which opens a PTY on macOS and Linux by spawning
+its `spawn-helper` binary. `pnpm deploy --prod`, which stages the sidecar's
+production dependencies, writes that file **without the executable bit**, so
+`prepare-desktop-sidecar.mjs` restores it after bundling and asserts that the
+host platform's helper is executable.
+
+Do not proceed with a build when that assertion fails. Without the bit the app
+breaks in a way that is easy to misread: **the server reports `running` while
+every CLI launch fails**, including plain `bash`.
+
+```
+startup_failed  kind=ptyError; error=posix_spawnp failed.  cmd=bash
+```
+
+When you see `posix_spawnp failed.`, check this first:
+
+```bash
+ls -l apps/desktop/src-tauri/resources/server/node_modules/node-pty/prebuilds/*/spawn-helper
+```
+
+Re-run `pnpm prepare:desktop-sidecar` if the bit is missing. The repository's
+own `node_modules` is handled separately by the
+`scripts/fix-node-pty-permissions.mjs` postinstall hook.
+
 ## Release action maintenance
 
 `tauri-apps/tauri-action` is maintained as the tag-release workflow action. The

--- a/docs/desktop-release.ja.md
+++ b/docs/desktop-release.ja.md
@@ -25,6 +25,32 @@ Tauri runtime stack を 2.11 系へ更新しました。対象には `tauri`,
 手順、updater 設定、リリース運用手順は変更しません。検証は既存の
 `desktop_check` および `desktop_distribution_smoke` CI jobs を通じて行います。
 
+## サイドカーのネイティブヘルパー権限
+
+サイドカーは node-pty を同梱しており、macOS / Linux では PTY を開くために
+`spawn-helper` バイナリを spawn します。サイドカーの本番依存を作る
+`pnpm deploy --prod` はこのファイルを**実行ビットなし**で書き出すため、
+`prepare-desktop-sidecar.mjs` が同梱後に実行ビットを復元し、ホスト
+プラットフォーム向けのヘルパーが実行可能であることを検証します。
+
+この検証が失敗した場合、ビルドを進めてはいけません。実行ビットが落ちた
+状態のアプリは、**サーバーは `running` と報告するのに、あらゆるCLI起動が
+失敗する**という分かりにくい壊れ方をします（`bash` すら起動できません）。
+
+```
+startup_failed  kind=ptyError; error=posix_spawnp failed.  cmd=bash
+```
+
+`posix_spawnp failed.` を見たら、まず次を確認します。
+
+```bash
+ls -l apps/desktop/src-tauri/resources/server/node_modules/node-pty/prebuilds/*/spawn-helper
+```
+
+実行ビットが無ければ `pnpm prepare:desktop-sidecar` を再実行します。なお
+リポジトリの `node_modules` 側は postinstall の
+`scripts/fix-node-pty-permissions.mjs` が別途担当します。
+
 ## Release action maintenance
 
 `tauri-apps/tauri-action` は tag-release workflow action として保守します。

--- a/scripts/prepare-desktop-sidecar.mjs
+++ b/scripts/prepare-desktop-sidecar.mjs
@@ -124,6 +124,50 @@ function copyTreeDereference(sourcePath, destinationPath) {
   copyFileSync(sourcePath, destinationPath);
 }
 
+/**
+ * node-pty spawns its `spawn-helper` binary to open a PTY on macOS and Linux.
+ * `pnpm deploy` writes the staged copy without the executable bit, and the loss
+ * is silent: the sidecar starts, reports "running", and then fails every CLI
+ * launch with `posix_spawnp failed.` — including the shell, so nothing in the
+ * desktop app can start.
+ */
+function restoreNativeHelperPermissions(rootDir) {
+  const restored = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+      } else if (entry.isFile() && entry.name === "spawn-helper") {
+        chmodSync(entryPath, 0o755);
+        restored.push(entryPath);
+      }
+    }
+  };
+  walk(rootDir);
+  return restored;
+}
+
+function assertPtyHelperExecutable(rootDir, targetTriple) {
+  if (targetTriple.includes("windows")) return;
+
+  const platform = targetTriple.includes("apple-darwin") ? "darwin" : "linux";
+  const arch = targetTriple.startsWith("aarch64") ? "arm64" : "x64";
+  const helper = path.join(
+    rootDir,
+    "node_modules/node-pty/prebuilds",
+    `${platform}-${arch}`,
+    "spawn-helper"
+  );
+
+  if (!existsSync(helper)) {
+    throw new Error(`[sidecar] node-pty spawn-helper missing for ${platform}-${arch}: ${helper}`);
+  }
+  if ((lstatSync(helper).mode & 0o111) === 0) {
+    throw new Error(`[sidecar] node-pty spawn-helper is not executable: ${helper}`);
+  }
+}
+
 if (!existsSync(workspaceFile)) {
   throw new Error("pnpm-workspace.yaml not found. Run this script from the repository.");
 }
@@ -179,6 +223,10 @@ try {
   rmForce(path.join(bundledServerDir, ".env.local"));
   rmForce(path.join(bundledServerDir, ".env.development"));
   rmForce(path.join(bundledServerDir, ".env.production"));
+
+  const restoredHelpers = restoreNativeHelperPermissions(bundledServerDir);
+  console.log(`[sidecar] Restored executable bit on ${restoredHelpers.length} native helper(s).`);
+  assertPtyHelperExecutable(bundledServerDir, targetTriple);
 
   console.log("[sidecar] Copying node runtime...");
   rmForce(sidecarNodeDir);


### PR DESCRIPTION
## 症状

Desktop アプリで**あらゆるCLIが起動できない**。サーバーは「running」と表示されるが、起動しようとすると必ず失敗する。

クリーンな `pnpm dev:desktop:managed` で観測した実際のログ:

```
startup_failed        kind=ptyError; error=posix_spawnp failed.  cmd=bash
launch_session_failed kind=ptyError; error=posix_spawnp failed.  cmd=claude   presetName=Claude Code
```

`bash` すら起動できないので、アプリ内から何ひとつ実行できない状態だった。

## 原因

node-pty は macOS / Linux で PTY を開くために `spawn-helper` バイナリを spawn する。サイドカーの本番依存を作る `pnpm deploy --prod` が、このファイルを**実行ビットなしで**書き出していた。

```
元 (node_modules/.pnpm/node-pty@1.1.0/.../darwin-arm64/spawn-helper)
  -rwxr-xr-x

サイドカー (apps/desktop/src-tauri/resources/server/.../darwin-arm64/spawn-helper)
  -rw-r--r--     ← 実行ビットが落ちている
```

`copyFileSync` はモードを保持するので、失われているのは `pnpm deploy` の段階。

失敗の仕方が悪質で、**サーバー自体は正常に起動して "running" を報告する**。PTY を開こうとした瞬間に初めて `posix_spawnp failed.` になるため、サーバー起動の問題に見えてしまう。

`scripts/fix-node-pty-permissions.mjs` が postinstall で pnpm store 側の同じ問題をすでに直しているが、デプロイ後のコピーはその後に作られるため対象外だった。

## 修正

`prepare-desktop-sidecar.mjs` で、バンドル後のサーバー配下にある `spawn-helper` すべてに実行ビットを戻す。加えて、**ホストプラットフォーム向けのヘルパーが存在し実行可能であることを assert** して、同じ退行が黙って出荷されないようにした。

隣接する node ランタイムのコピーには既に `chmodSync(sidecarNodePath, 0o755)` があり、同じ問題に対する部分的な対処が入っていた。今回はそれを `spawn-helper` にも広げた形。

## 検証

```
$ rm -rf apps/desktop/src-tauri/resources/server
$ pnpm prepare:desktop-sidecar
[sidecar] Copying deployed server bundle...
[sidecar] Restored executable bit on 6 native helper(s).
[sidecar] Done.
```

バンドル後のサイドカーから実際に PTY を開けることを確認:

```
$ node -e "const pty=require('./apps/desktop/src-tauri/resources/server/node_modules/node-pty');
           const p=pty.spawn('bash',['-lc','echo PTY_OK'],{cwd:'/tmp'});
           p.onData(d=>{if(d.includes('PTY_OK'))console.log('sidecar PTY spawn OK')})"
sidecar PTY spawn OK
```

修正前は同じコマンドが `posix_spawnp failed.` になる。

## 補足

`scripts/fix-node-pty-permissions.mjs`（pnpm store 用）と今回追加した処理は、対象ディレクトリ構造が違うため別実装になっている。将来まとめる余地はあるが、本PRでは触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)