### PR TITLE
feat(llm): add DeepSeek provider

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -27,6 +27,10 @@ LOG_SOURCE=auto
 # LLM settings
 # LLM_PROVIDER=disabled
 # MOCK_LLM_MODE=
+# DeepSeek V4 Flash (when LLM_PROVIDER=deepseek)
+# DEEPSEEK_API_KEY=
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+# DEEPSEEK_MODEL=deepseek-v4-flash
 
 # Timeout settings (ms)
 # COMMENT_TIMEOUT_MS=3000        # Timeout for individual comment() calls

--- a/apps/server/src/llm/factory.ts
+++ b/apps/server/src/llm/factory.ts
@@ -6,8 +6,9 @@ import { createGroqAdapter } from "./providers/groq.js";
 import { createLocalAdapter } from "./providers/local.js";
 import { createGeminiAdapter } from "./providers/gemini.js";
 import { createAnthropicAdapter } from "./providers/anthropic.js";
+import { createDeepSeekAdapter } from "./providers/deepseek.js";
 
-const VALID_PROVIDERS = ["disabled", "mock", "openai", "groq", "local", "anthropic", "gemini"] as const;
+const VALID_PROVIDERS = ["disabled", "mock", "openai", "deepseek", "groq", "local", "anthropic", "gemini"] as const;
 
 export function createLLMAdapter(env: Record<string, string | undefined> = process.env): LLMAdapter {
   const provider = env.LLM_PROVIDER?.toLowerCase() ?? "";
@@ -22,6 +23,10 @@ export function createLLMAdapter(env: Record<string, string | undefined> = proce
 
   if (provider === "openai") {
     return createOpenAIAdapter(env);
+  }
+
+  if (provider === "deepseek") {
+    return createDeepSeekAdapter(env);
   }
 
   if (provider === "groq") {

--- a/apps/server/src/llm/providers/deepseek.ts
+++ b/apps/server/src/llm/providers/deepseek.ts
@@ -1,0 +1,32 @@
+import type { LLMAdapter } from "../adapter.js";
+import { createOpenAICompatAdapter } from "./openai_compat.js";
+
+export const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+export const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash";
+
+/**
+ * Creates a DeepSeek LLM adapter.
+ *
+ * Environment variables:
+ * - DEEPSEEK_API_KEY (required)
+ * - DEEPSEEK_BASE_URL (optional, defaults to https://api.deepseek.com)
+ * - DEEPSEEK_MODEL (optional, defaults to deepseek-v4-flash)
+ */
+export function createDeepSeekAdapter(
+  env: Record<string, string | undefined> = process.env
+): LLMAdapter {
+  const apiKey = env.DEEPSEEK_API_KEY;
+
+  if (!apiKey) {
+    throw new Error("DEEPSEEK_API_KEY is required for DeepSeek provider");
+  }
+
+  return createOpenAICompatAdapter({
+    name: "deepseek",
+    baseURL: env.DEEPSEEK_BASE_URL || DEFAULT_DEEPSEEK_BASE_URL,
+    apiKey,
+    model: env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL,
+    defaultMaxTokens: 256,
+    defaultTemperature: 0.7,
+  });
+}

--- a/apps/server/src/shared/validation.ts
+++ b/apps/server/src/shared/validation.ts
@@ -72,6 +72,7 @@ export function normalizeProviderName(value?: string): ProviderName | undefined 
     normalized === "disabled" ||
     normalized === "mock" ||
     normalized === "openai" ||
+    normalized === "deepseek" ||
     normalized === "groq" ||
     normalized === "local" ||
     normalized === "anthropic" ||

--- a/apps/server/src/tests/deepseek.provider.test.ts
+++ b/apps/server/src/tests/deepseek.provider.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDeepSeekAdapter,
+  DEFAULT_DEEPSEEK_BASE_URL,
+  DEFAULT_DEEPSEEK_MODEL,
+} from "../llm/providers/deepseek.js";
+
+describe("createDeepSeekAdapter", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("requires DEEPSEEK_API_KEY", () => {
+    expect(() => createDeepSeekAdapter({})).toThrow(
+      "DEEPSEEK_API_KEY is required for DeepSeek provider"
+    );
+  });
+
+  it("uses the official V4 Flash defaults", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "OK" } }] }),
+    });
+
+    const adapter = createDeepSeekAdapter({ DEEPSEEK_API_KEY: "test-key" });
+    await adapter.generateText({ messages: [{ role: "user", content: "Hi" }] });
+
+    expect(adapter.name).toBe("deepseek");
+    expect(fetch).toHaveBeenCalledWith(
+      `${DEFAULT_DEEPSEEK_BASE_URL}/chat/completions`,
+      expect.anything()
+    );
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body.model).toBe(DEFAULT_DEEPSEEK_MODEL);
+  });
+
+  it("accepts custom endpoint and model settings", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "OK" } }] }),
+    });
+
+    const adapter = createDeepSeekAdapter({
+      DEEPSEEK_API_KEY: "test-key",
+      DEEPSEEK_BASE_URL: "https://example.test/v1",
+      DEEPSEEK_MODEL: "deepseek-custom",
+    });
+    await adapter.generateText({ messages: [{ role: "user", content: "Hi" }] });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://example.test/v1/chat/completions",
+      expect.anything()
+    );
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body.model).toBe("deepseek-custom");
+  });
+});
+
+describe("DeepSeek factory integration", () => {
+  it("creates the DeepSeek adapter", async () => {
+    const { createLLMAdapter } = await import("../llm/factory.js");
+    const adapter = createLLMAdapter({
+      LLM_PROVIDER: "deepseek",
+      DEEPSEEK_API_KEY: "test-key",
+    });
+
+    expect(adapter.name).toBe("deepseek");
+  });
+});

--- a/apps/server/src/tests/llm.contract.test.ts
+++ b/apps/server/src/tests/llm.contract.test.ts
@@ -22,6 +22,10 @@ const PROVIDERS = [
     env: { LLM_PROVIDER: "openai", OPENAI_API_KEY: "test-key" },
   },
   {
+    name: "deepseek",
+    env: { LLM_PROVIDER: "deepseek", DEEPSEEK_API_KEY: "test-key" },
+  },
+  {
     name: "groq",
     env: { LLM_PROVIDER: "groq", GROQ_API_KEY: "test-key" },
   },
@@ -43,6 +47,7 @@ const PROVIDERS = [
 function getMockSuccessResponse(providerName: string): unknown {
   switch (providerName) {
     case "openai":
+    case "deepseek":
     case "groq":
     case "local":
       return {
@@ -67,6 +72,7 @@ function getMockSuccessResponse(providerName: string): unknown {
 function getMockEmptyResponse(providerName: string): unknown {
   switch (providerName) {
     case "openai":
+    case "deepseek":
     case "groq":
     case "local":
       return { choices: [] };
@@ -82,6 +88,7 @@ function getMockEmptyResponse(providerName: string): unknown {
 function getMockHttpErrorResponse(providerName: string): unknown {
   switch (providerName) {
     case "openai":
+    case "deepseek":
     case "groq":
     case "local":
       return { error: { message: "Unauthorized" } };

--- a/apps/web/src/components/ProfileEditor.tsx
+++ b/apps/web/src/components/ProfileEditor.tsx
@@ -45,6 +45,7 @@ const LLM_PROVIDERS: { value: ProviderName | ""; label: string }[] = [
   { value: "", label: "（既定の設定に従う）" },
   { value: "disabled", label: "ルール版のみ（LLMを使わない）" },
   { value: "openai", label: "OpenAI" },
+  { value: "deepseek", label: "DeepSeek V4 Flash" },
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Gemini" },
   { value: "groq", label: "Groq" },

--- a/docs/LLM_ADAPTER.ja.md
+++ b/docs/LLM_ADAPTER.ja.md
@@ -7,14 +7,17 @@ LLMプロバイダーを差し替え可能にするAdapter層。
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLM_PROVIDER` | disabled | 使用するプロバイダー (disabled/mock/openai/groq/local/anthropic/gemini) |
+| `LLM_PROVIDER` | disabled | 使用するプロバイダー (disabled/mock/openai/deepseek/groq/local/anthropic/gemini) |
 | `MOCK_LLM_MODE` | (empty) | `error` でmockがエラーを投げる（テスト用） |
+| `DEEPSEEK_API_KEY` | (required) | DeepSeek APIキー |
+| `DEEPSEEK_BASE_URL` | https://api.deepseek.com | DeepSeekのOpenAI互換API URL |
+| `DEEPSEEK_MODEL` | deepseek-v4-flash | DeepSeek実況モデル |
 | `GOOGLE_API_KEY` | (required) | Gemini APIキー（`x-goog-api-key` ヘッダーで送信） |
 | `GEMINI_MODEL` | gemini-3.5-flash | Geminiの使用モデル |
 
 ## 現状
 - factory と実況生成への統合は完了
-- disabled / mock / OpenAI / Groq / local / Anthropic / Gemini を実装済み
+- disabled / mock / OpenAI / DeepSeek / Groq / local / Anthropic / Gemini を実装済み
 - LLM呼び出しが失敗した場合は、文脈付きルールベース実況へフォールバック
 - Geminiの既定モデルは、短文実況のレイテンシと出力完結性を優先して
   `thinkingConfig.thinkingBudget=0` を送信する
@@ -31,7 +34,8 @@ apps/server/src/llm/
 └── providers/
     ├── mock.ts          # 決定論的mock（テスト用）
     ├── disabled.ts      # 未設定時の明示的エラー
-    ├── openai_compat.ts # OpenAI / Groq / local
+    ├── openai_compat.ts # OpenAI / DeepSeek / Groq / local
+    ├── deepseek.ts      # DeepSeek V4 Flash
     ├── anthropic.ts     # Anthropic
     └── gemini.ts        # Gemini
 ```
@@ -44,6 +48,7 @@ import { createLLMAdapter } from "./llm/index.js";
 const adapter = createLLMAdapter();
 // LLM_PROVIDER 未設定 → disabledAdapter (呼ぶとエラー)
 // LLM_PROVIDER=mock → mockAdapter (決定論的レスポンス)
+// LLM_PROVIDER=deepseek → createDeepSeekAdapter (DEEPSEEK_API_KEY が必要)
 // LLM_PROVIDER=gemini → createGeminiAdapter (GOOGLE_API_KEY が必要)
 
 const response = await adapter.generateText({

--- a/packages/shared/src/parse-server-message.ts
+++ b/packages/shared/src/parse-server-message.ts
@@ -36,6 +36,7 @@ const PROVIDERS = new Set<ProviderName>([
   "disabled",
   "mock",
   "openai",
+  "deepseek",
   "groq",
   "local",
   "anthropic",

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -72,6 +72,7 @@ export type ProviderName =
   | "disabled"
   | "mock"
   | "openai"
+  | "deepseek"
   | "groq"
   | "local"
   | "anthropic"

--- a/scripts/smoke-llm.sh
+++ b/scripts/smoke-llm.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-VALID_PROVIDERS="openai groq gemini anthropic local mock"
+VALID_PROVIDERS="openai deepseek groq gemini anthropic local mock"
 
 # --- Helper functions ---
 log() {
@@ -75,6 +75,7 @@ get_required_env() {
   local provider=$1
   case "$provider" in
     openai) echo "OPENAI_API_KEY" ;;
+    deepseek) echo "DEEPSEEK_API_KEY" ;;
     groq) echo "GROQ_API_KEY" ;;
     gemini) echo "GOOGLE_API_KEY" ;;
     anthropic) echo "ANTHROPIC_API_KEY" ;;
@@ -191,7 +192,7 @@ run_smoke() {
 }
 
 run_all() {
-  local providers="openai groq gemini anthropic local mock"
+  local providers="openai deepseek groq gemini anthropic local mock"
   local results=""
   local any_failure=0
 


### PR DESCRIPTION
## HUMAN向け解説
- 結果: DeepSeek V4 Flashを実況AIとして選べる最小実装を追加しました。
- 影響: 既定のプロバイダーは変更せず、DeepSeekを選んだ場合だけAPIキーが必要です。
- 次にお願い: 自動チェック完了後、実装と表示名を確認してマージ可否を判断してください。

## What
- OpenAI互換APIを使うDeepSeek adapterとfactory統合を追加
- Provider型、入力検証、プロフィール選択肢、環境変数例、LLM adapter文書を更新
- 専用テスト、共通contractテスト、`smoke-llm.sh`のDeepSeek経路を追加

## Why
未コミットのDeepSeek対応を、他プロバイダーや汎用ランチャー改修を含めない1目的の差分として保全・PR化するためです。

## Impact
- `LLM_PROVIDER=deepseek` またはプロフィールのDeepSeek選択時にDeepSeek V4 Flashを利用できます。
- 既定プロバイダーと既存プロバイダーの挙動は変わりません。

## Checks
- GitHub Actions: 全9 checks PASS（Linux / Windows / desktop / docs / CodeQL）
- server tests: 56 files / 872 tests PASS
- web tests: 11 files / 102 tests PASS
- server typecheck/build, web lint/build PASS
- doc-sync guard/tests, sidecar runtime tests, local readiness tests PASS
- desktop `cargo check` / `cargo test` (12 tests) PASS
- `smoke-llm.sh deepseek`: ローカルOpenAI互換mock endpointで `comment_ok` PASS（実APIキー未設定）
