### PR TITLE
docs: add 2026-08-01 handoff (#374/#376 reapply instructions)

### DIFF
--- a/handoff/status-2026-08-01.md
+++ b/handoff/status-2026-08-01.md
@@ -1,0 +1,188 @@
+# handoff 2026-08-01 — cli-commentator / 実況品質4PRのmerge漏れ復旧と、TUI構造化対応
+
+## 1. HUMAN判断待ち（最初に読む）
+
+- **判断事項1**：PR #374 / #376 の内容を main へ再適用する作業を Codex（Gino）に実行させてよいか
+  - 推奨：**実行させてよい**。cherry-pick がコンフリクトなしで通り、全検証が通ることをKUROが実測済み（手順は §6）。作業自体は機械的で、判断を要する設計変更を含まない
+  - 選択肢：A. Codexが実行しPRを作る（推奨） / B. KUROが実行する / C. 当面mainは#373+#375のみで運用する
+  - 期限・緊急度：次にアプリを実機で試す前 / **緊急度高**
+  - 判断しない場合の影響：失敗時の読み上げ（#374）とTUI再描画の除去（#376）がmainに入らないまま。Claude Code起動時にスピナーやトークンカウンタを音読する状態が続く
+- **判断事項2**：復旧後、選択肢C（構造化行だけを信頼する実況）へ進むか
+  - 推奨：**進む**。#376適用後でもClaude Codeセッションの読み上げは「作業の状態が変わりました。」の反復が残ることを実測済み（§4）
+  - 選択肢：A. 復旧完了後すぐ着手（推奨） / B. 実機で一度聞いてから判断
+  - 期限・緊急度：復旧merge後 / 緊急度中
+  - 判断しない場合の影響：ノイズは消えるが「単純すぎる反復」というHUMANの当初の不満が残る
+
+## 2. 現在地
+
+- main：`1a5a125`（PR #373）
+- **mainに入っているもの**：#375（spawn-helper実行ビット）、#373（実況＋解説の具体化）
+- **mainに入っていないもの**：#374（失敗時の読み上げ）、#376（TUI再描画の除去）
+- PR #373 / #374 / #375 / #376：GitHub上はすべて MERGED
+- サイドカー：main で再生成済み、`spawn-helper` 実行ビット6件復元、PTY起動確認済み
+
+### merge漏れの原因
+
+PRのbaseが連鎖していた。
+
+| PR | base | 実際のmerge先 |
+|---|---|---|
+| #375 | main | main ✅ |
+| #373 | main | main ✅ |
+| #374 | `feat/narration-detail-aware` | 同ブランチ（mainではない） |
+| #376 | `feat/failure-speech` | 同ブランチ（mainではない） |
+
+#373 を squash merge して親ブランチを削除したため、#374 / #376 の内容は main へ到達しなかった。GitHub上は MERGED と表示されるが実体が無い。
+
+**KUROが「GitHubが自動でbaseを追従させる」と説明したのは誤り。squash mergeでは追従しない。** 今後スタックPRを作る場合は、親がmergeされた時点で子のbaseをmainへ手動で張り替えるか、最初から独立PRにする。
+
+### 実体の確認方法
+
+```bash
+ls apps/server/src/commentary/narration-subject.ts    # #373 → 存在する
+ls packages/shared/src/failure-classification.js      # #374 → 存在しない
+ls apps/server/src/terminal-escapes.ts                # #376 → 存在しない
+```
+
+## 3. 今回やったこと
+
+- 実況・解説の具体化（#373）、失敗時の読み上げ（#374）、TUI再描画の除去（#376）を実装
+- **デスクトップアプリが全CLIを起動できないバグを発見・修正（#375）**。`pnpm deploy --prod` が node-pty の `spawn-helper` を実行ビット無しで書き出しており、サーバーは `running` を報告するのに `posix_spawnp failed.` で `bash` すら起動できなかった。7月24日以降のrelease `.app` が該当
+- Computer Use でデスクトップアプリを実機操作し、Claude Code セッションでの読み上げを観測
+- 実PTY出力をキャプチャし、ノイズの原因を3点特定（§4）
+- 4PR統合ブランチでコンフリクト・回帰が無いことを検証
+- merge後に main の実体を確認し、#374 / #376 の欠落を検出
+
+## 4. 重要な発見・リスク
+
+### ANSI escape 正規表現の欠陥（#376で修正、main未適用）
+
+`[@-Z\\-_]` は `\`(0x5C)〜`_`(0x5F) の**範囲**で `]`(0x5D) を含む。そのため `ESC ]` が2文字エスケープとしてマッチし、OSC本体が本文として残っていた。Claude Code はターミナルタイトルをスピナー付きで書き換え続けるため、`0;⠂ List files in docs folder` が延々とログに流入し音読されていた。
+
+同じクラスが `Z` 止まりのため、再描画のたびに出る `ESC 7` / `ESC 8` が文字列 `78` として残っていた。
+
+さらに PTY はチャンク境界でエスケープを分断するため、`40;1H` `[22` `8;5;174m` が本文として残っていた。
+
+### #376 を入れても、実況はまだ製品水準ではない
+
+実キャプチャ（45秒のClaude Codeセッション）を#376適用後のパイプラインに通した結果：
+
+```
+ 1.6s  作業の状態が変わりました。
+ 3.2s  自動テストを実行しています。
+28.9s  作業の状態が変わりました。
+33.7s  作業の状態が変わりました。
+35.4s  作業の状態が変わりました。
+（以下、作業の状態が変わりました。が続く）
+```
+
+ゴミの音読は消えたが、**「作業の状態が変わりました。」の反復**に置き換わっただけ。部分再描画で本文が壊れた `stdout` イベントが実況を作れず汎用フォールバックに落ちるため。
+
+```
+壊れた本文の例:
+  rqurements.nmd / requirement.ja.m
+  certificsecretsen.md / certificate-secrets.ja.md
+  ies, runing1 shell command…
+```
+
+フィルタでは修復不能。**ルールセットが `⏺ Tool(...)` のような構造化行だけを信頼する方式（選択肢C）が必要。**
+
+### 実況の読み上げ経路に関する事実
+
+- 読み上げられるのは `narration` のみ（`speech.text` = `payload.narration ?? payload.explanation`）。`explanation` は画面表示専用
+- `error` は urgent 優先度のため `applySpeechContract` が `buildUrgentSpeechText` に分岐し、実況を読まない
+- `stderr` 型はどのルールセット・入力経路も生成していない（型定義のみ）
+
+### 検証数値の訂正
+
+統合検証時に「835 tests passed」と報告したが、一時テストファイルを含んだ誤り。**正しくは 813**。
+
+## 5. 次の一手（AI別）
+
+- **HUMAN**：判断事項1・2を決める。復旧PRのmergeを行う
+- **Gino（Codex）**：§6の手順で復旧PRを作る。cherry-pick・検証はKURO実測済みなので、再現確認とPR作成が主
+- **KURO**：復旧merge後、選択肢C（構造化行だけを信頼する実況）に着手する
+- **JEM**：今回は依頼なし
+
+## 6. 作業指示書：#374 / #376 を main へ再適用（Codex向け）
+
+```
+目的:
+  PR #374（失敗時の読み上げ）と #376（TUI再描画の除去）の内容を main へ入れる。
+  GitHub上はMERGEDだがbase連鎖のためmainに実体が無い。
+
+現状:
+  main = 1a5a125（#373 + #375 済み）
+  復旧元ブランチ = origin/feat/suppress-tui-noise（3コミットが未適用のまま残存）
+
+やること（優先順）:
+  1. main から作業ブランチを作る
+  2. 3コミットを cherry-pick する
+  3. 検証コマンドを全て通す
+  4. base=main で PR を作成する（squash merge 前提）
+
+やらないこと:
+  - コミット内容の変更・追加実装（復旧のみ）
+  - main への直接push
+  - merge（HUMANのみ）
+  - 選択肢C（構造化行対応）の先行実装
+
+成功条件:
+  - 下記4ファイルが存在する
+      packages/shared/src/failure-classification.js
+      packages/shared/src/failure-classification.d.ts
+      apps/server/src/terminal-escapes.ts
+      apps/server/src/tests/tui-noise.test.ts
+  - 検証コマンドが全て成功し、下記の期待値と一致する
+  - origin/feat/suppress-tui-noise との内容差分が
+    scripts/prepare-desktop-sidecar.mjs と docs/ 以外で存在しない
+
+実行コマンド:
+  cd ~/AION_Project/repos/cli-commentator
+  git fetch origin
+  git switch -c fix/reapply-374-376 origin/main
+  git cherry-pick f69f0d1 08c794f 4063bbb
+
+  pnpm -C apps/server exec tsc --noEmit
+  pnpm -C apps/web exec tsc --noEmit
+  pnpm -C apps/server exec vitest run
+  pnpm -C apps/web exec vitest run
+  pnpm build:server
+  pnpm -C apps/web build
+  pnpm eval:phase-b
+
+  git push -u origin fix/reapply-374-376
+  gh pr create --base main --title "fix: reapply #374 and #376 to main"
+
+期待値（KURO実測 2026-08-01）:
+  cherry-pick   : コンフリクトなし
+  server tsc    : エラーなし
+  web tsc       : エラーなし
+  server vitest : 53 files / 813 tests passed
+  web vitest    : 102 tests passed
+  eval:phase-b  : Snapshot: MATCH
+  内容差分      : sidecar/docs 以外は空
+
+cherry-pick 対象コミット:
+  f69f0d1  feat(commentary): say what failed instead of that something failed   （#374 本体）
+  08c794f  fix(shared): import the failure classifier through its subpath       （#374 修正）
+  4063bbb  fix(extract): stop reading Claude Code's repaint chrome aloud        （#376）
+
+  ※ 08c794f は必須。バンドル版デスクトップの sidecar は素のNodeで動くため、
+    パッケージrootからの値インポートは ERR_UNKNOWN_FILE_EXTENSION で起動失敗する。
+    これを落とすと desktop_distribution_smoke が失敗する。
+
+ログの貼り方: エラーは末尾20行
+```
+
+### コンフリクトが出た場合
+
+出ないことを実測済みだが、万一出たら `git cherry-pick --abort` して停止し、HUMANへ報告すること。手動解決は行わない（#373 の squash 内容と重複する可能性があるため）。
+
+## 7. 参照リンク
+
+- PR #373: https://github.com/gatyoukatyou/cli-commentator/pull/373
+- PR #374: https://github.com/gatyoukatyou/cli-commentator/pull/374
+- PR #375: https://github.com/gatyoukatyou/cli-commentator/pull/375
+- PR #376: https://github.com/gatyoukatyou/cli-commentator/pull/376
+- 前回handoff: `handoff/status-2026-07-31.md`


### PR DESCRIPTION
2026-08-01 の節目 handoff。次のセッションと Codex への引き継ぎ資料。

## 中心的な内容

**PR #374 / #376 は GitHub 上 MERGED だが main に実体が無い。** base が親フィーチャーブランチだったため、#373 の squash merge で親が削除された時点で子の内容が main へ到達しなかった。

`handoff/status-2026-08-01.md` §6 に、Codex がそのまま実行できる作業指示書を置いた。cherry-pick と全検証は KURO が実測済みで、期待値も記載してある。

## 記録した主な発見

- デスクトップアプリが全CLIを起動できなかった原因（`spawn-helper` の実行ビット欠落。#375で修正済み）
- ANSI escape 正規表現の欠陥（`[@-Z\\-_]` が範囲として `]` を含み OSC を取り逃がす）
- **#376 を入れても実況は製品水準に達しない**という実測。ゴミの音読は消えるが「作業の状態が変わりました。」の反復に置き換わるだけで、構造化行だけを信頼する方式（選択肢C）が必要
- 統合検証時に報告した「835 tests」の訂正（正しくは813）

## 検証

`node ./scripts/check-doc-sync.mjs` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)