### PR TITLE
fix: reapply #374 and #376 to main

### DIFF
--- a/apps/server/src/commentary/beginner-lines.ts
+++ b/apps/server/src/commentary/beginner-lines.ts
@@ -1,3 +1,4 @@
+import { classifyFailure, type FailureKind } from "@cli-commentator/shared";
 import type { Event, EventType } from "../types.js";
 import { describeBashMeaning, detailCommand, extractReadTarget, extractSearchTerm, extractWriteTarget } from "./bash-meaning.js";
 import { describeNarrationSubject } from "./narration-subject.js";
@@ -39,6 +40,17 @@ function onDetail(re: RegExp) {
 function fixed(text: string) {
   return () => text;
 }
+
+/** Display wording per failure kind; the classification itself is shared. */
+const FAILURE_EXPLANATIONS: Record<FailureKind, string> = {
+  "type-error": "TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。",
+  "port-in-use":
+    "使おうとしたポートが既に別のプロセスに使われています。先に動いているものを止めるか、別のポートを使う場面です。",
+  permission: "権限が足りず操作が拒否されました。書き込み先や実行権限を確認する場面です。",
+  "module-not-found": "参照している部品が見つかりません。依存の導入漏れか、参照先の誤りが疑われます。",
+  "command-not-found": "必要なコマンドが見つかりません。導入漏れか、パスの設定を確認する場面です。",
+  "exit-code": "実行したコマンドが失敗して終了しました。原因は直前の出力に出ていることが多いです。",
+};
 
 const RULES: ReadonlyArray<ExplanationRule> = [
   // --- stdout: classify what the raw output actually is -------------------
@@ -287,41 +299,17 @@ const RULES: ReadonlyArray<ExplanationRule> = [
   },
 
   // --- failures: name the class of problem, then the next thing to check --
+  // Detection is shared with the spoken urgent line so the two cannot drift;
+  // only the wording differs, since display has room to explain and speech
+  // has to fit one interrupting breath.
   {
-    id: "error.typescript",
-    types: ["error"],
-    when: onDetail(/\bTS\d{4,5}\b/u),
-    line: fixed("TypeScript が『データや部品のつながりが合っていない』箇所を知らせています。"),
-  },
-  {
-    id: "error.command-not-found",
+    id: "error.classified",
     types: ["error", "stderr"],
-    when: onDetail(/command not found|: not found\b/iu),
-    line: fixed("必要なコマンドが見つかりません。導入漏れか、パスの設定を確認する場面です。"),
-  },
-  {
-    id: "error.module-not-found",
-    types: ["error", "stderr"],
-    when: onDetail(/Cannot find module|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND/iu),
-    line: fixed("参照している部品が見つかりません。依存の導入漏れか、参照先の誤りが疑われます。"),
-  },
-  {
-    id: "error.port-in-use",
-    types: ["error", "stderr"],
-    when: onDetail(/EADDRINUSE|address already in use/iu),
-    line: fixed("使おうとしたポートが既に別のプロセスに使われています。先に動いているものを止めるか、別のポートを使う場面です。"),
-  },
-  {
-    id: "error.permission",
-    types: ["error", "stderr"],
-    when: onDetail(/EACCES|permission denied/iu),
-    line: fixed("権限が足りず操作が拒否されました。書き込み先や実行権限を確認する場面です。"),
-  },
-  {
-    id: "error.exit-code",
-    types: ["error", "stderr"],
-    when: onDetail(/ELIFECYCLE|exited with code|exit code|failed with exit code/iu),
-    line: fixed("実行したコマンドが失敗して終了しました。原因は直前の出力に出ていることが多いです。"),
+    when: ({ detail }) => classifyFailure(detail) !== null,
+    line: ({ detail }) => {
+      const kind = classifyFailure(detail);
+      return kind ? FAILURE_EXPLANATIONS[kind] : null;
+    },
   },
 
   // --- generic tool call: last resort before the type-level table ---------

--- a/apps/server/src/commentary/beginner-lines.ts
+++ b/apps/server/src/commentary/beginner-lines.ts
@@ -1,4 +1,8 @@
-import { classifyFailure, type FailureKind } from "@cli-commentator/shared";
+// Import through the subpath, not the package root: the bundled desktop
+// sidecar runs on plain Node, and the root entry is a `.ts` file that only
+// resolves for type-only imports. This mirrors how `speech-policy` imports
+// `urgent-speech`.
+import { classifyFailure, type FailureKind } from "@cli-commentator/shared/failure-classification";
 import type { Event, EventType } from "../types.js";
 import { describeBashMeaning, detailCommand, extractReadTarget, extractSearchTerm, extractWriteTarget } from "./bash-meaning.js";
 import { describeNarrationSubject } from "./narration-subject.js";

--- a/apps/server/src/commentary/failure-speech.test.ts
+++ b/apps/server/src/commentary/failure-speech.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { classifyFailure } from "@cli-commentator/shared";
+import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
+import { beginnerOneLine } from "./beginner-lines.js";
+import type { Event } from "../types.js";
+
+const SAMPLES = [
+  ["TS2554: Expected 1 arguments, but got 2.", "type-error"],
+  ["listen EADDRINUSE: address already in use :::8787", "port-in-use"],
+  ["EACCES: permission denied, open '/etc/hosts'", "permission"],
+  ["Error: Cannot find module 'zod'", "module-not-found"],
+  ["zsh: command not found: pnpm", "command-not-found"],
+  ["ELIFECYCLE  Command failed with exit code 1.", "exit-code"],
+] as const;
+
+describe("classifyFailure", () => {
+  it.each(SAMPLES)("recognises %s", (detail, kind) => {
+    expect(classifyFailure(detail)).toBe(kind);
+  });
+
+  it("returns null when the log says nothing recognisable", () => {
+    expect(classifyFailure("something went wrong")).toBeNull();
+    expect(classifyFailure(undefined)).toBeNull();
+  });
+
+  // The port message also contains "listen", and an exit-code line often
+  // accompanies a more specific cause; the specific pattern has to win.
+  it("prefers the specific cause over a trailing exit code", () => {
+    expect(
+      classifyFailure("Error: listen EADDRINUSE: address already in use\nELIFECYCLE exit code 1")
+    ).toBe("port-in-use");
+  });
+});
+
+describe("urgent speech for failures", () => {
+  function failure(detail: string): Event {
+    // Every ruleset collapses failures to this summary, which is why the spoken
+    // line used to be "要対応です：エラーが出ている。" no matter what broke.
+    return { ts: 1, type: "error", summary: "エラーが出ている", detail };
+  }
+
+  it.each([
+    ["listen EADDRINUSE: address already in use :::8787", "要対応です：使用中のポートで起動できません。"],
+    ["zsh: command not found: pnpm", "要対応です：コマンドが見つかりません。"],
+    ["Error: Cannot find module 'zod'", "要対応です：参照先の部品が見つかりません。"],
+    ["EACCES: permission denied", "要対応です：権限が足りず実行できません。"],
+    ["TS2554: Expected 1 arguments", "要対応です：型の不一致が出ています。"],
+    ["ELIFECYCLE  Command failed with exit code 1.", "要対応です：コマンドが失敗して終了しました。"],
+  ])("names what failed: %s", (detail, expected) => {
+    expect(buildUrgentSpeechText(failure(detail))).toBe(expected);
+  });
+
+  it("keeps the summary when the log identifies no known failure", () => {
+    expect(buildUrgentSpeechText(failure("something went wrong"))).toBe(
+      "要対応です：エラーが出ている。"
+    );
+  });
+
+  // Approval and question prompts are more urgent than any failure text that
+  // happens to be scrolled into the same excerpt.
+  it("still prioritises an approval prompt", () => {
+    const event: Event = {
+      ts: 1,
+      type: "error",
+      summary: "コマンド実行の確認待ち",
+      detail: "would you like to run the following command?\n  pnpm test\nexit code 1",
+    };
+    expect(buildUrgentSpeechText(event)).toBe("要対応です：「テスト」の実行許可を求めています。");
+  });
+});
+
+describe("failure wording stays split between speech and display", () => {
+  it.each(SAMPLES)("explains %s at more length than it speaks it", (detail) => {
+    const event: Event = { ts: 1, type: "error", summary: "エラーが出ている", detail };
+    const spoken = buildUrgentSpeechText(event);
+    const displayed = beginnerOneLine(event);
+    expect(displayed.length).toBeGreaterThan(spoken.length);
+  });
+});

--- a/apps/server/src/commentary/failure-speech.test.ts
+++ b/apps/server/src/commentary/failure-speech.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyFailure } from "@cli-commentator/shared";
+import { classifyFailure } from "@cli-commentator/shared/failure-classification";
 import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
 import { beginnerOneLine } from "./beginner-lines.js";
 import type { Event } from "../types.js";

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,8 +1,9 @@
 import type { Event } from "./types.js";
 import { rulesForLine } from "./rulesets/index.js";
-import { isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
+import { isClaudeTuiNoise, isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
 import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
+import { ANSI_ESCAPE_RE } from "./terminal-escapes.js";
 
 // Legacy X10 mouse reports include three coordinate bytes after CSI M. Strip
 // them before the generic CSI matcher consumes only the introducer.
@@ -15,11 +16,6 @@ const LEGACY_MOUSE_REPORT_RE =
 const CHARSET_DESIGNATION_RE =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
   /\u001B[()*+][0-2A-Z]/g;
-
-// Remove ANSI/VT control sequences so TUI apps like Claude Code still match rules.
-const ANSI_ESCAPE_RE =
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
-  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
 
 function normalizeLine(line: string): string {
   return line
@@ -398,6 +394,9 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
     return null;
   }
   if (source === "codex" && isCodexProgressNoise(normalized)) {
+    return null;
+  }
+  if (source === "claude" && isClaudeTuiNoise(normalized)) {
     return null;
   }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types.js";
 import { redact } from "./redact.js";
 import { extractEvents } from "./extract.js";
+import { createEscapeCarry } from "./terminal-escapes.js";
 import { comment } from "./styles/index.js";
 import { getAutoDetectedSource, resetAutoDetection } from "./rulesets/index.js";
 import * as profileManager from "./profile/manager.js";
@@ -364,6 +365,8 @@ async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
   }
 }
 
+const carryEscape = createEscapeCarry();
+
 /**
  * Process incoming data from any input source (PTY or FileTail).
  * This is the common data processing pipeline.
@@ -381,7 +384,9 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
     sourceState.mode === "auto"
       ? sourceState.detected ?? currentSourceMode
       : sourceState.mode;
-  const evs = extractEvents(clean, activeSource);
+  // Raw output goes to the terminal pane unchanged; only event extraction needs
+  // the chunk boundary repaired, so a split escape sequence is not read aloud.
+  const evs = extractEvents(carryEscape(clean), activeSource);
   const detected = getAutoDetectedSource();
   if (detected) broadcastSource(detected);
 

--- a/apps/server/src/progress-noise.ts
+++ b/apps/server/src/progress-noise.ts
@@ -15,6 +15,49 @@ export function isTerminalRenderingNoise(text: string): boolean {
   );
 }
 
+/**
+ * Claude Code repaints its whole frame many times a second. Each repaint is
+ * delivered as ordinary output, so the extractor turns spinner glyphs, the
+ * animated status word and the token counter into `stdout` events — which the
+ * commentary then reads aloud as
+ * `今見えている出力は「✻(2s · ↓4 tokens)」です。`
+ *
+ * These are the decorations, removed before judging whether anything was said.
+ */
+const CLAUDE_SPINNER_GLYPHS = /[✢-✧✱-✿⏺⏸❯⎽]/gu;
+const BOX_DRAWING = /[─-▟]/gu;
+const BRAILLE_SPINNER = /[⠀-⣿]/gu;
+// No `\b`: a repaint often glues the word to the previous counter (`✽37Lollygagging…`),
+// and there is no word boundary between a digit and a letter.
+/** The animated status word, e.g. `Lollygagging…`, `Catapulting…`, `Herding…`. */
+const SPINNER_WORD = /[A-Za-z]{3,24}(?:…|\.{3})/gu;
+/** `(2s · ↓8 tokens)`, `(13s · ↓618 tokens)`, and the fragments repaints leave. */
+const TOKEN_COUNTER = /\(?\s*\d+\s*s?\s*[·•]?\s*[↑↓]?\s*[\d.]+\s*k?\s*tokens?\s*\)?/giu;
+/** Persistent footer/help chrome that never describes what the AI is doing. */
+const STATUS_CHROME =
+  /esc to interrupt|\? for shortcuts|manual mode on|Try "[^"]*"|You've used \d+% of your weekly limit|run \/login to renew|Crunched for \d+s|connecting…/giu;
+
+/** Letters and CJK only; stray digits left by a repaint are not content. */
+function meaningfulLength(text: string): number {
+  return (text.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{L}]/gu) ?? []).length;
+}
+
+const MIN_MEANINGFUL_CHARS = 8;
+
+export function isClaudeTuiNoise(text: string): boolean {
+  const residue = text
+    .replace(STATUS_CHROME, " ")
+    .replace(TOKEN_COUNTER, " ")
+    .replace(SPINNER_WORD, " ")
+    .replace(CLAUDE_SPINNER_GLYPHS, " ")
+    .replace(BOX_DRAWING, " ")
+    .replace(BRAILLE_SPINNER, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+  return meaningfulLength(residue) < MIN_MEANINGFUL_CHARS;
+}
+
 export function isCodexProgressNoise(text: string): boolean {
   return (
     /^working\s*\(\d+s\s*[•·]\s*esc to interrupt\)$/i.test(text) ||

--- a/apps/server/src/rulesets/claude-supervision.ts
+++ b/apps/server/src/rulesets/claude-supervision.ts
@@ -1,8 +1,5 @@
 import type { Event } from "../types.js";
-
-const ANSI_ESCAPE_RE =
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
-  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
+import { ANSI_ESCAPE_RE } from "../terminal-escapes.js";
 
 function normalizeTuiChunk(chunk: string): { readable: string; compact: string } {
   const readable = chunk

--- a/apps/server/src/terminal-escapes.ts
+++ b/apps/server/src/terminal-escapes.ts
@@ -1,0 +1,76 @@
+/**
+ * Terminal escape sequence stripping, shared by the extractor and the Claude
+ * supervision ruleset so the two cannot diverge.
+ *
+ * The OSC alternative (`ESC ] ... BEL`) must come first. The two-character
+ * escape class was previously written `[@-Z\\-_]`, where `\\-_` is a *range*
+ * from `\` (0x5C) to `_` (0x5F) and therefore contains `]` (0x5D). `ESC ]` then
+ * matched as a two-character escape, consuming only the introducer and leaving
+ * the OSC body behind — so every terminal-title update leaked into the log as
+ * `0;⠂ List files in docs folder` and was read aloud verbatim.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+export const ANSI_ESCAPE_RE =
+  /\u001B(?:\][^\u0007]*(?:\u0007|\u001B\\)|\[[0-?]*[ -/]*[@-~]|[()*+][0-2A-Z]|[0-~])/g;
+
+export function stripTerminalEscapes(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+const ESC = "\u001B";
+const BEL = "\u0007";
+/** Long enough for any real sequence, short enough that a stray ESC cannot stall the stream. */
+const MAX_CARRY = 256;
+
+/**
+ * Index at which an escape sequence starts but does not finish inside `text`,
+ * or -1 when the tail is complete.
+ */
+function incompleteEscapeStart(text: string): number {
+  const start = text.lastIndexOf(ESC);
+  if (start < 0) return -1;
+
+  const rest = text.slice(start);
+  if (rest.length === 1) return start;
+
+  switch (rest[1]) {
+    case "[":
+      // CSI: parameter and intermediate bytes until a final byte 0x40–0x7E.
+      return /^\[[0-?]*[ -/]*[@-~]/.test(rest) ? -1 : start;
+    case "]":
+      // OSC: terminated by BEL or ST.
+      return rest.includes(BEL) || rest.includes(`${ESC}\\`) ? -1 : start;
+    case "(":
+    case ")":
+    case "*":
+    case "+":
+      return rest.length >= 3 ? -1 : start;
+    default:
+      return -1;
+  }
+}
+
+/**
+ * A PTY delivers arbitrary byte chunks, so an escape sequence can be split
+ * across two `onData` callbacks. Stripping each chunk independently then leaves
+ * the tail behind as text — the log fills with fragments like `40;1H`, `[22` or
+ * `0;⠂ List files in docs folder`, and the commentary reads them aloud.
+ *
+ * Returns a function that holds back an unfinished trailing sequence and
+ * prepends it to the next chunk.
+ */
+export function createEscapeCarry(): (chunk: string) => string {
+  let pending = "";
+
+  return (chunk: string) => {
+    const text = pending + chunk;
+    pending = "";
+
+    const start = incompleteEscapeStart(text);
+    if (start < 0) return text;
+    if (text.length - start > MAX_CARRY) return text;
+
+    pending = text.slice(start);
+    return text.slice(0, start);
+  };
+}

--- a/apps/server/src/tests/tui-noise.test.ts
+++ b/apps/server/src/tests/tui-noise.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { isClaudeTuiNoise } from "../progress-noise.js";
+import { createEscapeCarry, stripTerminalEscapes } from "../terminal-escapes.js";
+
+const ESC = "\u001B";
+const BEL = "\u0007";
+
+describe("terminal escape stripping", () => {
+  // `[@-Z\\-_]` was a range covering `]`, so `ESC ]` matched as a two-character
+  // escape and the OSC body survived as text.
+  it("removes an OSC terminal-title sequence, body included", () => {
+    expect(stripTerminalEscapes(`${ESC}]0;✳ Claude Code${BEL}rest`)).toBe("rest");
+    expect(stripTerminalEscapes(`${ESC}]0;⠂ List files in docs folder${BEL}`)).toBe("");
+  });
+
+  it("removes an OSC sequence terminated by ST", () => {
+    expect(stripTerminalEscapes(`${ESC}]0;title${ESC}\\tail`)).toBe("tail");
+  });
+
+  // Claude Code emits these on every repaint; the old class stopped at `Z`.
+  it("removes the cursor save/restore pair", () => {
+    expect(stripTerminalEscapes(`${ESC}7${ESC}8text`)).toBe("text");
+  });
+
+  it("still removes CSI and charset sequences", () => {
+    expect(stripTerminalEscapes(`${ESC}[38;5;174mhello${ESC}[0m`)).toBe("hello");
+    expect(stripTerminalEscapes(`${ESC}(Bplain`)).toBe("plain");
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(stripTerminalEscapes("docs/ の中身は以下の通りです。")).toBe("docs/ の中身は以下の通りです。");
+  });
+});
+
+describe("escape sequences split across PTY chunks", () => {
+  it("carries an unfinished CSI into the next chunk", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`before${ESC}[38;`)).toBe("before");
+    expect(stripTerminalEscapes(carry("5;174mafter"))).toBe("after");
+  });
+
+  it("carries an unfinished OSC into the next chunk", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`${ESC}]0;⠂ List files`)).toBe("");
+    expect(stripTerminalEscapes(carry(`in docs folder${BEL}done`))).toBe("done");
+  });
+
+  it("carries a lone trailing ESC", () => {
+    const carry = createEscapeCarry();
+    expect(carry(`text${ESC}`)).toBe("text");
+    expect(stripTerminalEscapes(carry("[0mmore"))).toBe("more");
+  });
+
+  it("passes complete chunks through untouched", () => {
+    const carry = createEscapeCarry();
+    expect(carry("plain text")).toBe("plain text");
+  });
+
+  // A stray ESC must not stall the stream indefinitely.
+  it("gives up once the carried tail grows past the cap", () => {
+    const carry = createEscapeCarry();
+    const long = `${ESC}[${"1;".repeat(200)}`;
+    expect(carry(long)).toBe(long);
+  });
+});
+
+describe("isClaudeTuiNoise", () => {
+  // Captured from a real Claude Code session, after escape stripping.
+  it.each([
+    "✶82 ✻5✽37Lollygagging…8912Lol",
+    "✢4⏺6·Lollygagging…6Lollygagging…gg✢yg",
+    "ap✢Ca✳t✶✻a✽C✻",
+    "✻(2s · ↓4 tokens)",
+    "Lollygagging… (13s · ↓618 tokens)",
+    "✻Crunched for 13s",
+    "❯ ? for shortcuts",
+    "esc to interrupt",
+  ])("drops repaint chrome: %s", (line) => {
+    expect(isClaudeTuiNoise(line)).toBe(true);
+  });
+
+  it.each([
+    "docs/の中身は以下の通りです。",
+    "⏺ Read(apps/web/src/App.tsx)",
+    "$ ls -1 /Users/home/AION_Project/repos/cli-commentator/docs",
+    "Listed 3 directories, ran 1 shell command",
+    "Error: Cannot find module 'zod'",
+  ])("keeps what actually reports progress: %s", (line) => {
+    expect(isClaudeTuiNoise(line)).toBe(false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     "./urgent-speech": {
       "types": "./src/urgent-speech.d.ts",
       "default": "./src/urgent-speech.js"
+    },
+    "./failure-classification": {
+      "types": "./src/failure-classification.d.ts",
+      "default": "./src/failure-classification.js"
     }
   }
 }

--- a/packages/shared/src/failure-classification.d.ts
+++ b/packages/shared/src/failure-classification.d.ts
@@ -1,0 +1,9 @@
+export type FailureKind =
+  | "type-error"
+  | "port-in-use"
+  | "permission"
+  | "module-not-found"
+  | "command-not-found"
+  | "exit-code";
+
+export declare function classifyFailure(detail?: string): FailureKind | null;

--- a/packages/shared/src/failure-classification.js
+++ b/packages/shared/src/failure-classification.js
@@ -1,0 +1,23 @@
+/**
+ * Recognises what kind of failure a log excerpt describes.
+ *
+ * Rulesets collapse every failure into a single summary ("エラーが出ている"), so
+ * both the spoken urgent line and the displayed explanation would otherwise say
+ * only that something failed. Detection lives here, shared, while each layer
+ * keeps its own wording: speech needs one short clause, display can explain.
+ *
+ * Patterns are ordered from specific to general, and the first match wins.
+ */
+const FAILURE_PATTERNS = [
+  ["type-error", /\bTS\d{4,5}\b/u],
+  ["port-in-use", /EADDRINUSE|address already in use/iu],
+  ["permission", /\bEACCES\b|\bEPERM\b|permission denied/iu],
+  ["module-not-found", /Cannot find module|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND|Module not found/iu],
+  ["command-not-found", /command not found|:\s*not found\b/iu],
+  ["exit-code", /ELIFECYCLE|exited with code|exit code|failed with exit code|non-zero exit/iu],
+];
+
+export function classifyFailure(detail) {
+  if (!detail) return null;
+  return FAILURE_PATTERNS.find(([, pattern]) => pattern.test(detail))?.[0] ?? null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./protocol.js";
 export * from "./parse-server-message.js";
 export * from "./urgent-speech.js";
+export * from "./failure-classification.js";
 export * from "./speech-repetition.js";

--- a/packages/shared/src/urgent-speech.js
+++ b/packages/shared/src/urgent-speech.js
@@ -1,4 +1,20 @@
+import { classifyFailure } from "./failure-classification.js";
+
 const APPROVAL_PROMPT_RE = /would you like to run the following command\?/iu;
+
+/**
+ * One short clause per failure kind. The urgent line interrupts whatever is
+ * being spoken, so it has to name the problem in a single breath; the detailed
+ * version belongs to the on-screen explanation.
+ */
+const FAILURE_SPEECH = {
+  "type-error": "型の不一致が出ています",
+  "port-in-use": "使用中のポートで起動できません",
+  permission: "権限が足りず実行できません",
+  "module-not-found": "参照先の部品が見つかりません",
+  "command-not-found": "コマンドが見つかりません",
+  "exit-code": "コマンドが失敗して終了しました",
+};
 const QUESTION_RE = /Question\s+(\d+)\/\d+\s+\((?:[1-9]\d*) unanswered\)/iu;
 const COMMAND_START_RE =
   /^(?:(?:sudo|command|env)\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:pnpm|npm|yarn|bun|npx|node|git|gh|cargo|docker|make|go|python\d*|deno|rm|mv|cp|mkdir|chmod|curl)\b/iu;
@@ -94,6 +110,11 @@ export function buildUrgentSpeechText(event) {
       ? `要対応です：質問${questionNumber}への回答を求めています。`
       : "要対応です：質問への回答を求めています。";
   }
+
+  // Every failure shares one ruleset summary ("エラーが出ている"), so fall back to
+  // the summary only when the log says nothing more specific.
+  const failure = classifyFailure(detail);
+  if (failure) return `要対応です：${FAILURE_SPEECH[failure]}。`;
 
   return `要対応です：${withoutTrailingSentencePunctuation(event.summary)}。`;
 }


### PR DESCRIPTION
🧑 HUMAN向け（先に読む）
・やったこと: main から漏れていた2件の修正を、内容を変えずに戻しました。
・なぜ必要か: 失敗時の読み上げ改善と、画面描画ノイズの除去を製品へ届けるためです。
・あなたの操作: PR #379 を開いて差分を確認し、「Ready for review」→「Squash and merge」の順に押してください。

## Summary

PR #374（失敗時の読み上げ）と #376（TUI再描画ノイズ除去）の3コミットを、最新の `main` へそのまま再適用します。スタックPRの親ブランチへ merge され、`main` に届いていなかった内容の復旧のみです。

ドキュメント更新は不要です。原因・手順・後続判断は、先に merge 済みの PR #377 と `handoff/status-2026-08-01.md` に記録済みです。

## Related Issues

Closes #378

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Checklist

### General

- [x] Tests pass locally
- [x] No new TypeScript errors
- [x] Code follows existing patterns in the codebase

### LLM / Comment Changes

- [x] Logs do NOT contain PII
- [x] Error cases are covered by the restored regression tests
- [x] Other LLM-specific checklist items are not applicable (no adapter change)

### Documentation

- [x] Documentation freshness reviewed; PR #377 already records the recovery and follow-up
- [x] No env vars or config changed
- [x] No new non-obvious logic was introduced; this is an exact reapplication

### Desktop / Tauri

- [x] Required shared import fix `08c794f` is included
- [x] GitHub CI `desktop_distribution_smoke` — PASS

### Reviewer Focus

- [x] Scope is limited to the three commits specified in Issue #378
- [x] No additional implementation of option C is included

## Test Plan

Local verification on 2026-08-01:

- `pnpm -C apps/server exec tsc --noEmit` — PASS
- `pnpm -C apps/web exec tsc --noEmit` — PASS
- `pnpm -C apps/server exec vitest run` — 53 files / 813 tests passed
- `pnpm -C apps/web exec vitest run` — 11 files / 102 tests passed
- `pnpm build:server` — PASS
- `pnpm -C apps/web build` — PASS
- `pnpm eval:phase-b` — Snapshot: MATCH
- Content diff against `origin/feat/suppress-tui-noise` is empty outside sidecar/docs/handoff files

## Todoist / Gate

- Card: `6h9qHq7RvfhxGg6C`
- Gate: `gate/human`
