### PR TITLE
feat(codex): drive commentary from real TUI output

### DIFF
--- a/apps/server/src/__tests__/detect.test.ts
+++ b/apps/server/src/__tests__/detect.test.ts
@@ -73,6 +73,13 @@ describe("ruleset auto detect", () => {
     expect(detectSourceFromText(fixture.raw)).toBe("claude");
   });
 
+  it("detects the sanitized real Codex TUI capture", async () => {
+    const filePath = path.join(fixturesDir, "codex-tui/real-session-0.146.0.json");
+    const fixture = JSON.parse(await fs.readFile(filePath, "utf8")) as { raw: string };
+
+    expect(detectSourceFromText(fixture.raw)).toBe("codex");
+  });
+
   it("detects Claude from its startup banner before the first tool result", () => {
     const detector = createAutoDetector();
 

--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -72,6 +72,43 @@ describe("extractEvents fixtures", () => {
     expect(events).toEqual([]);
   });
 
+  it("extracts a real Codex TUI command card", () => {
+    const events = extractEvents(
+      "• Ran find docs -maxdepth 1 -type f -print | sort\n└ docs/README.md",
+      "codex"
+    );
+
+    expect(events).toMatchObject([
+      {
+        type: "search",
+        summary: "ファイル一覧を検索している",
+        detail: "⏺ Glob(find docs -maxdepth 1 -type f -print)",
+      },
+    ]);
+  });
+
+  it("keeps a substantive Codex TUI assistant update", () => {
+    expect(
+      extractEvents("• リポジトリの安全確認を先に行い、指定されたコマンドを実行します。", "codex")
+    ).toMatchObject([
+      {
+        type: "stdout",
+        summary: "Codexが説明している",
+      },
+    ]);
+  });
+
+  it("redacts secrets from a Codex TUI command card", () => {
+    const events = extractEvents(
+      "• Ran curl --token secret-value https://example.invalid\n└ ok",
+      "codex"
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toContain("--token=[REDACTED]");
+    expect(events[0]?.detail).not.toContain("secret-value");
+  });
+
   it("uses the runtime source override for Codex noise suppression", () => {
     delete process.env.LOG_SOURCE;
     const events = extractEvents("10;?\n•2", "codex");

--- a/apps/server/src/command-analysis.ts
+++ b/apps/server/src/command-analysis.ts
@@ -162,12 +162,18 @@ export function isSearchExecution(command: string): boolean {
 }
 
 export function isFileListExecution(command: string): boolean {
-  return commandInvocations(unwrapCommandDetail(command)).some(({ segment, start, executable }) =>
-    executable === "find" ||
-    executable === "fd" ||
-    executable === "ls" ||
-    (executable === "rg" && segment.slice(start + 1).includes("--files"))
+  return extractFileListCommand(command) !== null;
+}
+
+export function extractFileListCommand(command: string): string | null {
+  const invocation = commandInvocations(unwrapCommandDetail(command)).find(
+    ({ segment, start, executable }) =>
+      executable === "find" ||
+      executable === "fd" ||
+      executable === "ls" ||
+      (executable === "rg" && segment.slice(start + 1).includes("--files"))
   );
+  return invocation?.segment.join(" ") ?? null;
 }
 
 const SEARCH_VALUE_OPTIONS = new Set([

--- a/apps/server/src/commentary/narration-subject.ts
+++ b/apps/server/src/commentary/narration-subject.ts
@@ -139,11 +139,11 @@ export function describeNarrationSubject(ev: Event): NarrationSubject {
       return fileSubject(extractWriteTarget(detail));
     case "search": {
       const command = detailCommand(detail);
+      if (isFileListExecution(command)) return { kind: "fileList" };
       const term = extractSearchPattern(detail);
       if (term && SAFE_TERM_RE.test(term)) {
         return { kind: "searchTerm", term: clip(term, MAX_SEARCH_TERM_LENGTH) };
       }
-      if (isFileListExecution(command)) return { kind: "fileList" };
       return NONE;
     }
     case "test": {

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -128,6 +128,24 @@ function contextExplanation(
   return beginner || undefined;
 }
 
+function codexTuiNarration(ev: Event, style: Style): string {
+  if (ev.summary === "Codexが説明している") {
+    return say(style, {
+      standard: "Codexが作業内容を説明しています。",
+      kansai: "Codexが作業内容を説明してるで。",
+      zundamon: "Codexが作業内容を説明してるのだ。",
+    });
+  }
+  if (ev.summary === "Codexが回答した") {
+    return say(style, {
+      standard: "Codexが回答しました。",
+      kansai: "Codexが回答したで。",
+      zundamon: "Codexが回答したのだ。",
+    });
+  }
+  return "";
+}
+
 export function commentByRules(
   ev: Event,
   style: Style,
@@ -146,10 +164,11 @@ export function commentByRules(
   // Japanese regardless of the selected entertainment/narration style.
   const beginner = beginnerOneLine(ev);
   const glossaryNotes = context ? [...context.glossaryNotes] : getGlossaryNotes(ev.detail, ev.type);
-  const spotlight = detailSpotlight(ev, style);
+  const codexNarration = codexTuiNarration(ev, style);
+  const spotlight = codexNarration ? "" : detailSpotlight(ev, style);
 
   const subject = describeNarrationSubject(ev);
-  const core = COMMENTERS[style](ev, subject);
+  const core = codexNarration || COMMENTERS[style](ev, subject);
   const contextual = context ? contextNarration(context, style) : "";
   // The context line spells out the full path, which overruns the progress
   // speech budget and gets replaced by a generic fallback — losing the target

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -1,8 +1,8 @@
 import type { Event } from "./types.js";
 import { getAutoDetectedSource, rulesForLine } from "./rulesets/index.js";
-import { isClaudeTuiNoise, isCodexProgressNoise, isTerminalRenderingNoise } from "./progress-noise.js";
+import { isClaudeTuiNoise, isCodexProgressNoise, isCodexTuiAssistantLine, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
-import { isFileListExecution, isSearchExecution } from "./command-analysis.js";
+import { extractFileListCommand, isFileListExecution, isSearchExecution } from "./command-analysis.js";
 import { ANSI_ESCAPE_RE } from "./terminal-escapes.js";
 
 // Legacy X10 mouse reports include three coordinate bytes after CSI M. Strip
@@ -303,34 +303,124 @@ function safeCommandPreview(cmd: string): string {
   const redacted = compact
     .replace(/\b([A-Za-z_][A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Za-z0-9_]*)=([^\s]+)/gi, "$1=[REDACTED]")
     .replace(/(--?(?:token|secret|password|api[-_]?key))(?:=|\s+)('[^']*'|\"[^\"]*\"|[^\s]+)/gi, "$1=[REDACTED]");
-  return redacted.length <= 240 ? redacted : `${redacted.slice(0, 237)}...`;
+  if (redacted.length <= 240) return redacted;
+  return `${redacted.slice(0, 237)}...`;
 }
 
 function classifyExecCommands(commands: string[]): string | null {
   if (commands.length === 0) return null;
-  const visible = commands.slice(0, 2).map(safeCommandPreview);
+  const visible = commands.slice(0, 2).map((command) => safeCommandPreview(command));
   const omitted = commands.length - visible.length;
   const combined = visible.join(" ; ") + (omitted > 0 ? ` ... (+${omitted} commands)` : "");
   return classifyExecCommand(combined);
 }
 
-function classifyExecCommand(cmd: string): string {
+function classifyExecCommand(cmd: string, displayCmd = cmd): string {
   const compact = cmd.trim();
   if (!compact) return "⏺ Bash(exec_command)";
+  const display = displayCmd.trim();
 
   if (isFileListExecution(compact)) {
-    return `⏺ Glob(${compact})`;
+    return `⏺ Glob(${display})`;
   }
 
   if (isSearchExecution(compact)) {
-    return `⏺ Grep(${compact})`;
+    return `⏺ Grep(${display})`;
   }
 
   if (/^\s*(cat|sed|head|tail|less|more|nl)\b/i.test(compact)) {
-    return `⏺ Read(${compact})`;
+    return `⏺ Read(${display})`;
   }
 
-  return `⏺ Bash(${compact})`;
+  return `⏺ Bash(${display})`;
+}
+
+const CODEX_TUI_BUFFER_LIMIT = 8_192;
+let codexTuiBuffer = "";
+let lastCodexTuiCommand = "";
+let lastCodexTuiAssistant = "";
+let lastCodexTuiAnswer = "";
+
+export function resetExtractionState(): void {
+  codexTuiBuffer = "";
+  lastCodexTuiCommand = "";
+  lastCodexTuiAssistant = "";
+  lastCodexTuiAnswer = "";
+}
+
+function normalizeTuiStream(chunk: string): string {
+  return chunk
+    .replace(LEGACY_MOUSE_REPORT_RE, "")
+    .replace(CHARSET_DESIGNATION_RE, "")
+    .replace(ANSI_ESCAPE_RE, "")
+    .replace(/\r/g, "")
+    .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, "");
+}
+
+function eventForCanonicalLine(line: string, ts: number): Event | null {
+  const hit = rulesForLine(line, "codex")
+    .find((rule) => rule.match ? rule.match(line) : rule.re.test(line));
+  return hit ? { ts, type: hit.type, summary: hit.summary, detail: line } : null;
+}
+
+function extractCodexTuiEvents(chunk: string, ts: number): Event[] {
+  const separator = codexTuiBuffer ? "\n" : "";
+  codexTuiBuffer = `${codexTuiBuffer}${separator}${normalizeTuiStream(chunk)}`
+    .slice(-CODEX_TUI_BUFFER_LIMIT);
+
+  const events: Event[] = [];
+  const commandCard = /(?:^|\n)\s*•\s+Ran\s+([\s\S]*?)\n\s*└\s*/gu;
+  let consumedThrough = 0;
+
+  for (const match of codexTuiBuffer.matchAll(commandCard)) {
+    consumedThrough = (match.index ?? 0) + match[0].length;
+    const command = match[1]
+      .split("\n")
+      .map((line) => line.replace(/^\s*│\s?/u, "").trim())
+      .filter(Boolean)
+      .join(" ")
+      .replace(/\s+/gu, " ")
+      .trim();
+    if (!command || command === lastCodexTuiCommand) continue;
+
+    const displayCommand = extractFileListCommand(command) ?? command;
+    const canonical = classifyExecCommand(command, safeCommandPreview(displayCommand));
+    const event = eventForCanonicalLine(canonical, ts);
+    if (event) events.push(event);
+    lastCodexTuiCommand = command;
+  }
+
+  const responseBlock = /(?:^|\n)\s*─{40,}\s*\n([\s\S]*?)\n\s*─{40,}(?=\n|$)/gu;
+  for (const match of codexTuiBuffer.matchAll(responseBlock)) {
+    consumedThrough = Math.max(consumedThrough, (match.index ?? 0) + match[0].length);
+    if (/•\s+Ran\b/u.test(match[1])) continue;
+
+    const answer = match[1]
+      .split("\n")
+      .map((line) => line.trim().replace(/^•\s*/u, ""))
+      .map((line) => line.replace(/›Write tests for @filename.*$/iu, "").trim())
+      .filter((line) => line.length >= 8)
+      .filter((line) => !/^(?:[A-Za-z]:[\\/]|[/~])\S+$/u.test(line))
+      .filter((line) => !/gpt-[\w.-]+\s+(?:high|medium|low)\b/iu.test(line))
+      .join(" ")
+      .replace(/\s+/gu, " ")
+      .trim();
+    if (!answer || answer === lastCodexTuiAnswer) continue;
+
+    events.push({
+      ts,
+      type: "stdout",
+      summary: "Codexが回答した",
+      detail: answer,
+      priority: "notice",
+    });
+    lastCodexTuiAnswer = answer;
+  }
+
+  if (consumedThrough > 0) {
+    codexTuiBuffer = codexTuiBuffer.slice(consumedThrough);
+  }
+  return events;
 }
 
 function canonicalizeCodexToolCall(rawLine: string): string | null {
@@ -439,6 +529,12 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
     return normalized;
   }
 
+  if (source === "codex" && isCodexTuiAssistantLine(normalized)) {
+    if (normalized === lastCodexTuiAssistant) return null;
+    lastCodexTuiAssistant = normalized;
+    return normalized;
+  }
+
   if (/^>\s/.test(normalized) || /\bapply_patch\b|ELIFECYCLE|exit code|error|failed|exception|TS\d{4,5}/i.test(normalized)) {
     return normalized;
   }
@@ -453,13 +549,24 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
 export function extractEvents(chunk: string, sourceEnv: string | undefined = process.env.LOG_SOURCE): Event[] {
   const ts = Date.now();
 
+  const rawLines = chunk.split(/\r?\n/);
+  if ((sourceEnv ?? "auto").trim().toLowerCase() === "auto" && !getAutoDetectedSource()) {
+    for (const rawLine of rawLines) {
+      const sourceLine = normalizeLine(rawLine);
+      if (!sourceLine) continue;
+      rulesForLine(sourceLine, sourceEnv);
+      if (getAutoDetectedSource()) break;
+    }
+  }
+
   if (resolvedSourceId(sourceEnv) === "claude") {
     const supervisionEvents = extractClaudeSupervisionEvents(chunk, ts);
     if (supervisionEvents.length > 0) return supervisionEvents;
   }
 
-  const rawLines = chunk.split(/\r?\n/);
-  const events: Event[] = [];
+  const events: Event[] = resolvedSourceId(sourceEnv) === "codex"
+    ? extractCodexTuiEvents(chunk, ts)
+    : [];
   for (let index = 0; index < rawLines.length; index += 1) {
     const rawLine = rawLines[index];
     const sourceLine = normalizeLine(rawLine);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,7 +15,7 @@ import type {
   WsOutgoing,
 } from "./types.js";
 import { redact } from "./redact.js";
-import { extractEvents } from "./extract.js";
+import { extractEvents, resetExtractionState } from "./extract.js";
 import { createEscapeCarry } from "./terminal-escapes.js";
 import { comment } from "./styles/index.js";
 import { getAutoDetectedSource, resetAutoDetection } from "./rulesets/index.js";
@@ -458,6 +458,7 @@ function setupPTY(
     acceptsHumanInput: /(?:^|[/\\])(?:codex|claude)(?:$|\s)/i.test(config.cmd),
   });
   commentaryGate.reset();
+  resetExtractionState();
   const term = ptyManager.spawn(config);
   silenceTimer.start();
   transitionServerState("setup_pty_success", "pty_running", {
@@ -901,6 +902,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName
   console.log(`Starting file tail mode: ${filePath}`);
   sessionContext.reset({ presetName: options?.presetName });
   commentaryGate.reset();
+  resetExtractionState();
 
   // Reset auto-detection
   if (sourceState.mode === "auto") {

--- a/apps/server/src/progress-noise.ts
+++ b/apps/server/src/progress-noise.ts
@@ -67,3 +67,19 @@ export function isCodexProgressNoise(text: string): boolean {
     /^[.•·]\d+$/i.test(text)
   );
 }
+
+export function isCodexTuiAssistantLine(text: string): boolean {
+  const match = text.match(/^•\s+(.+)$/u);
+  if (!match) return false;
+
+  const message = match[1].trim();
+  if (
+    /^(?:Ran|Working|Booting MCP|Starting MCP|MCP servers?|Usage status)\b/iu.test(message) ||
+    /esc to interrupt|Write tests for @filename/iu.test(message)
+  ) {
+    return false;
+  }
+
+  const meaningful = message.match(/[\p{L}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/gu) ?? [];
+  return meaningful.length >= 8;
+}

--- a/apps/server/src/rulesets/codex.ts
+++ b/apps/server/src/rulesets/codex.ts
@@ -1,5 +1,6 @@
 import type { RuleSet } from "./types.js";
 import { isSearchExecution, isTestExecution } from "../command-analysis.js";
+import { isCodexTuiAssistantLine } from "../progress-noise.js";
 
 export const codexRuleset: RuleSet = {
   id: "codex",
@@ -12,6 +13,7 @@ export const codexRuleset: RuleSet = {
     { id: "codex.update", priority: 90, re: /^[⏺•]\s*Update\(/, type: "write", summary: "ファイルを更新している" },
     { id: "codex.write", priority: 80, re: /^[⏺•]\s*Write\(/, type: "write", summary: "ファイルを書き込んでいる" },
     { id: "codex.patch", priority: 75, re: /\bapply_patch\b|apply patch/i, type: "write", summary: "パッチを適用している" },
+    { id: "codex.tui.assistant", priority: 70, re: /^•\s+\S/u, match: isCodexTuiAssistantLine, type: "stdout", summary: "Codexが説明している" },
     // Codex CLI v0.145.0 redraws this as "Questions 1/1 answered" after submission,
     // but requiring a positive count also prevents completed counters from becoming urgent.
     { id: "codex.question", priority: 66, re: /^Question \d+\/\d+ \((?:[1-9]\d*) unanswered\)$/i, type: "stdout", summary: "質問への回答を待っている" },

--- a/apps/server/src/rulesets/detect.ts
+++ b/apps/server/src/rulesets/detect.ts
@@ -27,6 +27,7 @@ const CLAUDE_MEDIUM = [
 ];
 
 const CODEX_STRONG = [
+  /\bOpenAI\s+Codex\s*\(v\d+\.\d+\.\d+\)/i,
   /would you like to run the following command\?/i,
   /you approved .* to run/i,
   /^(apply_patch|apply patch|\*\*\* Begin Patch\b)/i,

--- a/apps/server/src/tests/codex.real-fixture.test.ts
+++ b/apps/server/src/tests/codex.real-fixture.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { commentByRules } from "../commentary/rule-based.js";
+import { applySpeechContract } from "../commentary/speech-policy.js";
+import { extractEvents, resetExtractionState } from "../extract.js";
+import { getAutoDetectedSource, resetAutoDetection } from "../rulesets/index.js";
+import { createSessionContext } from "../session-context.js";
 import { createEscapeCarry, stripTerminalEscapes } from "../terminal-escapes.js";
 
 type CodexTuiFixture = {
@@ -30,6 +35,25 @@ function visibleText(raw: string): string {
   return text;
 }
 
+function extractRealEvents(source: "codex" | "auto") {
+  const fixture = loadFixture();
+  resetAutoDetection();
+  resetExtractionState();
+  const carry = createEscapeCarry();
+  const events = [];
+
+  for (let offset = 0; offset < fixture.raw.length; offset += 512) {
+    events.push(
+      ...extractEvents(carry(fixture.raw.slice(offset, offset + 512)), source)
+    );
+  }
+
+  return {
+    detected: getAutoDetectedSource(),
+    events,
+  };
+}
+
 describe("real Codex TUI fixture", () => {
   it("contains a real command execution, output, and final response", () => {
     const fixture = loadFixture();
@@ -54,5 +78,57 @@ describe("real Codex TUI fixture", () => {
     expect(fixture.raw).not.toContain("gatyoukatyou");
     expect(fixture.raw).not.toMatch(/usage limit resets? available/i);
     expect(fixture.raw).toContain("/Users/demo/project");
+  });
+
+  it("extracts only the substantive assistant update, command card, and final answer", () => {
+    const explicit = extractRealEvents("codex");
+    const automatic = extractRealEvents("auto");
+    const explicitEvents = explicit.events.map(({ type, summary, detail }) => ({
+      type,
+      summary,
+      detail,
+    }));
+    const automaticEvents = automatic.events.map(({ type, summary, detail }) => ({
+      type,
+      summary,
+      detail,
+    }));
+
+    expect(explicitEvents).toEqual([
+      {
+        type: "stdout",
+        summary: "Codexが説明している",
+        detail: "• リポジトリの安全確認を先に行い、指定された2コマンドを実行します。ファイル変更はしません。",
+      },
+      {
+        type: "search",
+        summary: "ファイル一覧を検索している",
+        detail: expect.stringContaining("find docs -maxdepth 1 -type f -print"),
+      },
+      {
+        type: "stdout",
+        summary: "Codexが回答した",
+        detail: expect.stringContaining("Both commands succeeded"),
+      },
+    ]);
+    expect(automatic.detected).toBe("codex");
+    expect(automaticEvents).toEqual(explicitEvents);
+    expect(explicit.events.at(-1)?.priority).toBe("notice");
+  });
+
+  it("narrates the substantive Codex events without generic fallbacks", () => {
+    const events = extractRealEvents("codex").events;
+    const context = createSessionContext();
+    const spoken = events.map((event) => {
+      const snapshot = context.observeEvent(event);
+      const payload = commentByRules(event, "standard", snapshot);
+      return applySpeechContract(payload, event, snapshot).speech?.text;
+    });
+
+    expect(spoken).toEqual([
+      "Codexが作業内容を説明しています。",
+      "ファイル一覧を調べています。",
+      "Codexが回答しました。",
+    ]);
   });
 });


### PR DESCRIPTION
🧑 HUMAN向け（先に読む）
・やったこと: Codexの実際の画面から、作業説明・コマンド実行・回答完了を読み上げられるようにしました。
・なぜ必要か: 従来はCodexを選ぶと無音になり、autoでは大量の画面描画を誤って実況していたためです。
・あなたの操作: 3つの発話内容を確認し、問題なければPRをMergeしてください。

## 結果

#385で追加したCodex CLI v0.146.0の実PTYフィクスチャを基準に、TUI面の抽出とauto判定を実装しました。旧ログ面の抽出処理は維持しています。

### 実測

修正前:

- `LOG_SOURCE=codex`: 0 events
- `LOG_SOURCE=auto`: 124 events、detected=`generic`

修正後:

- `LOG_SOURCE=codex`: 3 events
- `LOG_SOURCE=auto`: 3 events、detected=`codex`
- 両モードの内容は完全一致

実際の読み上げ:

1. 「Codexが作業内容を説明しています。」
2. 「ファイル一覧を調べています。」
3. 「Codexが回答しました。」

## 変更点

- `OpenAI Codex (vX.Y.Z)` 起動バナーをauto判定の強い手がかりとして追加
- チャンク境界をまたぐ `• Ran / │ / └` の複数行コマンドカードを復元
- ツールカードを既存の検索・読込・テスト・Git等の分類へ接続
- 回答ブロックを抽出し、間引かれない `notice` として通知
- TUI描画ノイズと入力欄の定型文を抑制
- コマンドの秘密値をマスクし、表示長を制限
- セッション開始時にTUI抽出状態をリセット
- 実フィクスチャで `codex` / `auto` の一致と音声を回帰テスト化

## 原因

既存Codex rulesetはRust tracingの「ログ面」を想定していましたが、アプリが捕捉するCodex v0.146.0は箱枠の「TUI面」でした。既存パターンが実出力に存在しないため、明示指定では有用イベントが0件、autoではCodexと判定できず描画ノイズが残っていました。

## 検証

- server: 46 files / 648 tests passed（`apps/server/dist` 除去後）
- web: 11 files / 102 tests passed
- server TypeScript: PASS
- server / web build: PASS
- Phase B snapshot: MATCH
- doc-sync: PASS
- `git diff --check`: PASS

## 確認してほしいこと

- 3発話の量と表現が監督用途として適切か
- 最終回答を `notice` として必ず通知する設計でよいか
- 旧Codexログ形式の回帰がないこと

Related: #383, #385