### PR TITLE
fix(eval): preserve provider measurement accuracy

### DIFF
--- a/apps/server/src/commentary/orchestrator.ts
+++ b/apps/server/src/commentary/orchestrator.ts
@@ -25,6 +25,7 @@ export type CommentMeasurement = {
   result: "comment_ok" | "comment_timeout" | "comment_aborted" | "comment_llm_error";
   durationMs: number;
   provider: string;
+  model: string;
   style: string;
   eventType: string;
   inputTokens: number;
@@ -37,13 +38,14 @@ function logComment(
   result: "ok" | "timeout" | "aborted" | "llm_error",
   durationMs: number,
   meta: CommentLogMeta,
+  model: string,
   usage: { inputTokens?: number; outputTokens?: number } = {},
   observe?: CommentMeasurementObserver
 ): void {
   const inputTokens = usage.inputTokens ?? 0;
   const outputTokens = usage.outputTokens ?? 0;
   const resultName = `comment_${result}` as CommentMeasurement["result"];
-  const msg = `${resultName} duration_ms=${durationMs} provider=${meta.provider} style=${meta.style} event=${meta.eventType} input_tokens=${inputTokens} output_tokens=${outputTokens}`;
+  const msg = `${resultName} duration_ms=${durationMs} provider=${meta.provider} model=${model} style=${meta.style} event=${meta.eventType} input_tokens=${inputTokens} output_tokens=${outputTokens}`;
   if (result === "ok") {
     if (process.env.DEBUG) console.log(msg);
   } else {
@@ -53,6 +55,7 @@ function logComment(
     result: resultName,
     durationMs,
     provider: meta.provider,
+    model,
     style: meta.style,
     eventType: meta.eventType,
     inputTokens,
@@ -101,7 +104,7 @@ async function generateLLMText(
   adapter: LLMAdapter,
   prompt: string,
   signal?: AbortSignal
-): Promise<{ text: string; usage?: { inputTokens?: number; outputTokens?: number } }> {
+): Promise<{ text: string; model: string; usage?: { inputTokens?: number; outputTokens?: number } }> {
   const res = await adapter.generateText({
     messages: [{ role: "user", content: prompt }],
     signal,
@@ -112,11 +115,17 @@ async function generateLLMText(
     throw new CommentError("comment_llm_error", "Empty LLM response");
   }
 
-  return { text, usage: res.usage };
+  return { text, model: res.model, usage: res.usage };
 }
 
 function providerLabel(narrationProvider?: ProviderName, explanationProvider?: ProviderName): string {
   return `${narrationProvider ?? "disabled"}/${explanationProvider ?? "disabled"}`;
+}
+
+function modelLabel(narrationModel?: string, explanationModel?: string): string {
+  if (narrationModel && narrationModel === explanationModel) return narrationModel;
+  if (narrationModel && explanationModel) return `${narrationModel}/${explanationModel}`;
+  return narrationModel ?? explanationModel ?? "unknown";
 }
 
 async function commentInternal(
@@ -127,11 +136,13 @@ async function commentInternal(
   context?: SessionContextSnapshot
 ): Promise<{
   payload: CommentaryPayload;
+  model: string;
   usage: { inputTokens: number; outputTokens: number };
 }> {
   if (isSuppressedCommentaryEvent(ev)) {
     return {
       payload: commentByRules(ev, style, context),
+      model: "rules",
       usage: { inputTokens: 0, outputTokens: 0 },
     };
   }
@@ -144,6 +155,7 @@ async function commentInternal(
   if (!narrationAdapter && !explanationAdapter) {
     return {
       payload: rules,
+      model: "rules",
       usage: { inputTokens: 0, outputTokens: 0 },
     };
   }
@@ -154,6 +166,7 @@ async function commentInternal(
           .then((response) => ({
             text: normalizeGeneratedCommentaryText(response.text, "narration"),
             provider: narrationAdapter.name,
+            model: response.model,
             usage: response.usage,
           }))
           .catch(() => null)
@@ -163,6 +176,7 @@ async function commentInternal(
           .then((response) => ({
             text: normalizeGeneratedCommentaryText(response.text, "explanation"),
             provider: explanationAdapter.name,
+            model: response.model,
             usage: response.usage,
           }))
           .catch(() => null)
@@ -183,6 +197,7 @@ async function commentInternal(
         explanationProvider: explanation?.provider ?? rules.meta?.explanationProvider ?? "rules",
       },
     }),
+    model: modelLabel(narration?.model, explanation?.model),
     usage: {
       inputTokens:
         (narration?.usage?.inputTokens ?? 0) + (explanation?.usage?.inputTokens ?? 0),
@@ -232,15 +247,15 @@ export async function comment(
         onTimeout: () => controller.abort(),
       }
     );
-    logComment("ok", Date.now() - start, meta, result.usage, observe);
+    logComment("ok", Date.now() - start, meta, result.model, result.usage, observe);
     return applySpeechContract(result.payload, ev, context);
   } catch (err) {
     const duration = Date.now() - start;
     if (err instanceof CommentError) {
       const resultType = err.code.replace("comment_", "") as "timeout" | "aborted" | "llm_error";
-      logComment(resultType, duration, meta, {}, observe);
+      logComment(resultType, duration, meta, "unknown", {}, observe);
     } else {
-      logComment("llm_error", duration, meta, {}, observe);
+      logComment("llm_error", duration, meta, "unknown", {}, observe);
     }
     return applySpeechContract(commentByRules(ev, style, context), ev, context);
   }

--- a/apps/server/src/evaluation/phase-b-replay.ts
+++ b/apps/server/src/evaluation/phase-b-replay.ts
@@ -98,6 +98,7 @@ export type PhaseBProviderMetrics = {
   model: string;
   timeoutMs: number;
   attempted: number;
+  skipped: number;
   withinTimeoutSuccesses: number;
   withinTimeoutSuccessRate: number;
   results: Record<CommentMeasurement["result"], number>;
@@ -107,7 +108,6 @@ export type PhaseBProviderMetrics = {
 
 export type PhaseBReplayOptions = {
   llmProvider?: ProviderName;
-  llmModel?: string;
 };
 
 export type PhaseBEventTypeComparison = {
@@ -227,8 +227,8 @@ function buildMetrics(
 
 function buildProviderMetrics(
   provider: ProviderName,
-  model: string,
-  measurements: CommentMeasurement[]
+  measurements: CommentMeasurement[],
+  skipped: number
 ): PhaseBProviderMetrics {
   const results: PhaseBProviderMetrics["results"] = {
     comment_ok: 0,
@@ -242,11 +242,17 @@ function buildProviderMetrics(
   const withinTimeoutSuccesses = measurements.filter(
     ({ result, durationMs }) => result === "comment_ok" && durationMs <= COMMENT_TIMEOUT_MS
   ).length;
+  const measuredModels = Array.from(new Set(
+    measurements
+      .map(({ model }) => model)
+      .filter((model) => model !== "unknown" && model !== "rules")
+  ));
   return {
     provider,
-    model,
+    model: measuredModels.join(", ") || "unknown",
     timeoutMs: COMMENT_TIMEOUT_MS,
     attempted: measurements.length,
+    skipped,
     withinTimeoutSuccesses,
     withinTimeoutSuccessRate:
       measurements.length === 0 ? 0 : withinTimeoutSuccesses / measurements.length,
@@ -271,6 +277,7 @@ export async function replayPhaseBFixture(
   const commentaryComparisons: PhaseBReplayResult["commentaryComparisons"] = [];
   const providerComparisons: NonNullable<PhaseBReplayResult["providerComparisons"]> = [];
   const providerMeasurements: CommentMeasurement[] = [];
+  let skippedProviderMeasurements = 0;
   const suppressions: PhaseBSuppression[] = [];
   const sessionContext = createSessionContext({ now: () => currentOffsetMs });
   sessionContext.setTaskContext({ ...fixture.taskContext, source: "fixture" });
@@ -347,24 +354,25 @@ export async function replayPhaseBFixture(
             providerMeasurements.push(item);
           }
         );
-        if (!measurement) {
-          throw new Error("LLM commentary completed without a measurement");
+        if (measurement) {
+          providerComparisons.push({
+            offsetMs: currentOffsetMs,
+            eventType: event.type,
+            rules: {
+              narration: rules.narration,
+              explanation: rules.explanation,
+              speech: rules.speech,
+            },
+            llm: {
+              narration: llm.narration,
+              explanation: llm.explanation,
+              speech: llm.speech,
+            },
+            measurement,
+          });
+        } else {
+          skippedProviderMeasurements += 1;
         }
-        providerComparisons.push({
-          offsetMs: currentOffsetMs,
-          eventType: event.type,
-          rules: {
-            narration: rules.narration,
-            explanation: rules.explanation,
-            speech: rules.speech,
-          },
-          llm: {
-            narration: llm.narration,
-            explanation: llm.explanation,
-            speech: llm.speech,
-          },
-          measurement,
-        });
       }
       messages.push({ kind: "commentary", ts: currentOffsetMs, ev: event, ...payload });
     }
@@ -385,8 +393,8 @@ export async function replayPhaseBFixture(
     result.providerComparisons = providerComparisons;
     result.providerMetrics = buildProviderMetrics(
       options.llmProvider,
-      options.llmModel ?? "unknown",
-      providerMeasurements
+      providerMeasurements,
+      skippedProviderMeasurements
     );
   }
   return result;

--- a/apps/server/src/llm/providers/anthropic.ts
+++ b/apps/server/src/llm/providers/anthropic.ts
@@ -20,6 +20,7 @@ interface AnthropicRequest {
 }
 
 interface AnthropicResponse {
+  model?: string;
   content?: Array<{ type?: string; text?: string }>;
   usage?: {
     input_tokens?: number;
@@ -138,6 +139,7 @@ export function createAnthropicAdapter(
 
       return {
         text,
+        model: data.model ?? body.model,
         usage: data.usage
           ? {
               inputTokens: data.usage.input_tokens,

--- a/apps/server/src/llm/providers/gemini.ts
+++ b/apps/server/src/llm/providers/gemini.ts
@@ -22,6 +22,7 @@ interface GeminiRequest {
 }
 
 interface GeminiResponse {
+  modelVersion?: string;
   candidates?: Array<{
     content?: {
       parts?: Array<{ text?: string }>;
@@ -64,7 +65,8 @@ export function createGeminiAdapter(
         throw new CommentError("comment_aborted");
       }
 
-      const endpoint = `${API_BASE}/${model}:generateContent`;
+      const actualModel = req.model ?? model;
+      const endpoint = `${API_BASE}/${actualModel}:generateContent`;
 
       // Convert OpenAI-style messages to Gemini format
       const contents: GeminiContent[] = req.messages.map((m) => ({
@@ -77,7 +79,7 @@ export function createGeminiAdapter(
         generationConfig: {
           temperature: req.temperature ?? 0.7,
           maxOutputTokens: req.maxTokens ?? 256,
-          ...(supportsZeroThinkingBudget(model)
+          ...(supportsZeroThinkingBudget(actualModel)
             ? { thinkingConfig: { thinkingBudget: 0 } }
             : {}),
         },
@@ -135,6 +137,7 @@ export function createGeminiAdapter(
 
       return {
         text,
+        model: data.modelVersion ?? actualModel,
         usage: data.usageMetadata
           ? {
               inputTokens: data.usageMetadata.promptTokenCount,

--- a/apps/server/src/llm/providers/mock.ts
+++ b/apps/server/src/llm/providers/mock.ts
@@ -21,6 +21,7 @@ export const mockAdapter: LLMAdapter = {
     const id = hashMessages(req.messages);
     return {
       text: `[mock-${id}] This is a mock response.`,
+      model: req.model ?? "mock",
       usage: { inputTokens: 10, outputTokens: 20 },
     };
   },

--- a/apps/server/src/llm/providers/openai_compat.ts
+++ b/apps/server/src/llm/providers/openai_compat.ts
@@ -14,6 +14,7 @@ export interface OpenAICompatConfig {
 interface OpenAIChatCompletionResponse {
   id: string;
   object: string;
+  model?: string;
   choices: Array<{
     index: number;
     message: {
@@ -61,8 +62,9 @@ export function createOpenAICompatAdapter(config: OpenAICompatConfig): LLMAdapte
 
       const endpoint = `${baseURL.replace(/\/$/, "")}/chat/completions`;
 
+      const actualModel = req.model ?? model;
       const body = {
-        model,
+        model: actualModel,
         messages: req.messages.map((m) => ({
           role: m.role,
           content: m.content,
@@ -123,6 +125,7 @@ export function createOpenAICompatAdapter(config: OpenAICompatConfig): LLMAdapte
 
       return {
         text,
+        model: data.model ?? actualModel,
         usage: data.usage
           ? {
               inputTokens: data.usage.prompt_tokens,

--- a/apps/server/src/llm/types.ts
+++ b/apps/server/src/llm/types.ts
@@ -15,6 +15,7 @@ export type GenerateTextRequest = {
 
 export type GenerateTextResponse = {
   text: string;
+  model: string;
   usage?: { inputTokens?: number; outputTokens?: number };
   raw?: unknown;
 };

--- a/apps/server/src/tests/anthropic.provider.test.ts
+++ b/apps/server/src/tests/anthropic.provider.test.ts
@@ -106,6 +106,7 @@ describe("createAnthropicAdapter", () => {
     });
 
     expect(result.text).toBe("Hello world");
+    expect(result.model).toBe("claude-3-5-sonnet-20240620");
     expect(result.usage).toEqual({ inputTokens: 12, outputTokens: 4 });
   });
 

--- a/apps/server/src/tests/gemini.provider.test.ts
+++ b/apps/server/src/tests/gemini.provider.test.ts
@@ -51,6 +51,7 @@ describe("createGeminiAdapter", () => {
     });
 
     expect(result.text).toBe("Hello from Gemini!");
+    expect(result.model).toBe("gemini-3.5-flash");
     expect(result.usage).toEqual({
       inputTokens: 10,
       outputTokens: 5,

--- a/apps/server/src/tests/local.provider.test.ts
+++ b/apps/server/src/tests/local.provider.test.ts
@@ -186,6 +186,7 @@ describe("createLocalAdapter", () => {
     });
 
     expect(result.text).toBe("vLLM response");
+    expect(result.model).toBe("Qwen/Qwen2.5-7B-Instruct");
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:8000/v1/chat/completions",
       expect.anything()

--- a/apps/server/src/tests/openai_compat.test.ts
+++ b/apps/server/src/tests/openai_compat.test.ts
@@ -23,6 +23,7 @@ describe("createOpenAICompatAdapter", () => {
     const mockResponse = {
       id: "chatcmpl-123",
       object: "chat.completion",
+      model: "gpt-4-actual",
       choices: [
         {
           index: 0,
@@ -48,6 +49,7 @@ describe("createOpenAICompatAdapter", () => {
     });
 
     expect(result.text).toBe("Hello, world!");
+    expect(result.model).toBe("gpt-4-actual");
     expect(result.usage).toEqual({
       inputTokens: 10,
       outputTokens: 5,

--- a/apps/server/src/tests/phase-b-evaluation.test.ts
+++ b/apps/server/src/tests/phase-b-evaluation.test.ts
@@ -156,7 +156,6 @@ describe("Phase B evaluation replay", () => {
     const fixture = await loadFixture();
     const result = await replayPhaseBFixture(fixture, {
       llmProvider: "mock",
-      llmModel: "mock",
     });
 
     expect(result.providerComparisons).toHaveLength(5);
@@ -173,6 +172,7 @@ describe("Phase B evaluation replay", () => {
       measurement: {
         result: "comment_ok",
         provider: "mock/mock",
+        model: "mock",
         inputTokens: 20,
         outputTokens: 40,
       },
@@ -182,6 +182,7 @@ describe("Phase B evaluation replay", () => {
       model: "mock",
       timeoutMs: 3000,
       attempted: 5,
+      skipped: 0,
       withinTimeoutSuccesses: 5,
       withinTimeoutSuccessRate: 1,
       results: {
@@ -192,6 +193,23 @@ describe("Phase B evaluation replay", () => {
       },
       inputTokens: 100,
       outputTokens: 200,
+    });
+  });
+
+  it("skips provider comparisons when an adapter cannot produce a measurement", async () => {
+    const fixture = await loadFixture();
+    const result = await replayPhaseBFixture(fixture, {
+      llmProvider: "openai",
+    });
+
+    expect(result.providerComparisons).toEqual([]);
+    expect(result.providerMetrics).toMatchObject({
+      provider: "openai",
+      model: "unknown",
+      attempted: 0,
+      skipped: 5,
+      withinTimeoutSuccesses: 0,
+      withinTimeoutSuccessRate: 0,
     });
   });
 

--- a/docs/LLM_ADAPTER.ja.md
+++ b/docs/LLM_ADAPTER.ja.md
@@ -49,11 +49,17 @@ const adapter = createLLMAdapter();
 const response = await adapter.generateText({
   messages: [{ role: "user", content: "Hello" }],
 });
+
+// response.model には、API応答またはリクエストで実際に使われたモデル名が入る
 ```
 
 ## 統合ポイント
 `apps/server/src/commentary/orchestrator.ts` がLLM実況を呼び出し、失敗時は
 ルールベース実況へフォールバックする。
+
+Phase B評価では、この応答の `model` を `CommentMeasurement` 経由で集計する。
+モデル名を評価スクリプト側で重複管理せず、計測が作られなかった実況は異常終了ではなく
+`providerMetrics.skipped` として数える。`LLM_PROVIDER` は既知のプロバイダー名だけを受け付ける。
 
 ## テスト
 

--- a/scripts/run-phase-b-evaluation.mts
+++ b/scripts/run-phase-b-evaluation.mts
@@ -9,7 +9,7 @@ import {
   type PhaseBReplayResult,
 } from "../apps/server/src/evaluation/phase-b-replay.js";
 import { buildPhaseBEvaluationArtifacts } from "../apps/server/src/evaluation/phase-b-artifacts.js";
-import { DEFAULT_GEMINI_MODEL } from "../apps/server/src/llm/providers/gemini.js";
+import { normalizeProviderName } from "../apps/server/src/shared/validation.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), "..");
@@ -36,15 +36,6 @@ function inferredBaselinePath(fixturePath: string): string {
   return fixturePath.endsWith(".json")
     ? fixturePath.replace(/\.json$/u, ".expected.json")
     : `${fixturePath}.expected.json`;
-}
-
-function configuredModel(provider: string): string {
-  if (provider === "gemini") return process.env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
-  if (provider === "anthropic") return process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-20240620";
-  if (provider === "openai") return process.env.OPENAI_MODEL || "gpt-4o-mini";
-  if (provider === "groq") return process.env.GROQ_MODEL || "llama-3.3-70b-versatile";
-  if (provider === "local") return process.env.LOCAL_MODEL || "llama3.2";
-  return provider === "mock" ? "mock" : "unknown";
 }
 
 function missingProviderCredential(provider: string): string | undefined {
@@ -153,6 +144,7 @@ function markdownReport(
           "## Context-aware rules / LLM provider comparison",
           "",
           `- successes within timeout: ${providerMetrics.withinTimeoutSuccesses}/${providerMetrics.attempted} (${(providerMetrics.withinTimeoutSuccessRate * 100).toFixed(1)}%)`,
+          `- skipped measurements: ${providerMetrics.skipped}`,
           `- results: \`${JSON.stringify(providerMetrics.results)}\``,
           `- tokens: input=${providerMetrics.inputTokens}, output=${providerMetrics.outputTokens}`,
           "",
@@ -171,10 +163,15 @@ const baselinePath = resolveRepoPath(
 );
 const fixture = JSON.parse(await fs.readFile(fixturePath, "utf8")) as PhaseBReplayFixture;
 const withLlm = process.argv.includes("--with-llm");
-const llmProvider = process.env.LLM_PROVIDER ?? "disabled";
-const missingCredential = withLlm ? missingProviderCredential(llmProvider) : undefined;
+const configuredProvider = process.env.LLM_PROVIDER ?? "disabled";
+const llmProvider = normalizeProviderName(configuredProvider);
+if (withLlm && !llmProvider) {
+  throw new Error(`Unknown LLM_PROVIDER: ${configuredProvider}`);
+}
+const missingCredential = withLlm && llmProvider
+  ? missingProviderCredential(llmProvider)
+  : undefined;
 const llmEnabled = withLlm && llmProvider !== "disabled" && !missingCredential;
-const llmModel = configuredModel(llmProvider);
 if (withLlm && missingCredential) {
   console.warn(`Skipping LLM measurement: ${missingCredential} is not set`);
 }
@@ -185,8 +182,7 @@ const candidate = await replayPhaseBFixture(
   fixture,
   llmEnabled
     ? {
-        llmProvider: llmProvider as NonNullable<Parameters<typeof replayPhaseBFixture>[1]>["llmProvider"],
-        llmModel,
+        llmProvider,
       }
     : {}
 );


### PR DESCRIPTION
## 何をしたか

Issue #346 の項目1・3を修正し、Phase B評価が実際のモデル名と計測欠落を正確に記録できるようにしました。

## 変更点

- LLM応答と `CommentMeasurement` に実使用モデルを載せ、評価スクリプトのモデル名二重管理を削除
- measurement欠落をthrowではなく `providerMetrics.skipped` として集計し、provider名を既知リストで検証
- 項目2（Markdownエスケープ）と項目4（suppressed計上）は対象外のまま

## 検証

- server: 46 files / 652 tests PASS、typecheck・build PASS
- web: 11 files / 102 tests PASS、build・lint PASS
- sidecar runtime 9 tests、local readiness 13 tests、doc-sync 11 tests / check PASS
- `LLM_PROVIDER=mock pnpm eval:phase-b --with-llm`: snapshot MATCH、model=mock、skipped=0
- 未知provider: `Unknown LLM_PROVIDER` で明示的に拒否

## HUMAN向け解説
結果: 評価レポートに、実際に使われたAIモデルと計測できなかった件数が正しく残るようになりました。
影響: 普段の実況機能は変えず、評価結果の信頼性と失敗時の分かりやすさだけを改善します。
次にお願いしたいこと: Draft差分を確認し、問題なければHUMAN判断でマージしてください（gate/human）。

Refs #346
