### PR TITLE
fix(extract): stop reading Claude Code's repaint chrome aloud

### DIFF
--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,8 +1,9 @@
 import type { Event } from "./types.js";
 import { rulesForLine } from "./rulesets/index.js";
-import { isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
+import { isClaudeTuiNoise, isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
 import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
+import { ANSI_ESCAPE_RE } from "./terminal-escapes.js";
 
 // Legacy X10 mouse reports include three coordinate bytes after CSI M. Strip
 // them before the generic CSI matcher consumes only the introducer.
@@ -15,11 +16,6 @@ const LEGACY_MOUSE_REPORT_RE =
 const CHARSET_DESIGNATION_RE =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
   /\u001B[()*+][0-2A-Z]/g;
-
-// Remove ANSI/VT control sequences so TUI apps like Claude Code still match rules.
-const ANSI_ESCAPE_RE =
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
-  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
 
 function normalizeLine(line: string): string {
   return line
@@ -398,6 +394,9 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
     return null;
   }
   if (source === "codex" && isCodexProgressNoise(normalized)) {
+    return null;
+  }
+  if (source === "claude" && isClaudeTuiNoise(normalized)) {
     return null;
   }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types.js";
 import { redact } from "./redact.js";
 import { extractEvents } from "./extract.js";
+import { createEscapeCarry } from "./terminal-escapes.js";
 import { comment } from "./styles/index.js";
 import { getAutoDetectedSource, resetAutoDetection } from "./rulesets/index.js";
 import * as profileManager from "./profile/manager.js";
@@ -364,6 +365,8 @@ async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
   }
 }
 
+const carryEscape = createEscapeCarry();
+
 /**
  * Process incoming data from any input source (PTY or FileTail).
  * This is the common data processing pipeline.
@@ -381,7 +384,9 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
     sourceState.mode === "auto"
       ? sourceState.detected ?? currentSourceMode
       : sourceState.mode;
-  const evs = extractEvents(clean, activeSource);
+  // Raw output goes to the terminal pane unchanged; only event extraction needs
+  // the chunk boundary repaired, so a split escape sequence is not read aloud.
+  const evs = extractEvents(carryEscape(clean), activeSource);
   const detected = getAutoDetectedSource();
   if (detected) broadcastSource(detected);
 

--- a/apps/server/src/progress-noise.ts
+++ b/apps/server/src/progress-noise.ts
@@ -15,6 +15,49 @@ export function isTerminalRenderingNoise(text: string): boolean {
   );
 }
 
+/**
+ * Claude Code repaints its whole frame many times a second. Each repaint is
+ * delivered as ordinary output, so the extractor turns spinner glyphs, the
+ * animated status word and the token counter into `stdout` events — which the
+ * commentary then reads aloud as
+ * `今見えている出力は「✻(2s · ↓4 tokens)」です。`
+ *
+ * These are the decorations, removed before judging whether anything was said.
+ */
+const CLAUDE_SPINNER_GLYPHS = /[✢-✧✱-✿⏺⏸❯⎽]/gu;
+const BOX_DRAWING = /[─-▟]/gu;
+const BRAILLE_SPINNER = /[⠀-⣿]/gu;
+// No `\b`: a repaint often glues the word to the previous counter (`✽37Lollygagging…`),
+// and there is no word boundary between a digit and a letter.
+/** The animated status word, e.g. `Lollygagging…`, `Catapulting…`, `Herding…`. */
+const SPINNER_WORD = /[A-Za-z]{3,24}(?:…|\.{3})/gu;
+/** `(2s · ↓8 tokens)`, `(13s · ↓618 tokens)`, and the fragments repaints leave. */
+const TOKEN_COUNTER = /\(?\s*\d+\s*s?\s*[·•]?\s*[↑↓]?\s*[\d.]+\s*k?\s*tokens?\s*\)?/giu;
+/** Persistent footer/help chrome that never describes what the AI is doing. */
+const STATUS_CHROME =
+  /esc to interrupt|\? for shortcuts|manual mode on|Try "[^"]*"|You've used \d+% of your weekly limit|run \/login to renew|Crunched for \d+s|connecting…/giu;
+
+/** Letters and CJK only; stray digits left by a repaint are not content. */
+function meaningfulLength(text: string): number {
+  return (text.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{L}]/gu) ?? []).length;
+}
+
+const MIN_MEANINGFUL_CHARS = 8;
+
+export function isClaudeTuiNoise(text: string): boolean {
+  const residue = text
+    .replace(STATUS_CHROME, " ")
+    .replace(TOKEN_COUNTER, " ")
+    .replace(SPINNER_WORD, " ")
+    .replace(CLAUDE_SPINNER_GLYPHS, " ")
+    .replace(BOX_DRAWING, " ")
+    .replace(BRAILLE_SPINNER, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+  return meaningfulLength(residue) < MIN_MEANINGFUL_CHARS;
+}
+
 export function isCodexProgressNoise(text: string): boolean {
   return (
     /^working\s*\(\d+s\s*[•·]\s*esc to interrupt\)$/i.test(text) ||

--- a/apps/server/src/rulesets/claude-supervision.ts
+++ b/apps/server/src/rulesets/claude-supervision.ts
@@ -1,8 +1,5 @@
 import type { Event } from "../types.js";
-
-const ANSI_ESCAPE_RE =
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
-  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
+import { ANSI_ESCAPE_RE } from "../terminal-escapes.js";
 
 function normalizeTuiChunk(chunk: string): { readable: string; compact: string } {
   const readable = chunk

--- a/apps/server/src/terminal-escapes.ts
+++ b/apps/server/src/terminal-escapes.ts
@@ -1,0 +1,76 @@
+/**
+ * Terminal escape sequence stripping, shared by the extractor and the Claude
+ * supervision ruleset so the two cannot diverge.
+ *
+ * The OSC alternative (`ESC ] ... BEL`) must come first. The two-character
+ * escape class was previously written `[@-Z\\-_]`, where `\\-_` is a *range*
+ * from `\` (0x5C) to `_` (0x5F) and therefore contains `]` (0x5D). `ESC ]` then
+ * matched as a two-character escape, consuming only the introducer and leaving
+ * the OSC body behind — so every terminal-title update leaked into the log as
+ * `0;⠂ List files in docs folder` and was read aloud verbatim.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+export const ANSI_ESCAPE_RE =
+  /\u001B(?:\][^\u0007]*(?:\u0007|\u001B\\)|\[[0-?]*[ -/]*[@-~]|[()*+][0-2A-Z]|[0-~])/g;
+
+export function stripTerminalEscapes(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+const ESC = "\u001B";
+const BEL = "\u0007";
+/** Long enough for any real sequence, short enough that a stray ESC cannot stall the stream. */
+const MAX_CARRY = 256;
+
+/**
+ * Index at which an escape sequence starts but does not finish inside `text`,
+ * or -1 when the tail is complete.
+ */
+function incompleteEscapeStart(text: string): number {
+  const start = text.lastIndexOf(ESC);
+  if (start < 0) return -1;
+
+  const rest = text.slice(start);
+  if (rest.length === 1) return start;
+
+  switch (rest[1]) {
+    case "[":
+      // CSI: parameter and intermediate bytes until a final byte 0x40–0x7E.
+      return /^\[[0-?]*[ -/]*[@-~]/.test(rest) ? -1 : start;
+    case "]":
+      // OSC: terminated by BEL or ST.
+      return rest.includes(BEL) || rest.includes(`${ESC}\\`) ? -1 : start;
+    case "(":
+    case ")":
+    case "*":
+    case "+":
+      return rest.length >= 3 ? -1 : start;
+    default:
+      return -1;
+  }
+}
+
+/**
+ * A PTY delivers arbitrary byte chunks, so an escape sequence can be split
+ * across two `onData` callbacks. Stripping each chunk independently then leaves
+ * the tail behind as text — the log fills with fragments like `40;1H`, `[22` or
+ * `0;⠂ List files in docs folder`, and the commentary reads them aloud.
+ *
+ * Returns a function that holds back an unfinished trailing sequence and
+ * prepends it to the next chunk.
+ */
+export function createEscapeCarry(): (chunk: string) => string {
+  let pending = "";
+
+  return (chunk: string) => {
+    const text = pending + chunk;
+    pending = "";
+
+    const start = incompleteEscapeStart(text);
+    if (start < 0) return text;
+    if (text.length - start > MAX_CARRY) return text;
+
+    pending = text.slice(start);
+    return text.slice(0, start);
+  };
+}

--- a/apps/server/src/tests/tui-noise.test.ts
+++ b/apps/server/src/tests/tui-noise.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { isClaudeTuiNoise } from "../progress-noise.js";
+import { createEscapeCarry, stripTerminalEscapes } from "../terminal-escapes.js";
+
+const ESC = "\u001B";
+const BEL = "\u0007";
+
+describe("terminal escape stripping", () => {
+  // `[@-Z\\-_]` was a range covering `]`, so `ESC ]` matched as a two-character
+  // escape and the OSC body survived as text.
+  it("removes an OSC terminal-title sequence, body included", () => {
+    expect(stripTerminalEscapes(`${ESC}]0;✳ Claude Code${BEL}rest`)).toBe("rest");
+    expect(stripTerminalEscapes(`${ESC}]0;⠂ List files in docs folder${BEL}`)).toBe("");
+  });
+
+  it("removes an OSC sequence terminated by ST", () => {
+    expect(stripTerminalEscapes(`${ESC}]0;title${ESC}\\tail`)).toBe("tail");
+  });
+
+  // Claude Code emits these on every repaint; the old class stopped at `Z`.
+  it("removes the cursor save/restore pair", () => {
+    expect(stripTerminalEscapes(`${ESC}7${ESC}8text`)).toBe("text");
+  });
+
+  it("still removes CSI and charset sequences", () => {
+    expect(stripTerminalEscapes(`${ESC}[38;5;174mhello${ESC}[0m`)).toBe("hello");
+    expect(stripTerminalEscapes(`${ESC}(Bplain`)).toBe("plain");
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(stripTerminalEscapes("docs/ の中身は以下の通りです。")).toBe("docs/ の中身は以下の通りです。");
+  });
+});
+
+describe("escape sequences split across PTY chunks", () => {
+  it("carries an unfinished CSI into the next chunk", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`before${ESC}[38;`)).toBe("before");
+    expect(stripTerminalEscapes(carry("5;174mafter"))).toBe("after");
+  });
+
+  it("carries an unfinished OSC into the next chunk", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`${ESC}]0;⠂ List files`)).toBe("");
+    expect(stripTerminalEscapes(carry(`in docs folder${BEL}done`))).toBe("done");
+  });
+
+  it("carries a lone trailing ESC", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`text${ESC}`)).toBe("text");
+    expect(stripTerminalEscapes(carry("[0mmore"))).toBe("more");
+  });
+
+  it("passes complete chunks through untouched", () => {
+    const carry = createEscapeCarry();
+    expect(carry("plain text")).toBe("plain text");
+  });
+
+  // A stray ESC must not stall the stream indefinitely.
+  it("gives up once the carried tail grows past the cap", () => {
+    const carry = createEscapeCarry();
+    const long = `${ESC}[${"1;".repeat(200)}`;
+    expect(carry(long)).toBe(long);
+  });
+});
+
+describe("isClaudeTuiNoise", () => {
+  // Captured from a real Claude Code session, after escape stripping.
+  it.each([
+    "✶82 ✻5✽37Lollygagging…8912Lol",
+    "✢4⏺6·Lollygagging…6Lollygagging…gg✢yg",
+    "ap✢Ca✳t✶✻a✽C✻",
+    "✻(2s · ↓4 tokens)",
+    "Lollygagging… (13s · ↓618 tokens)",
+    "✻Crunched for 13s",
+    "❯ ? for shortcuts",
+    "esc to interrupt",
+  ])("drops repaint chrome: %s", (line) => {
+    expect(isClaudeTuiNoise(line)).toBe(true);
+  });
+
+  it.each([
+    "docs/の中身は以下の通りです。",
+    "⏺ Read(apps/web/src/App.tsx)",
+    "$ ls -1 /Users/home/AION_Project/repos/cli-commentator/docs",
+    "Listed 3 directories, ran 1 shell command",
+    "Error: Cannot find module 'zod'",
+  ])("keeps what actually reports progress: %s", (line) => {
+    expect(isClaudeTuiNoise(line)).toBe(false);
+  });
+});


### PR DESCRIPTION
> base は `feat/failure-speech`（[#374](https://github.com/gatyoukatyou/cli-commentator/pull/374)）。#373 → #374 → 本PR の順にマージする前提。

## 症状（実機で確認）

Desktop アプリで Claude Code を起動したところ、実況が端末の再描画断片をそのまま読み上げ始めた。

```
今見えている出力は「✻(2s · ↓4 tokens)」です。
今見えている出力は「0;⠂ List files in docs folder」です。
今見えている出力は「※ng4」です。
今見えている出力は「Running1shellcommand…」です。
```

Claude Code は TUI なので出力の大半が `stdout` 型になる。#373 / #374 で具体化したのは read / write / search / test / git などで、**TUIの主戦場である `stdout` は手つかず**だった。

## 原因は3つ、いずれも PTY バイト列 → イベントの経路

### 1. OSC が剥がれていなかった

`ANSI_ESCAPE_RE` の2文字エスケープ用クラスが `[@-Z\\-_]` と書かれていた。`\\-_` は `\`(0x5C) から `_`(0x5F) への**範囲**で、`]`(0x5D) を含む。そのため `ESC ]` が2文字エスケープとしてマッチし、導入部だけ消えて本体が残る。

Claude Code はターミナルタイトルをスピナー付きで書き換え続けるので、`0;⠂ List files in docs folder` が延々とログに流れ込んでいた。

### 2. 同じクラスが `Z` 止まりだった

再描画のたびに出るカーソル保存/復元 `ESC 7` / `ESC 8` が処理されず、文字列 `78` として残っていた。

### 3. チャンク境界で分断されたエスケープ

PTY は任意のバイト境界でデータを渡すので、エスケープシーケンスが2回の `onData` に割れる。各チャンクを独立に処理していたため末尾が本文として残り、`40;1H`、`[22`、`8;5;174m` がログに出ていた。

## 修正

- 正規表現を**OSC優先**に並べ替え、2文字エスケープの終端バイトを 0x30–0x7E 全域に拡張。抽出器と supervision ruleset にコピペされていたものを `terminal-escapes.ts` へ集約
- `createEscapeCarry()` が未完のエスケープを次チャンクへ持ち越す。**生出力はターミナルペインへ従来どおり無加工で流す**（イベント抽出の経路だけ境界を修復）
- エスケープを剥がしても残る「意味のないテキスト」＝スピナー字形・アニメーション状態語・トークンカウンタ・フッタのヘルプを `isClaudeTuiNoise` で除去し、実質的な中身が残らない行は落とす

## 効果（実セッション45秒をキャプチャして計測）

| | イベント数 |
|---|---|
| 修正前 | 28 |
| OSC + 2文字エスケープ修正後 | 28（残骸は消滅） |
| チャンク持ち越し追加後 | 28（`40;1H` 等が消滅） |
| TUIノイズ除去追加後 | **21** |

純粋なチロメ行は全て消えた:

```
消えた例:
  ✶82 ✻5✽37Lollygagging…8912Lol
  ✢4⏺6·Lollygagging…6Lollygagging…gg✢yg
  ap✢Ca✳t✶✻a✽C✻
  0;⠂ List files in docs folder
  78

残った例（正しく残すべきもの）:
  docs/の中身は以下の通りです。docs/ 直下（30ファイル…
  $ ls -1 /Users/home/AION_Project/repos/cli-commentator/docs
  Listed 3 directories, ran 1 shell command
```

## 残る問題（本PRでは直せない）

部分再描画で**文字列自体が壊れている**行が残る:

```
rqurements.nmd / requirement.ja.m
certificsecretsen.md / certificate-secrets.ja.md
ies, runing1 shell command…
```

これはフィルタでは修復できない。ルールセット側が `⏺ Tool(...)` のような**構造化された行だけを信頼する**方式（当初の選択肢C）に変える必要がある。別PR。

## 検証

- `pnpm -C apps/server exec vitest run` — 835 passed（新規23件を含む）
- `pnpm -C apps/web exec vitest run` — 102 passed
- `tsc --noEmit`（両workspace）、`pnpm build:server`
- `pnpm eval:phase-b` — Snapshot: MATCH（差分なし）

新規テスト `tui-noise.test.ts`：OSC/ST/カーソル保存復元/CSI/charset の除去、チャンク分断の持ち越し（CSI・OSC・単独ESC・上限打ち切り）、実セッション由来のノイズ行8件と残すべき行5件。

## レビュー観点

- `isClaudeTuiNoise` の閾値（実質文字8文字未満で破棄）が厳しすぎ／緩すぎないか
- `STATUS_CHROME` に入れた文言の妥当性
- `createEscapeCarry` の上限256文字
- 生出力をターミナルペインへ無加工で流す方針を維持している点

🤖 Generated with [Claude Code](https://claude.com/claude-code)