### PR TITLE
fix(terminal): sync managed PTY dimensions

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import type {
   Event,
   InputMode,
   LaunchSessionInput,
+  PtySize,
   SourceMode,
   SourceState,
   Style,
@@ -35,6 +36,7 @@ import {
   type PtyFailure,
   type FileFallbackResult,
 } from "./pty/index.js";
+import { parsePtySize } from "./pty/size.js";
 import { createFileTail, resolveFileFallback, type FileTail } from "./input/index.js";
 import {
   buildServerStateEvent,
@@ -69,6 +71,7 @@ const INPUT_MODE: InputMode = parseInputMode(INPUT_MODE_RAW);
 const INPUT_FILE = process.env.INPUT_FILE ?? "";
 const ptyCapture = createPtyCapture(process.env.PTY_CAPTURE_FILE);
 let runtimeInputMode: InputMode = INPUT_MODE;
+let latestPtySize: PtySize | null = null;
 
 // --- Mutable state ---
 let currentStyle: Style = "kansai";
@@ -459,7 +462,7 @@ function setupPTY(
   });
   commentaryGate.reset();
   resetExtractionState();
-  const term = ptyManager.spawn(config);
+  const term = ptyManager.spawn(latestPtySize ? { ...config, ...latestPtySize } : config);
   silenceTimer.start();
   transitionServerState("setup_pty_success", "pty_running", {
     inputMode: "pty",
@@ -790,6 +793,19 @@ wss.on("connection", async (ws) => {
             ptyManager.write(msg.data);
           }
           break;
+
+        case "resizePty": {
+          const size = parsePtySize(msg.cols, msg.rows);
+          if (!size) break;
+          latestPtySize = size;
+          if (runtimeInputMode !== "pty") break;
+          try {
+            ptyManager.resize(size.cols, size.rows);
+          } catch (err) {
+            console.warn("Failed to resize PTY:", err);
+          }
+          break;
+        }
 
         case "getProfiles": {
           const list = await profileManager.list();

--- a/apps/server/src/pty/manager.ts
+++ b/apps/server/src/pty/manager.ts
@@ -139,6 +139,7 @@ export type PTYManager = {
   readonly current: IPty | null;
   spawn: (config: PTYConfig) => IPty;
   kill: () => void;
+  resize: (cols: number, rows: number) => void;
   write: (data: string) => void;
 };
 
@@ -198,6 +199,12 @@ export function createPTYManager(): PTYManager {
           // Ignore errors when killing
         }
         currentPty = null;
+      }
+    },
+
+    resize(cols: number, rows: number) {
+      if (currentPty) {
+        currentPty.resize(cols, rows);
       }
     },
 

--- a/apps/server/src/pty/size.ts
+++ b/apps/server/src/pty/size.ts
@@ -1,0 +1,23 @@
+import type { PtySize } from "@cli-commentator/shared";
+
+export const MIN_PTY_COLS = 2;
+export const MAX_PTY_COLS = 500;
+export const MIN_PTY_ROWS = 1;
+export const MAX_PTY_ROWS = 300;
+
+export function parsePtySize(cols: unknown, rows: unknown): PtySize | null {
+  if (!Number.isSafeInteger(cols) || !Number.isSafeInteger(rows)) return null;
+
+  const normalizedCols = cols as number;
+  const normalizedRows = rows as number;
+  if (
+    normalizedCols < MIN_PTY_COLS ||
+    normalizedCols > MAX_PTY_COLS ||
+    normalizedRows < MIN_PTY_ROWS ||
+    normalizedRows > MAX_PTY_ROWS
+  ) {
+    return null;
+  }
+
+  return { cols: normalizedCols, rows: normalizedRows };
+}

--- a/apps/server/src/tests/pty.manager.test.ts
+++ b/apps/server/src/tests/pty.manager.test.ts
@@ -204,6 +204,50 @@ describe("pty/manager", () => {
   });
 
   describe("createPTYManager", () => {
+    it("resizes the active PTY and ignores resize requests after it is killed", async () => {
+      vi.resetModules();
+      const originalForceNoPty = process.env.CLI_COMMENTATOR_FORCE_NO_PTY;
+      const resize = vi.fn();
+      const term = {
+        onData: vi.fn(),
+        onExit: vi.fn(),
+        write: vi.fn(),
+        kill: vi.fn(),
+        resize,
+      };
+      const spawn = vi.fn(() => term);
+
+      delete process.env.CLI_COMMENTATOR_FORCE_NO_PTY;
+
+      try {
+        vi.doMock("node:module", () => ({
+          createRequire: () => {
+            return (specifier: string) => {
+              if (specifier === "node-pty") return { spawn };
+              throw new Error(`unexpected require: ${specifier}`);
+            };
+          },
+        }));
+
+        const { createPTYManager } = await import("../pty/manager.js");
+        const manager = createPTYManager();
+        manager.spawn({ cmd: "bash", args: [], cwd: process.cwd() });
+
+        manager.resize(96, 32);
+        expect(resize).toHaveBeenCalledWith(96, 32);
+
+        manager.kill();
+        manager.resize(120, 40);
+        expect(resize).toHaveBeenCalledTimes(1);
+      } finally {
+        if (originalForceNoPty === undefined) {
+          delete process.env.CLI_COMMENTATOR_FORCE_NO_PTY;
+        } else {
+          process.env.CLI_COMMENTATOR_FORCE_NO_PTY = originalForceNoPty;
+        }
+      }
+    });
+
     it("surfaces node-pty spawn failures unchanged", async () => {
       vi.resetModules();
       const originalForceNoPty = process.env.CLI_COMMENTATOR_FORCE_NO_PTY;

--- a/apps/server/src/tests/pty.resize-integration.test.ts
+++ b/apps/server/src/tests/pty.resize-integration.test.ts
@@ -1,0 +1,124 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { isNodePtyAvailable } from "../pty/manager.js";
+
+const canRun = process.platform !== "win32" && isNodePtyAvailable();
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Failed to resolve a free port"));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+    server.on("error", reject);
+  });
+}
+
+async function waitForHealth(port: number, child: ChildProcess): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    if (child.exitCode !== null) {
+      throw new Error(`Server exited before health check with code ${child.exitCode}`);
+    }
+
+    const healthy = await new Promise<boolean>((resolve) => {
+      const request = http.get(
+        { host: "127.0.0.1", port, path: "/healthz", timeout: 300 },
+        (response) => {
+          response.resume();
+          resolve(response.statusCode === 200);
+        }
+      );
+      request.on("error", () => resolve(false));
+      request.on("timeout", () => {
+        request.destroy();
+        resolve(false);
+      });
+    });
+    if (healthy) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error("Server health check timed out");
+}
+
+async function waitForOutput(getOutput: () => string, pattern: RegExp): Promise<string> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 5_000) {
+    const output = getOutput();
+    if (pattern.test(output)) return output;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`PTY output did not match ${pattern}: ${JSON.stringify(getOutput())}`);
+}
+
+describe.skipIf(!canRun)("PTY resize WebSocket integration", () => {
+  it("applies browser dimensions to the managed PTY", async () => {
+    const port = await getFreePort();
+    const child = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        CLI_COMMENTATOR_PORT: String(port),
+        INPUT_MODE: "pty",
+        TARGET_CMD: "bash",
+        TARGET_ARGS_JSON: JSON.stringify(["--noprofile", "--norc"]),
+        TARGET_CWD: process.cwd(),
+        LLM_PROVIDER: "disabled",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    let ws: WebSocket | null = null;
+    const receivedKinds: string[] = [];
+
+    try {
+      await waitForHealth(port, child);
+      ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      let rawOutput = "";
+      ws.on("message", (data) => {
+        const message = JSON.parse(data.toString()) as { kind?: string; data?: unknown };
+        if (message.kind) receivedKinds.push(message.kind);
+        if (message.kind === "raw" && typeof message.data === "string") {
+          rawOutput += message.data;
+        }
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        ws?.once("open", resolve);
+        ws?.once("error", reject);
+      });
+
+      await waitForOutput(() => receivedKinds.join(","), /(?:^|,)hello(?:,|$)/);
+
+      ws.send(JSON.stringify({ kind: "resizePty", cols: 96, rows: 32 }));
+      ws.send(JSON.stringify({ kind: "writeInput", data: "stty size\r" }));
+
+      const output = await waitForOutput(() => rawOutput, /32\s+96/);
+      expect(output).toMatch(/32\s+96/);
+    } catch (error) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\nstdout=${stdout}\nstderr=${stderr}\nmessages=${receivedKinds.join(",")}`
+      );
+    } finally {
+      ws?.close();
+      child.kill("SIGTERM");
+    }
+  }, 15_000);
+});

--- a/apps/server/src/tests/pty.size.test.ts
+++ b/apps/server/src/tests/pty.size.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PTY_COLS,
+  MAX_PTY_ROWS,
+  MIN_PTY_COLS,
+  MIN_PTY_ROWS,
+  parsePtySize,
+} from "../pty/size.js";
+
+describe("parsePtySize", () => {
+  it("accepts integer terminal dimensions within the supported range", () => {
+    expect(parsePtySize(96, 32)).toEqual({ cols: 96, rows: 32 });
+    expect(parsePtySize(MIN_PTY_COLS, MIN_PTY_ROWS)).toEqual({
+      cols: MIN_PTY_COLS,
+      rows: MIN_PTY_ROWS,
+    });
+    expect(parsePtySize(MAX_PTY_COLS, MAX_PTY_ROWS)).toEqual({
+      cols: MAX_PTY_COLS,
+      rows: MAX_PTY_ROWS,
+    });
+  });
+
+  it("rejects non-integer, non-finite, and out-of-range dimensions", () => {
+    expect(parsePtySize(95.5, 32)).toBeNull();
+    expect(parsePtySize(96, Number.NaN)).toBeNull();
+    expect(parsePtySize("96", 32)).toBeNull();
+    expect(parsePtySize(MIN_PTY_COLS - 1, 32)).toBeNull();
+    expect(parsePtySize(96, MIN_PTY_ROWS - 1)).toBeNull();
+    expect(parsePtySize(MAX_PTY_COLS + 1, 32)).toBeNull();
+    expect(parsePtySize(96, MAX_PTY_ROWS + 1)).toBeNull();
+  });
+});

--- a/apps/server/src/tests/pty.smoke.test.ts
+++ b/apps/server/src/tests/pty.smoke.test.ts
@@ -42,4 +42,36 @@ describe.skipIf(!canRunPtyTests)("PTY smoke test", () => {
 
     expect(output).toContain("hello-pty-smoke");
   });
+
+  it.skipIf(process.platform === "win32")("updates the child terminal dimensions after resize", async () => {
+    const { createPTYManager } = await import("../pty/manager.js");
+    const manager = createPTYManager();
+    const ptyProcess = manager.spawn({
+      cmd: "bash",
+      args: ["--noprofile", "--norc"],
+      cwd: process.cwd(),
+    });
+
+    const output = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      const timeout = setTimeout(() => {
+        manager.kill();
+        reject(new Error("PTY resize timeout after 5s"));
+      }, 5000);
+
+      ptyProcess.onData((chunk) => {
+        data += chunk;
+        if (/32\s+96/.test(data)) {
+          clearTimeout(timeout);
+          manager.kill();
+          resolve(data);
+        }
+      });
+
+      manager.resize(96, 32);
+      manager.write("stty size\r");
+    });
+
+    expect(output).toMatch(/32\s+96/);
+  });
 });

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -16,6 +16,7 @@ export type {
   ProfileLLMProviders,
   ProfileSummary,
   ProviderName,
+  PtySize,
   SourceMode,
   SourceState,
   Style,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   type AttentionNotice,
 } from "./lib/event-notify";
 import type { CommentaryItem } from "./lib/log-filter";
+import { sendPtyResize } from "./lib/pty-resize";
 import {
   buildLaunchDraft,
   buildLaunchSessionInput,
@@ -33,6 +34,7 @@ import type {
   SourceState,
   Profile,
   ProfileSummary,
+  PtySize,
 } from "./types";
 
 const TauriStatusPanel = lazy(() => import("./components/TauriStatusPanel"));
@@ -80,6 +82,8 @@ export default function App() {
   });
   const pendingEditIdRef = useRef<string | null>(null);
   const terminalPaneRef = useRef<TerminalPaneHandle | null>(null);
+  const latestTerminalSizeRef = useRef<PtySize | null>(null);
+  const [ptyResizeSyncToken, setPtyResizeSyncToken] = useState(0);
 
   // Profile state
   const [profiles, setProfiles] = useState<ProfileSummary[]>([]);
@@ -215,6 +219,10 @@ export default function App() {
     setPendingTerminalOutput("");
   }, []);
 
+  const handlePtyRestart = useCallback(() => {
+    setPtyResizeSyncToken((value) => value + 1);
+  }, []);
+
   const handleCopySuggestion = async () => {
     const suggestion = normalizeSuggestion(ptyUnavailable?.suggestion);
     if (!suggestion) return;
@@ -251,8 +259,22 @@ export default function App() {
     stopAndClearSpeech,
     resetTTSLifecycleSession,
     onServerEvent: handleServerEvent,
+    onPtyRestart: handlePtyRestart,
     clearAttention,
   });
+
+  const handleTerminalResize = useCallback(
+    (size: PtySize) => {
+      latestTerminalSizeRef.current = size;
+      sendPtyResize(wsRef.current, size);
+    },
+    [wsRef]
+  );
+
+  useEffect(() => {
+    if (connectionStatus !== "connected") return;
+    sendPtyResize(wsRef.current, latestTerminalSizeRef.current);
+  }, [connectionStatus, ptyResizeSyncToken, wsRef]);
   const {
     handleSelectProfile,
     handleEditProfile,
@@ -370,6 +392,7 @@ export default function App() {
           currentSessionLabel={currentSessionLabel}
           pendingTerminalOutput={pendingTerminalOutput}
           onTerminalData={sendTerminalInput}
+          onTerminalResize={handleTerminalResize}
           onPendingOutputFlushed={handlePendingTerminalOutputFlushed}
           onClearTerminal={clearTerminal}
           profiles={profiles}

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -3,6 +3,7 @@ import "xterm/css/xterm.css";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 import { createTerminalInputGate } from "../lib/terminal-input";
+import type { PtySize } from "../types";
 
 const TERMINAL_OUTPUT_MAX_CHARS = 24000;
 
@@ -23,6 +24,7 @@ export type TerminalPaneHandle = {
 type TerminalPaneProps = {
   className: string;
   onData: (data: string) => void;
+  onResize: (size: PtySize) => void;
   onPendingOutputFlushed: () => void;
   pendingOutput: string;
   theme: TerminalPaneTheme;
@@ -33,7 +35,7 @@ function trimTerminalOutput(value: string): string {
 }
 
 const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function TerminalPane(
-  { className, onData, onPendingOutputFlushed, pendingOutput, theme },
+  { className, onData, onResize, onPendingOutputFlushed, pendingOutput, theme },
   ref
 ) {
   const hostRef = useRef<HTMLDivElement | null>(null);
@@ -78,6 +80,7 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
 
     let disposed = false;
     let frameId: number | null = null;
+    let lastReportedSize = "";
 
     const fitAddon = new FitAddon();
     const terminal = new Terminal({
@@ -90,6 +93,13 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
       theme,
     });
 
+    const reportSize = (cols: number, rows: number) => {
+      const sizeKey = `${cols}x${rows}`;
+      if (lastReportedSize === sizeKey) return;
+      lastReportedSize = sizeKey;
+      onResize({ cols, rows });
+    };
+
     const scheduleFit = () => {
       if (disposed) return;
       if (frameId !== null) {
@@ -100,6 +110,8 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
         if (disposed) return;
         try {
           fitAddon.fit();
+          reportSize(terminal.cols, terminal.rows);
+          terminal.refresh(0, Math.max(0, terminal.rows - 1));
           terminal.focus();
         } catch (error) {
           if (import.meta.env.DEV) {
@@ -111,6 +123,9 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
 
     terminal.loadAddon(fitAddon);
     terminal.open(host);
+    const resizeDisposable = terminal.onResize(({ cols, rows }) => {
+      reportSize(cols, rows);
+    });
     scheduleFit();
 
     terminal.onData((data) => {
@@ -155,6 +170,7 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
         window.cancelAnimationFrame(frameId);
       }
       resizeObserver?.disconnect();
+      resizeDisposable.dispose();
       textarea?.removeEventListener("compositionstart", handleCompositionStart);
       textarea?.removeEventListener("compositionend", handleCompositionEnd);
       textarea?.removeEventListener("paste", handlePaste);
@@ -162,7 +178,7 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [onData, theme]);
+  }, [onData, onResize, theme]);
 
   useEffect(() => {
     const terminal = terminalRef.current;

--- a/apps/web/src/components/WorkspaceLeft.tsx
+++ b/apps/web/src/components/WorkspaceLeft.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, type Dispatch, type RefObject, type SetStateAction } from "react";
 import type { LaunchDraft, LaunchPresetId } from "../lib/session-launcher";
-import type { ProfileSummary, Style } from "../types";
+import type { ProfileSummary, PtySize, Style } from "../types";
 import { LauncherPanel } from "./LauncherPanel";
 import { ProfileSelector } from "./ProfileSelector";
 import type { TerminalPaneHandle, TerminalPaneTheme } from "./TerminalPane";
@@ -19,6 +19,7 @@ type WorkspaceLeftProps = {
   currentSessionLabel: string;
   pendingTerminalOutput: string;
   onTerminalData: (data: string) => void;
+  onTerminalResize: (size: PtySize) => void;
   onPendingOutputFlushed: () => void;
   onClearTerminal: () => void;
   profiles: ProfileSummary[];
@@ -41,6 +42,7 @@ export function WorkspaceLeft({
   currentSessionLabel,
   pendingTerminalOutput,
   onTerminalData,
+  onTerminalResize,
   onPendingOutputFlushed,
   onClearTerminal,
   profiles,
@@ -93,6 +95,7 @@ export function WorkspaceLeft({
             ref={terminalPaneRef}
             className="terminal-panel__screen terminal-panel__screen--xterm"
             onData={onTerminalData}
+            onResize={onTerminalResize}
             onPendingOutputFlushed={onPendingOutputFlushed}
             pendingOutput={pendingTerminalOutput}
             theme={terminalTheme}

--- a/apps/web/src/hooks/useCommentatorSocket.ts
+++ b/apps/web/src/hooks/useCommentatorSocket.ts
@@ -45,6 +45,7 @@ type UseCommentatorSocketOptions = {
   stopAndClearSpeech: () => void;
   resetTTSLifecycleSession: (trigger: string) => void;
   onServerEvent: (ev: Event) => void;
+  onPtyRestart: () => void;
   clearAttention: () => void;
 };
 
@@ -85,6 +86,7 @@ export function useCommentatorSocket({
   stopAndClearSpeech,
   resetTTSLifecycleSession,
   onServerEvent,
+  onPtyRestart,
   clearAttention,
 }: UseCommentatorSocketOptions) {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("connecting");
@@ -120,9 +122,6 @@ export function useCommentatorSocket({
       ws.onopen = () => {
         if (cancelled || wsRef.current !== ws) return;
         console.log("WebSocket connected");
-        setConnectionStatus("connected");
-        setProfileError(null); // Clear WS offline error on reconnect
-        reconnectAttemptRef.current = 0;
       };
 
       ws.onmessage = (e) => {
@@ -133,6 +132,9 @@ export function useCommentatorSocket({
 
           switch (message.kind) {
             case "hello":
+              setConnectionStatus("connected");
+              setProfileError(null);
+              reconnectAttemptRef.current = 0;
               setStyle(message.style);
               setSource(message.source);
               break;
@@ -217,6 +219,7 @@ export function useCommentatorSocket({
               setProfileError(null);
               setPtyError(null);
               setCurrentSessionLabel([message.cmd, ...message.args].filter(Boolean).join(" ") || "session");
+              onPtyRestart();
               break;
             case "ptyError":
               setPtyError(message.error);
@@ -285,6 +288,7 @@ export function useCommentatorSocket({
     clearPendingSpeech,
     clearTerminal,
     onServerEvent,
+    onPtyRestart,
     pendingEditIdRef,
     profilesRef,
     queueSpeech,

--- a/apps/web/src/lib/pty-resize.test.ts
+++ b/apps/web/src/lib/pty-resize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendPtyResize } from "./pty-resize";
+
+describe("sendPtyResize", () => {
+  it("sends the latest terminal dimensions over an open socket", () => {
+    const send = vi.fn();
+
+    expect(sendPtyResize({ readyState: 1, send }, { cols: 96, rows: 32 })).toBe(true);
+    expect(send).toHaveBeenCalledWith(JSON.stringify({ kind: "resizePty", cols: 96, rows: 32 }));
+  });
+
+  it("waits when the socket or dimensions are unavailable", () => {
+    const send = vi.fn();
+
+    expect(sendPtyResize(null, { cols: 96, rows: 32 })).toBe(false);
+    expect(sendPtyResize({ readyState: 0, send }, { cols: 96, rows: 32 })).toBe(false);
+    expect(sendPtyResize({ readyState: 1, send }, null)).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/pty-resize.ts
+++ b/apps/web/src/lib/pty-resize.ts
@@ -1,0 +1,13 @@
+import type { PtySize, WsIncoming } from "../types";
+
+type ResizeSocket = Pick<WebSocket, "readyState" | "send">;
+
+const WEB_SOCKET_OPEN = 1;
+
+export function sendPtyResize(socket: ResizeSocket | null, size: PtySize | null): boolean {
+  if (!socket || socket.readyState !== WEB_SOCKET_OPEN || !size) return false;
+
+  const message: WsIncoming = { kind: "resizePty", cols: size.cols, rows: size.rows };
+  socket.send(JSON.stringify(message));
+  return true;
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -15,6 +15,7 @@ export type {
   ProfileLLMProviders,
   ProfileSummary,
   ProviderName,
+  PtySize,
   SourceMode,
   SourceState,
   Style,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -121,6 +121,11 @@ export type LaunchSessionInput = {
   logSource?: SourceMode;
 };
 
+export type PtySize = {
+  cols: number;
+  rows: number;
+};
+
 export type WsOutgoing =
   | { kind: "hello"; style: Style; source: SourceState }
   | { kind: "style"; style: Style }
@@ -141,6 +146,7 @@ export type WsIncoming =
   | { kind: "setStyle"; style: Style }
   | { kind: "launchSession"; session: LaunchSessionInput }
   | { kind: "writeInput"; data: string }
+  | ({ kind: "resizePty" } & PtySize)
   | { kind: "getProfiles" }
   | { kind: "getProfile"; id: string }
   | { kind: "saveProfile"; profile: CreateProfileInput & { id?: string } }


### PR DESCRIPTION
## 結果

Managed Terminal の実際の列数・行数をサーバー側PTYへ同期し、ウィンドウ変更後に端末を再描画するよう修正しました。

Closes #395

## HUMAN向け解説

これまで画面側とClaude Code側で「端末の横幅・高さ」の認識がずれていたため、長い行の折り返し位置が合わず、文字や罫線が重なっていました。

この変更では、画面の大きさをClaude Code側にも通知します。実機で長文表示とフルスクリーン切り替えを確認し、文字の重なりや残像が出ないことを確認しました。

このPRはDraftです。自動テストと実機確認は合格していますが、マージはHUMANレビュー後に行ってください。マージ後は修正版 v0.2.2 のビルド・配布確認が次の作業です。

## 変更内容

- xterm のサイズ変更を検知し、列数・行数をWebSocketで通知
- サーバーでサイズを検証し、稼働中PTYへ反映
- PTY再起動・WebSocket再接続時に最新サイズを再送
- fit後に表示行を再描画
- 単体・スモーク・実サーバーWebSocket統合テストを追加

## 検証

- Server: 57 files / 866 tests passed
- Web: 12 files / 104 tests passed
- PTY resize integration: 3回連続 passed
- Server/Web typecheck: passed
- Web lint/build、Server build: passed
- Phase B snapshot: MATCH
- Internal release verification: ALL CHECKS PASSED
- 実アプリ: PTYが実画面の 81×27 を認識
- Claude Code TUI: 長文の折り返し、フルスクリーン後の再描画とも合格
- 公式 v0.2.1 アプリはテスト後に復元済み

## 次にお願いしたいこと

1. Draft PRの内容をHUMANレビュー
2. 問題なければマージ
3. マージ後に v0.2.2 をビルドして配布前確認