### PR TITLE
fix(release): align desktop version for v0.2.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cli-commentator/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "cli-commentator-desktop"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "process-wrap",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-commentator-desktop"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CLI Commentator",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "identifier": "com.cli-commentator.desktop",
   "build": {
     "devUrl": "http://localhost:5173",

--- a/docs/desktop-release.en.md
+++ b/docs/desktop-release.en.md
@@ -185,7 +185,7 @@ After setting `plugins.updater`, start desktop managed mode and verify:
 
 ## 6) Minimal release flow
 
-1. Bump version (`tauri.conf.json` and release notes if needed)
+1. Bump `apps/desktop/package.json`, `Cargo.toml`, `cli-commentator-desktop` in `Cargo.lock`, and `tauri.conf.json` to the same version (and update release notes if needed)
 2. `pnpm -C apps/web build`
 3. `pnpm -C apps/desktop tauri:build`
 4. Create and push tag:

--- a/docs/desktop-release.ja.md
+++ b/docs/desktop-release.ja.md
@@ -184,7 +184,7 @@ Desktop updater の契約は意図的に狭く固定します。
 
 ## 6) 配布手順（最小）
 
-1. バージョン更新（`tauri.conf.json` + 必要ならリリースノート）
+1. `apps/desktop/package.json`、`Cargo.toml`、`Cargo.lock` の `cli-commentator-desktop`、`tauri.conf.json` を同じ版数へ更新（必要ならリリースノートも更新）
 2. `pnpm -C apps/web build`
 3. `pnpm -C apps/desktop tauri:build`
 4. タグ作成・push

--- a/docs/release-runbook.en.md
+++ b/docs/release-runbook.en.md
@@ -178,7 +178,11 @@ Current policy: update checks are manual from the Desktop Server panel. Do not t
 
 ## 2) Standard release flow (happy path)
 
-1. Bump version in `apps/desktop/src-tauri/tauri.conf.json`
+1. Bump these desktop versions to the same `X.Y.Z` and verify they match:
+   - `apps/desktop/package.json`
+   - `apps/desktop/src-tauri/Cargo.toml`
+   - `cli-commentator-desktop` in `apps/desktop/src-tauri/Cargo.lock`
+   - `apps/desktop/src-tauri/tauri.conf.json`
 2. Commit and push
 3. Create and push tag
    - `git tag -a vX.Y.Z -m "vX.Y.Z"`

--- a/docs/release-runbook.ja.md
+++ b/docs/release-runbook.ja.md
@@ -179,7 +179,11 @@ Release candidate が updater artifacts を生成する場合は、以下を確�
 
 ## 2) 標準リリース手順（Happy Path）
 
-1. バージョンを更新（`apps/desktop/src-tauri/tauri.conf.json`）
+1. 次のデスクトップ版数を同じ `X.Y.Z` に更新し、一致を確認
+   - `apps/desktop/package.json`
+   - `apps/desktop/src-tauri/Cargo.toml`
+   - `apps/desktop/src-tauri/Cargo.lock` の `cli-commentator-desktop`
+   - `apps/desktop/src-tauri/tauri.conf.json`
 2. コミット・push
 3. タグ作成とpush
    - `git tag -a vX.Y.Z -m "vX.Y.Z"`


### PR DESCRIPTION
🧑 HUMAN向け（先に読む）
・やったこと: デスクトップ版のソース版数を0.2.1へ揃え、配布手順も更新しました。
・なぜ必要か: ソースと配布物の版数不一致をなくし、同じ手順で再現できる状態にするためです。
・あなたの操作: CI完了後に差分を確認し、問題がなければReady化とMergeを判断してください。

## 結果

デスクトップ版の4つのversion宣言を`0.2.1`へ統一しました。基点は#371と#389を含む`de27cdf`で、#391と#392は含みません。

## 変更点

- `apps/desktop/package.json`
- `apps/desktop/src-tauri/Cargo.toml`
- `Cargo.lock`の`cli-commentator-desktop`
- `apps/desktop/src-tauri/tauri.conf.json`
- 日英のrelease runbookとdesktop release手順を、4か所同時更新へ修正

## 確認結果

- version整合: package / Cargo / Cargo.lock / Tauri configがすべて`0.2.1`
- Server: 55 files / 861 tests PASS、typecheck、build PASS
- Web: 11 files / 102 tests PASS、lint、build PASS
- Rust: cargo check、12 tests PASS
- doc-sync、sidecar prepare/ensure、sidecar runtime 9 tests、local readiness 13 tests PASS
- overrideなしのInfo.plistとDMG名が`0.2.1`
- unsigned arm64 DMG検証と、実bundleのhealth/comment/異常系smoke PASS

## スコープ外

- v0.2.0のタグ・Draft Releaseは変更していません。
- v0.2.1のタグ・Releaseは作成していません。
- PRのmergeやworktree削除は行いません。
