### PR TITLE
feat(claude): drive commentary from the real Claude Code output format

### DIFF
--- a/apps/server/src/__tests__/detect.test.ts
+++ b/apps/server/src/__tests__/detect.test.ts
@@ -65,4 +65,11 @@ describe("ruleset auto detect", () => {
     expect(MAX_DETECT_LINES).toBe(50);
     expect(MIN_DELTA).toBe(4);
   });
+
+  it("detects the sanitized real Claude Code TUI capture", async () => {
+    const filePath = path.join(fixturesDir, "claude-tui/real-session-2.1.220.json");
+    const fixture = JSON.parse(await fs.readFile(filePath, "utf8")) as { raw: string };
+
+    expect(detectSourceFromText(fixture.raw)).toBe("claude");
+  });
 });

--- a/apps/server/src/__tests__/detect.test.ts
+++ b/apps/server/src/__tests__/detect.test.ts
@@ -72,4 +72,10 @@ describe("ruleset auto detect", () => {
 
     expect(detectSourceFromText(fixture.raw)).toBe("claude");
   });
+
+  it("detects Claude from its startup banner before the first tool result", () => {
+    const detector = createAutoDetector();
+
+    expect(detector.update("▐▛███▜▌Claude Codev2.1.220")).toBe("claude");
+  });
 });

--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -62,14 +62,7 @@ describe("extractEvents fixtures", () => {
       extractEvents(
         "const replacements: ReadonlyArray<readonly [RegExp, string]> = [];"
       )
-    ).toEqual([
-      {
-        ts: new Date("2025-01-01T00:00:00.000Z").getTime(),
-        type: "stdout",
-        summary: "ログ更新",
-        detail: "const replacements: ReadonlyArray<readonly [RegExp, string]> = [];",
-      },
-    ]);
+    ).toEqual([]);
   });
 
   it("drops Codex progress-noise lines from extraction", () => {

--- a/apps/server/src/command-analysis.test.ts
+++ b/apps/server/src/command-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractSearchPattern, isSearchExecution, isTestExecution, tokenizeShellCommand } from "./command-analysis.js";
+import { extractSearchPattern, isFileListExecution, isSearchExecution, isTestExecution, tokenizeShellCommand } from "./command-analysis.js";
 import { getGlossaryNotes } from "./commentary/glossary.js";
 
 describe("shell command analysis", () => {
@@ -56,6 +56,16 @@ describe("shell command analysis", () => {
   it("distinguishes a search command from a test runner's grep option", () => {
     expect(isSearchExecution("rg -n TODO src")).toBe(true);
     expect(isSearchExecution("playwright test --grep smoke")).toBe(false);
+  });
+
+  it.each([
+    "ls -1 /Users/demo/project/docs",
+    "⎿  $ ls -la docs",
+    "find docs -type f",
+    "fd --type f . docs",
+    "rg --files docs",
+  ])("recognizes file-list commands: %s", (command) => {
+    expect(isFileListExecution(command)).toBe(true);
   });
 });
 

--- a/apps/server/src/command-analysis.ts
+++ b/apps/server/src/command-analysis.ts
@@ -8,7 +8,8 @@ function commandName(value: string): string {
 
 export function unwrapCommandDetail(detail: string): string {
   const wrapped = detail.match(/^[⏺•]\s*(?:Bash|Grep|Glob)\((.*)\)$/s);
-  return (wrapped?.[1] ?? detail).trim().replace(/^>\s+/, "");
+  const claudeResult = detail.match(/^⎿\s*\$\s*(.+)$/s);
+  return (wrapped?.[1] ?? claudeResult?.[1] ?? detail).trim().replace(/^>\s+/, "");
 }
 
 export function tokenizeShellCommand(command: string): string[] | null {
@@ -162,7 +163,10 @@ export function isSearchExecution(command: string): boolean {
 
 export function isFileListExecution(command: string): boolean {
   return commandInvocations(unwrapCommandDetail(command)).some(({ segment, start, executable }) =>
-    executable === "find" || executable === "fd" || (executable === "rg" && segment.slice(start + 1).includes("--files"))
+    executable === "find" ||
+    executable === "fd" ||
+    executable === "ls" ||
+    (executable === "rg" && segment.slice(start + 1).includes("--files"))
   );
 }
 

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,5 +1,5 @@
 import type { Event } from "./types.js";
-import { rulesForLine } from "./rulesets/index.js";
+import { getAutoDetectedSource, rulesForLine } from "./rulesets/index.js";
 import { isClaudeTuiNoise, isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
 import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
@@ -385,11 +385,16 @@ function hasOnlyEmptyFailureMarkers(line: string): boolean {
   );
 }
 
+function resolvedSourceId(sourceEnv?: string): string {
+  const configured = (sourceEnv ?? "").trim().toLowerCase();
+  return configured === "auto" ? getAutoDetectedSource() ?? "generic" : configured;
+}
+
 function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
   const normalized = normalizeLine(rawLine);
   if (!normalized) return null;
 
-  const source = (sourceEnv ?? "").trim().toLowerCase();
+  const source = resolvedSourceId(sourceEnv);
   if (source !== "generic" && isTerminalRenderingNoise(normalized)) {
     return null;
   }
@@ -448,7 +453,7 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
 export function extractEvents(chunk: string, sourceEnv: string | undefined = process.env.LOG_SOURCE): Event[] {
   const ts = Date.now();
 
-  if ((sourceEnv ?? "").trim().toLowerCase() === "claude") {
+  if (resolvedSourceId(sourceEnv) === "claude") {
     const supervisionEvents = extractClaudeSupervisionEvents(chunk, ts);
     if (supervisionEvents.length > 0) return supervisionEvents;
   }
@@ -486,7 +491,7 @@ export function extractEvents(chunk: string, sourceEnv: string | undefined = pro
         }
       }
       events.push({ ts, type: hit.type, summary: hit.summary, detail });
-    } else if ((sourceEnv ?? "").trim().toLowerCase() !== "claude") {
+    } else if (resolvedSourceId(sourceEnv) !== "claude") {
       events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
     }
   }

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -486,7 +486,9 @@ export function extractEvents(chunk: string, sourceEnv: string | undefined = pro
         }
       }
       events.push({ ts, type: hit.type, summary: hit.summary, detail });
-    } else events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
+    } else if ((sourceEnv ?? "").trim().toLowerCase() !== "claude") {
+      events.push({ ts, type: "stdout", summary: "ログ更新", detail: line });
+    }
   }
   return events;
 }

--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -1,14 +1,23 @@
 import type { RuleSet } from "./types.js";
+import { isFileListExecution, isSearchExecution, isTestExecution } from "../command-analysis.js";
+
+const CLAUDE_COMMAND_RE = /^⎿\s*\$\s*\S/u;
+const CLAUDE_ASSISTANT_RE = /^⏺\s*(?!Read\(|Glob\(|Grep\(|Update\(|Edit\(|Write\(|Bash\()[\p{L}\p{N}]/u;
+const CLAUDE_SUMMARY_RE = /^Listed \d+ director(?:y|ies), ran \d+ shell commands?$/iu;
 
 export const claudeRuleset: RuleSet = {
   id: "claude",
   label: "Claude Code",
-  detect: (line) => /^(⏺|•)\s*(Read|Update|Write|Bash)\(/.test(line),
+  detect: (line) =>
+    /^(⏺|•)\s*(Read|Update|Write|Bash)\(/.test(line) || CLAUDE_COMMAND_RE.test(line),
   rules: [
     { id: "claude.permission", priority: 130, re: /requires approval|do you want to proceed\?|trust this folder/i, type: "stdout", summary: "許可を待っている" },
     { id: "claude.question", priority: 125, re: /enter to select|which .* do you (?:choose|prefer)/i, type: "stdout", summary: "質問への回答を待っている" },
     { id: "claude.completion", priority: 120, re: /(?:^|[.!?]\s+)(?:the )?(?:task|work) is complete\.?$/i, type: "done", summary: "作業が完了した" },
     { id: "claude.exit-error", priority: 115, re: /failed with exit code|command not found/i, type: "error", summary: "エラーが発生している" },
+    { id: "claude.command.file-list", priority: 110, re: CLAUDE_COMMAND_RE, match: (line) => CLAUDE_COMMAND_RE.test(line) && isFileListExecution(line), type: "search", summary: "ファイル一覧を検索している" },
+    { id: "claude.command.search", priority: 108, re: CLAUDE_COMMAND_RE, match: (line) => CLAUDE_COMMAND_RE.test(line) && isSearchExecution(line), type: "search", summary: "該当箇所を検索している" },
+    { id: "claude.command.test", priority: 106, re: CLAUDE_COMMAND_RE, match: (line) => CLAUDE_COMMAND_RE.test(line) && isTestExecution(line), type: "test", summary: "テスト/型チェックを実行している" },
     { id: "claude.read", priority: 100, re: /^[⏺•]\s*Read\(/, type: "read", summary: "ファイルを読み込んでいる" },
     { id: "claude.glob", priority: 95, re: /^[⏺•]\s*Glob\(/, type: "search", summary: "ファイル一覧を検索している" },
     { id: "claude.grep", priority: 92, re: /^[⏺•]\s*Grep\(/, type: "search", summary: "該当箇所を検索している" },
@@ -16,14 +25,17 @@ export const claudeRuleset: RuleSet = {
     { id: "claude.edit", priority: 85, re: /^[⏺•]\s*Edit\(/, type: "write", summary: "ファイルを編集している" },
     { id: "claude.write", priority: 80, re: /^[⏺•]\s*Write\(/, type: "write", summary: "ファイルを書き込んでいる" },
     { id: "claude.bash", priority: 70, re: /^[⏺•]\s*Bash\(/, type: "stdout", summary: "コマンドを実行している" },
+    { id: "claude.assistant", priority: 65, re: CLAUDE_ASSISTANT_RE, type: "stdout", summary: "Claudeが説明している" },
+    { id: "claude.summary", priority: 64, re: CLAUDE_SUMMARY_RE, type: "stdout", summary: "作業結果を要約している" },
 
-    { id: "claude.search", priority: 60, re: /\b(rg|grep)\b/i, type: "search", summary: "該当箇所を検索している" },
-    { id: "claude.test", priority: 50, re: /\b(playwright|vitest|jest|test|typecheck|tsc)\b/i, type: "test", summary: "テスト/型チェックを実行している" },
+    { id: "claude.search", priority: 60, re: /\b(rg|grep)\b/i, match: isSearchExecution, type: "search", summary: "該当箇所を検索している" },
+    { id: "claude.test", priority: 50, re: /\b(playwright|vitest|jest|test|typecheck|tsc)\b/i, match: isTestExecution, type: "test", summary: "テスト/型チェックを実行している" },
 
     { id: "claude.github", priority: 40, re: /\bgh\s+(issue|pr|repo)\b/i, type: "github", summary: "GitHub操作をしている" },
     { id: "claude.git", priority: 30, re: /\bgit\s+(status|add|commit|push|pull|checkout|switch|merge|rebase)\b/i, type: "git", summary: "Git操作をしている" },
 
     { id: "claude.install", priority: 20, re: /\b(pnpm|npm|yarn)\s+(add|install|i|run)\b/i, type: "install", summary: "依存関係/スクリプトを処理している" },
+    { id: "claude.command", priority: 15, re: CLAUDE_COMMAND_RE, type: "stdout", summary: "コマンドを実行している" },
 
     { id: "claude.readonly", priority: 12, re: /\bread[-\s]?only mode\b|\bwrite is disabled\b/i, type: "error", summary: "書き込みが制限されている" },
     { id: "claude.error", priority: 10, re: /execution error|error|failed|exception|TS\d{5}/i, type: "error", summary: "エラーが出ている" }

--- a/apps/server/src/rulesets/detect.ts
+++ b/apps/server/src/rulesets/detect.ts
@@ -1,4 +1,5 @@
 import type { RuleSetId } from "./types.js";
+import { ANSI_ESCAPE_RE } from "../terminal-escapes.js";
 
 type Scores = { claude: number; codex: number };
 
@@ -14,9 +15,15 @@ const MEDIUM_SCORE = 2;
 const WEAK_SCORE = 1;
 
 const CLAUDE_STRONG = [
-  /^(⏺|•)\s*(Read|Bash|Glob|Grep|Update|Write|Edit)\(/
+  /^(⏺|•)\s*(Read|Bash|Glob|Grep|Update|Write|Edit)\(/,
+  /^⎿\s*\$\s*\S/u,
 ];
-const CLAUDE_MEDIUM = [/AskUserQuestion/i, /read[-\s]?only/i, /⎿/];
+const CLAUDE_MEDIUM = [
+  /AskUserQuestion/i,
+  /read[-\s]?only/i,
+  /^⏺\s*(?!Read\(|Glob\(|Grep\(|Update\(|Edit\(|Write\(|Bash\()[\p{L}\p{N}]/u,
+  /^Listed \d+ director(?:y|ies), ran \d+ shell commands?$/iu,
+];
 
 const CODEX_STRONG = [
   /would you like to run the following command\?/i,
@@ -50,6 +57,14 @@ function scoreLine(line: string): Scores {
   }
 
   return { claude, codex };
+}
+
+function normalizeSignalLine(line: string): string {
+  return line
+    .replace(ANSI_ESCAPE_RE, " ")
+    .replace(/[\u0000-\u001f\u007f]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
 }
 
 function decide(scores: Scores, threshold: number): RuleSetId | null {
@@ -105,7 +120,7 @@ export function createAutoDetector(options: DetectorOptions = {}) {
 
 export function detectSourceFromText(text: string, options: DetectorOptions = {}): RuleSetId {
   const detector = createAutoDetector(options);
-  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const lines = text.split(/\r?\n/).map(normalizeSignalLine).filter(Boolean);
   for (const line of lines) {
     const decided = detector.update(line);
     if (decided) return decided;

--- a/apps/server/src/rulesets/detect.ts
+++ b/apps/server/src/rulesets/detect.ts
@@ -17,6 +17,7 @@ const WEAK_SCORE = 1;
 const CLAUDE_STRONG = [
   /^(⏺|•)\s*(Read|Bash|Glob|Grep|Update|Write|Edit)\(/,
   /^⎿\s*\$\s*\S/u,
+  /\bClaude Code\s*v\d+\.\d+\.\d+\b/iu,
 ];
 const CLAUDE_MEDIUM = [
   /AskUserQuestion/i,

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -6,6 +6,7 @@ import { createEscapeCarry } from "../terminal-escapes.js";
 import { commentByRules } from "../commentary/rule-based.js";
 import { applySpeechContract } from "../commentary/speech-policy.js";
 import { createSessionContext } from "../session-context.js";
+import { resetAutoDetection } from "../rulesets/index.js";
 
 const fixtureDir = path.resolve(process.cwd(), "test/fixtures/claude-tui");
 
@@ -28,15 +29,16 @@ function loadRenderingFixture(): {
   };
 }
 
-function loadRealSessionEvents() {
+function loadRealSessionEvents(source: "claude" | "auto" = "claude") {
   const fixture = JSON.parse(
     fs.readFileSync(path.join(fixtureDir, "real-session-2.1.220.json"), "utf8")
   ) as { raw: string };
   const carry = createEscapeCarry();
   const events = [];
+  if (source === "auto") resetAutoDetection();
 
   for (let index = 0; index < fixture.raw.length; index += 512) {
-    events.push(...extractEvents(carry(fixture.raw.slice(index, index + 512)), "claude"));
+    events.push(...extractEvents(carry(fixture.raw.slice(index, index + 512)), source));
   }
 
   return events;
@@ -142,5 +144,9 @@ describe("Claude TUI supervision detection", () => {
     const spoken = applySpeechContract(payload, event!, snapshot).speech?.text;
 
     expect(spoken).toBe("ファイル一覧を調べています。");
+  });
+
+  it("applies Claude filtering after auto detection", () => {
+    expect(loadRealSessionEvents("auto")).toEqual(loadRealSessionEvents("claude"));
   });
 });

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { extractEvents } from "../extract.js";
+import { createEscapeCarry } from "../terminal-escapes.js";
+import { commentByRules } from "../commentary/rule-based.js";
+import { applySpeechContract } from "../commentary/speech-policy.js";
+import { createSessionContext } from "../session-context.js";
 
 const fixtureDir = path.resolve(process.cwd(), "test/fixtures/claude-tui");
 
@@ -22,6 +26,20 @@ function loadRenderingFixture(): {
     noiseChunks: string[];
     meaningfulChunks: string[];
   };
+}
+
+function loadRealSessionEvents() {
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(fixtureDir, "real-session-2.1.220.json"), "utf8")
+  ) as { raw: string };
+  const carry = createEscapeCarry();
+  const events = [];
+
+  for (let index = 0; index < fixture.raw.length; index += 512) {
+    events.push(...extractEvents(carry(fixture.raw.slice(index, index + 512)), "claude"));
+  }
+
+  return events;
 }
 
 describe("Claude TUI supervision detection", () => {
@@ -75,19 +93,54 @@ describe("Claude TUI supervision detection", () => {
     }
   });
 
-  it("keeps meaningful Claude Code redraw content", () => {
+  it("keeps untrusted redraw content out of Claude commentary", () => {
     const { meaningfulChunks } = loadRenderingFixture();
 
     for (const chunk of meaningfulChunks) {
-      expect(extractEvents(chunk, "claude"), chunk).not.toEqual([]);
+      expect(extractEvents(chunk, "claude"), chunk).toEqual([]);
     }
   });
 
-  it("preserves a separator when normalizing tab-delimited output", () => {
-    expect(extractEvents("apps/server/src/extract.ts\t42", "claude")).toEqual([
-      expect.objectContaining({
-        detail: "apps/server/src/extract.ts 42",
-      }),
+  it("does not promote tab-delimited terminal output to commentary", () => {
+    expect(extractEvents("apps/server/src/extract.ts\t42", "claude")).toEqual([]);
+  });
+
+  it("keeps only trustworthy activity from the real Claude Code redraw", () => {
+    const events = loadRealSessionEvents();
+
+    expect(events.map(({ type, summary, detail }) => ({ type, summary, detail }))).toEqual([
+      {
+        type: "search",
+        summary: "ファイル一覧を検索している",
+        detail: "⎿  $ ls -1 /Users/demo/project/docs",
+      },
+      {
+        type: "stdout",
+        summary: "作業結果を要約している",
+        detail: "Listed 3 directories, ran 1 shell command",
+      },
+      {
+        type: "stdout",
+        summary: "作業結果を要約している",
+        detail: "Listed 3 directories, ran 1 shell command",
+      },
+      {
+        type: "stdout",
+        summary: "Claudeが説明している",
+        detail: "⏺docs/の中身は以下の通りです。",
+      },
     ]);
+  });
+
+  it("narrates the real ls command as a file-list search", () => {
+    const event = loadRealSessionEvents().find(({ type }) => type === "search");
+    expect(event).toBeDefined();
+
+    const context = createSessionContext();
+    const snapshot = context.observeEvent(event!);
+    const payload = commentByRules(event!, "standard", snapshot);
+    const spoken = applySpeechContract(payload, event!, snapshot).speech?.text;
+
+    expect(spoken).toBe("ファイル一覧を調べています。");
   });
 });


### PR DESCRIPTION
🧑 HUMAN向け（先に読む）
・やったこと: Claude Codeの実際の表示から、壊れていない情報だけを実況に使うようにしました。
・なぜ必要か: 同じ汎用メッセージの反復を減らし、実行した内容を具体的に伝えるためです。
・あなたの操作: 残った4イベントの内訳を確認し、問題なければこのPRをマージしてください。

## Summary

実Claude Code v2.1.220の出力形式を認識し、`⎿ $ <command>`、AI回答本文、作業要約だけを実況イベントとして採用します。再描画で壊れた未分類stdoutはターミナルペインには残したまま、実況・読み上げから除外します。

実データの512バイト刻み再生では、明示 `claude` と `auto` のどちらもイベントが78件から4件へ、汎用実況「作業の状態が変わりました。」が60件から2件へ減りました。残った4件は、コマンド1件、作業要約2件、AI回答本文1件です。

`⎿ $ ls -1 /Users/demo/project/docs` は「ファイル一覧を調べています。」と読み上げられます。auto判定も同じ実キャプチャを `claude` と判定します。

作業要約2件は、Claude TUIが同じ `Listed 3 directories, ran 1 shell command` 行を再描画するための既知の重複です。既存の読み上げ側の間引きに任せ、このPRでは抽出時の状態保持や重複排除を追加していません。

`ls` は共有の `isFileListExecution` に意図的に追加しています。そのためClaudeだけでなくCodex/generic経路でも、実行コマンドとして観測された `ls` はファイル一覧の調査として扱われます。

ドキュメント更新は不要です。環境変数や設定、公開仕様は変更せず、Issue #381とhandoffで定義済みの抽出挙動だけを実装しています。

## Related Issues

Closes #381

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

### General
- [x] Tests pass locally (`pnpm -C apps/server test`)
- [x] No new TypeScript errors
- [x] Code follows existing patterns in the codebase

### LLM / Comment Changes
- [x] No LLM provider or timeout path changed
- [x] Logs do NOT contain PII
- [x] Error and HUMAN-wait supervision paths remain covered

### Documentation
- [x] CLAUDE.md update not required; no env or config change
- [x] ROADMAP/LLM_ADAPTER freshness reviewed; no update required
- [x] Inline comments remain limited to non-obvious parsing behavior

### Desktop / Tauri
- [x] Desktop packaging is outside this server-only change

### Reviewer Focus
- [x] Confirm the retained event mix is useful: command 1, summary 2, AI answer 1
- [x] Confirm unclassified redraw fragments remain visible only as raw terminal output

## Test Plan

- clean server Vitest: 45 files / 640 tests passed (main baseline: 45 / 630; 10 tests added)
- web Vitest: 11 files / 102 tests passed
- server and web TypeScript checks passed
- server and web builds passed
- web lint and doc-sync passed
- `pnpm eval:phase-b`: Snapshot MATCH

The earlier 54 / 835 baseline included 9 generated `dist/**/*.test.js` files and 205 compiled tests a second time. The clean baseline is 45 / 630. This independent Vitest discovery issue is intentionally not changed here.

---
Generated with Codex
