### PR TITLE
docs: add 2026-08-02b handoff (Codex output capture)

### DIFF
--- a/handoff/status-2026-08-02b.md
+++ b/handoff/status-2026-08-02b.md
@@ -1,0 +1,105 @@
+# handoff 2026-08-02b — cli-commentator / Codex実出力の採取（#382マージ後）
+
+## 1. HUMAN判断待ち（最初に読む）
+
+- **判断事項1**：Codex実出力の採取（Issue #383）をCodexに実行させてよいか
+  - 推奨：**実行させてよい**。第1段階を採取・計測のみに限定し、ruleset修正は実データを見てから第2段階で行う分割にしてある
+  - 選択肢：A. Codexが実行（推奨） / B. KUROが実行 / C. Claudeの実機評価を先に行う
+  - 期限・緊急度：DeepSeek実況AIの実機評価前 / 緊急度中
+  - 判断しない場合の影響：Codexセッションが実況されない状態が続き、DeepSeek実況AIの評価にも使えない
+- **判断事項2**：Claude Code側の「静かすぎるか」の実機評価をいつ行うか
+  - 推奨：**Codex対応後**。Claude利用枠を消費するため、Codexで評価環境が整ってからのほうが安い
+  - 選択肢：A. Codex対応後（推奨） / B. 先に実施
+  - 期限・緊急度：Codex対応完了後 / 緊急度低
+  - 判断しない場合の影響：#382の成果（静かすぎないか）が未確定のまま残る
+
+## 2. 現在地
+
+- main：`cb1538e`（PR #382）。Claude Code実出力対応まで完了
+- clean tests：**45ファイル / 640 passed**（`dist`を消してから測ること。§4参照）
+- サイドカー：最新mainで再生成済み、実行ビット6件復元、PTY起動OK
+- OPEN Issue：#383（本作業）、#346、#292、#138
+- **作業ツリー注意**：`repos/cli-commentator` は `feat/deepseek-commentary` に切り替わっており、DeepSeek実況AIの変更が未コミットで存在する（14ファイル、+99/−16）。ブランチを切り替えないこと
+
+## 3. 今回やったこと
+
+- PR #382 をレビューし、`auto`モードでclaude固有フィルタが一切効かない不具合を検出（141イベント）。Codexが `resolvedSourceId()` で解決後IDを一元化し、起動バナーをstrongシグナルに追加して141→4へ修正。HUMANがmerge
+- 最新mainでサイドカーを再生成し、PTY起動を確認
+- マージ後のmainで実際の読み上げを計測（§4）
+- HUMANがCodexで実機テストを実施し、「Codexは動いているが実況されない」を確認
+- Codex実出力を採取して原因を特定（§4）
+
+## 4. 重要な発見・リスク
+
+### Claude Code側：静かすぎる可能性
+
+マージ後のmainで実データ（45秒セッション）の読み上げを計測：
+
+```
+ 9.6s  ファイル一覧を調べています。
+25.7s  (無音: progress_interval)
+38.6s  (無音: progress_interval)
+38.6s  (無音: progress_interval)
+```
+
+ゴミの音読も汎用文の反復も解消され、話した1回は `⎿ $ ls -1` 由来の正しい実況。**ただし45秒で発話1回**。
+
+無音になった3件は「作業要約×2」と「**AIの回答本文**」。特に後者は監督者が最も知りたい「AIが答えを出した瞬間」で、`progress`優先度のため間引きで消えている。`event-priority.ts` で `notice` になるのは `done` 型と「長考・沈黙」だけ。**この2つを `notice` 相当に上げるべきか**が次の論点。実機聴取で判断する。
+
+また解説側が「手がかりを探して調査範囲を絞っています。」と汎用文に落ちている。`beginner-lines` の検索パターンが `rg`/`grep` 前提で `ls` を拾えていないため。軽微。
+
+### Codex側：ruleset が別の面を見ている
+
+実際の Codex v0.146.0 をPTYで起動して計測：
+
+| codex ruleset が依存するパターン | 実出力での出現数 |
+|---|---|
+| `⏺/• Read(` `Glob(` `Grep(` `Update(` `Write(` | **0** |
+| `ToolCall: exec` | **0** |
+| `apply_patch` | **0** |
+| `would you like to run` | **0** |
+| `codex_core::` | **0** |
+| `Question N/N` | **0** |
+
+実際に出ているのは箱枠TUI（`╭─╮ │ >_ OpenAI Codex (v0.146.0) │ ...`）。
+
+既存フィクスチャ `phase-b-codex-session.json` の中身は `codex_core::stream_events_utils: ToolCall: exec ...` で、これは Codex の**ログ面（Rust tracing）**。アプリが捕捉しているのは**TUI面**。別々の面を見ているため噛み合わない。
+
+Claude Codeは「同じ面だが形式が変わった」、Codexは「そもそも別の面」という違いはあるが、**どちらも実データで検証されていなかった**という根は同じ。
+
+**未証明の部分**：KUROのキャプチャは利用制限に当たり起動バナー10行で止まった。「ツール実行中に何が出るか」は未取得。稼働中セッションへの接続も応答が返らず547バイトのエコーのみ。これを埋めるのがIssue #383。
+
+### テスト数の測り方
+
+`apps/server` には vitest 設定ファイルが無く、`pnpm build:server` が生成した `dist/**/*.test.js` を二重実行する。
+
+```
+dist あり : 54 files / 850 tests   ← 誤り
+dist 削除 : 45 files / 640 tests   ← 実数
+```
+
+計測前に必ず `rm -rf apps/server/dist`。この二重実行自体は別件の不具合で、`vitest.config.ts` に `exclude: ["dist/**"]` を足せば解決する。未起票。
+
+## 5. 次の一手（AI別）
+
+- **HUMAN**：判断事項1・2を決める。Issue #383 をCodexへ割り当てる
+- **Gino（Codex）**：Issue #383 の第1段階（採取・サニタイズ・フィクスチャ化・基準線計測）を実行する
+- **KURO**：採取結果を確認し、第2段階（codex ruleset修正）の設計と指示書を作る
+- **JEM**：今回は依頼なし
+
+## 6. 作業指示書
+
+Issue #383 に全文を記載した。要点のみ再掲する。
+
+- **第1段階は採取のみ**。ruleset を修正しない（実データを見てから設計する）
+- **必ず `git worktree add` で別ディレクトリを作る**。`repos/cli-commentator` はDeepSeekの未コミット変更を抱えているのでブランチを切り替えない
+- DeepSeek実況AIの変更を混ぜない。別ブランチ・別PR
+- サニタイズはClaude版 `claude-tui/real-session-2.1.220.json` と同じ方針。エスケープは生のまま保存する
+- 計測前に `rm -rf apps/server/dist`
+
+## 7. 参照リンク
+
+- Issue #383: https://github.com/gatyoukatyou/cli-commentator/issues/383
+- PR #382: https://github.com/gatyoukatyou/cli-commentator/pull/382
+- 前回handoff: `handoff/status-2026-08-02.md`
+- Claude版フィクスチャ: `apps/server/test/fixtures/claude-tui/real-session-2.1.220.json`


### PR DESCRIPTION
#382 マージ後の節目 handoff。Codex 実出力採取（Issue #383）への引き継ぎ。

## Codex 側の発見

**codex ruleset が依存する6パターンは、実際の Codex v0.146.0 の出力に0件。**

| パターン | 出現数 |
|---|---|
| `⏺/• Read(` `Glob(` `Grep(` `Update(` `Write(` | 0 |
| `ToolCall: exec` | 0 |
| `apply_patch` | 0 |
| `would you like to run` | 0 |
| `codex_core::` | 0 |
| `Question N/N` | 0 |

既存フィクスチャ `phase-b-codex-session.json` は `codex_core::stream_events_utils: ToolCall: exec ...` という **Codex のログ面（Rust tracing）**。アプリが捕捉しているのは **TUI面**。別々の面を見ているため噛み合わない。

Claude Code は「同じ面だが形式が変わった」、Codex は「そもそも別の面」。根はどちらも**実データで検証されていなかった**こと。

**未証明**：KUROのキャプチャは利用制限で起動バナー10行で止まり、「ツール実行中に何が出るか」は未取得。それを埋めるのが Issue #383。

## Claude Code 側の計測

マージ後の main で実データの読み上げを測った結果、**45秒で発話1回**。

```
 9.6s  ファイル一覧を調べています。
25.7s  (無音: progress_interval)
38.6s  (無音: progress_interval)
38.6s  (無音: progress_interval)
```

ノイズと汎用文の反復は解消されたが、無音になった3件が「作業要約×2」と「**AIの回答本文**」。後者は監督者が最も知りたい瞬間で、`progress` 優先度のため間引きで消えている。`notice` 相当へ上げるべきかは実機聴取で判断する。

## テスト数の測り方

`apps/server` に vitest 設定が無く、`pnpm build:server` の生成物 `dist/**/*.test.js` を二重実行する。

```
dist あり : 54 files / 850 tests   ← 誤り
dist 削除 : 45 files / 640 tests   ← 実数
```

計測前に `rm -rf apps/server/dist`。二重実行自体は別件の不具合（未起票）。

## 作業ツリー注意

`repos/cli-commentator` は `feat/deepseek-commentary` に切り替わっており、**DeepSeek実況AIの変更が未コミットで存在する**（14ファイル、+99/−16）。Codex は `git worktree add` で別ディレクトリを作って作業すること。本PRもそのようにした。

## 検証

- `node ./scripts/check-doc-sync.mjs` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)