### PR TITLE
fix(desktop): Managed Terminal のHUMANテスト不合格を解消

### DIFF
--- a/apps/server/src/commentary/narration-subject.test.ts
+++ b/apps/server/src/commentary/narration-subject.test.ts
@@ -189,4 +189,24 @@ describe("narration with a subject", () => {
       "ファイルを読んで状況を確認しています。"
     );
   });
+
+  it("describes silent waiting without claiming an unknown target is being handled", () => {
+    const waitingEvent: Event = {
+      ts: 1,
+      type: "stdout",
+      summary: "長考・沈黙が続いている",
+      detail: "60000ms outputなし",
+    };
+    const context = createSessionContext();
+    context.setTaskContext({ objective: "動作を確認する", source: "fixture" });
+    context.observeEvent(event("search", "rg context src"));
+    const snapshot = context.observeEvent(waitingEvent);
+
+    const payload = commentByRules(waitingEvent, "kansai", snapshot);
+    expect(payload.narration).toContain("次の出力を待ってる");
+    expect(payload.narration).not.toContain("対象を扱ってる");
+    expect(payload.explanation).toBe(
+      "エラーではありません。処理を続けながら、次の出力を待っている状態です。"
+    );
+  });
 });

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -88,6 +88,13 @@ function contextNarration(context: SessionContextSnapshot, style: Style): string
         zundamon: `${phase}段階に入って、HUMANの入力待ちなのだ。`,
       });
     }
+    if (context.phase === "waiting") {
+      return say(style, {
+        standard: "処理は続いています。次の出力を待っています。",
+        kansai: "処理は続いてるで。次の出力を待ってるところや。",
+        zundamon: "処理は続いているのだ。次の出力を待っているのだ。",
+      });
+    }
     return say(style, {
       standard: `${phase}段階に入り、${target}を扱っています。`,
       kansai: `${phase}段階に入って、${target}を扱ってるで。`,
@@ -121,6 +128,11 @@ function contextExplanation(
 
   const phase = SESSION_PHASE_LABELS[context.phase];
   const objective = context.task.objective;
+  if (context.phase === "waiting" && context.phaseChanged) {
+    return context.humanRequired
+      ? "作業を進めるには、ターミナルでの入力が必要です。"
+      : "エラーではありません。処理を続けながら、次の出力を待っている状態です。";
+  }
   if (objective && context.phaseChanged) {
     const purpose = objective.length <= 32 ? objective : `${objective.slice(0, 31).trimEnd()}…`;
     return `目的「${purpose}」に向けた${phase}段階です。`;

--- a/apps/server/src/session-context.test.ts
+++ b/apps/server/src/session-context.test.ts
@@ -50,6 +50,29 @@ describe("SessionContext", () => {
     });
   });
 
+  it("does not turn terminal mouse reports into a task objective", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true });
+    context.observeInput("\u001b[<35;70;35M\u001b[<35;68;36M");
+    context.observeInput("実況の流れを確認してください\r");
+
+    expect(context.snapshot().task).toMatchObject({
+      objective: "実況の流れを確認してください",
+      userPrompt: "実況の流れを確認してください",
+      source: "human_input",
+    });
+  });
+
+  it("strips terminal escapes from explicitly supplied task context", () => {
+    const context = createSessionContext();
+    context.setTaskContext({
+      objective: "\u001b[<35;70;35M安全に確認する",
+      source: "human_log",
+    });
+
+    expect(context.snapshot().task.objective).toBe("安全に確認する");
+  });
+
   it("does not accept input when the session is not a trusted human-prompt CLI", () => {
     const context = createSessionContext();
     context.observeInput("もっともらしい目的\n");

--- a/apps/server/src/session-context.ts
+++ b/apps/server/src/session-context.ts
@@ -3,6 +3,7 @@ import { tokenizeShellCommand, unwrapCommandDetail } from "./command-analysis.js
 import { redact } from "./redact.js";
 import { getEventPriority } from "./event-priority.js";
 import { getGlossaryNotes } from "./commentary/glossary.js";
+import { stripTerminalEscapes } from "./terminal-escapes.js";
 
 export type SessionPhase =
   | "unknown"
@@ -90,7 +91,12 @@ export const SESSION_PHASE_LABELS: Record<SessionPhase, string> = {
 };
 
 function limited(value: string | null | undefined, max: number): string | null {
-  const compact = redact(value ?? "").replace(/\s+/g, " ").trim();
+  const compact = redact(stripTerminalEscapes(value ?? ""))
+    // Terminal input can contain mouse reports and other control bytes. They
+    // are meaningful to the PTY, but must never become HUMAN-facing context.
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
   if (!compact) return null;
   return compact.length <= max ? compact : `${compact.slice(0, max - 1).trimEnd()}…`;
 }
@@ -342,7 +348,7 @@ function resumeFromHumanResponse(state: MutableState): void {
 
 function appendTerminalInput(buffer: string, data: string): string {
   let next = buffer;
-  const clean = data.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+  const clean = stripTerminalEscapes(data);
   for (const char of clean) {
     if (char === "\u0003" || char === "\u0015") {
       next = "";

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -312,6 +312,33 @@
   align-items: center;
 }
 
+.terminal-panel__input-status {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 4px;
+  color: var(--color-fg-muted);
+  font-size: var(--text-xs);
+}
+
+.terminal-panel__input-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--color-fg-muted);
+}
+
+.terminal-panel__input-status--active {
+  color: var(--color-success);
+  font-weight: var(--font-bold);
+}
+
+.terminal-panel__input-status--active .terminal-panel__input-dot {
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 18%, transparent);
+}
+
 /* Debug Panel */
 .debug-panel {
   position: fixed;
@@ -327,6 +354,44 @@
   width: min(360px, calc(100vw - 24px));
   text-align: left;
   box-shadow: var(--shadow-lg);
+}
+
+.debug-panel--collapsed {
+  width: auto;
+  max-width: calc(100vw - 24px);
+  padding: 0;
+}
+
+.debug-panel__summary-button {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: var(--text-sm);
+}
+
+.debug-panel__summary-action {
+  color: var(--color-fg-tertiary);
+  font-size: var(--text-xs);
+}
+
+.debug-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.debug-panel__collapse-button {
+  padding: 2px 4px;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--text-xs);
+  text-decoration: underline;
 }
 
 .debug-panel__title {
@@ -561,6 +626,11 @@
     bottom: var(--space-2);
     left: var(--space-2);
     right: var(--space-2);
+    width: auto;
+  }
+
+  .debug-panel--collapsed {
+    left: auto;
     width: auto;
   }
 }
@@ -1118,4 +1188,14 @@
   background: var(--color-bg-tertiary);
   border-radius: var(--radius-sm);
   padding: 0 var(--space-1);
+}
+
+.notice__next-action {
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-danger) 8%, transparent);
+  color: var(--color-fg-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
 }

--- a/apps/web/src/components/Notices.tsx
+++ b/apps/web/src/components/Notices.tsx
@@ -41,7 +41,8 @@ export function Notices({
               </div>
               <div className="notice__body">
                 <p>
-                  CLI が入力を待っている可能性があります。左のターミナルを確認してください。
+                  CLI が入力を待っている可能性があります。左のターミナルをクリックし、
+                  「入力受付中」を確認してから回答を入力し、Enter キーを押してください。
                   <span className="notice__time">
                     （{new Date(attention.ts).toLocaleTimeString()} 検出）
                   </span>
@@ -96,12 +97,18 @@ export function Notices({
         <div className="notice notice--error panel">
           <div className="notice__title">プロファイルエラー</div>
           <div className="notice__body">{profileError}</div>
+          <div className="notice__next-action">
+            次の操作：起動設定のコマンドと作業フォルダを見直し、「セッション起動」を再実行してください。
+          </div>
         </div>
       )}
       {ptyError && (
         <div className="notice notice--error panel">
           <div className="notice__title">PTYエラー</div>
           <div className="notice__body">{ptyError}</div>
+          <div className="notice__next-action">
+            次の操作：接続状態を確認し、左上の「セッション起動」を再実行してください。直らない場合は Desktop Server の詳細を開き、Retry Start を押してください。
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/TauriStatusPanel.tsx
+++ b/apps/web/src/components/TauriStatusPanel.tsx
@@ -51,6 +51,7 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
   const [diagnostics, setDiagnostics] = useState<DesktopDiagnostics | null>(null);
   const [copiedDiagnosticAction, setCopiedDiagnosticAction] = useState<string | null>(null);
   const [copiedRecoveryCommand, setCopiedRecoveryCommand] = useState<string | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(true);
 
   useEffect(() => {
     if (!isTauri) {
@@ -325,9 +326,38 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
       .join("\n");
   };
 
+  if (isCollapsed && state !== "failed" && !invokeError) {
+    return (
+      <div className="debug-panel debug-panel--collapsed">
+        <button
+          type="button"
+          className="debug-panel__summary-button"
+          onClick={() => setIsCollapsed(false)}
+          aria-expanded="false"
+        >
+          <span>Desktop Server</span>
+          <span className="debug-panel__badge" style={{ color: getStateColor(state) }}>
+            {DESKTOP_STATE_LABEL[state]}
+          </span>
+          <span className="debug-panel__summary-action">詳細</span>
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="debug-panel">
-      <div className="debug-panel__title">Desktop Server</div>
+      <div className="debug-panel__header">
+        <div className="debug-panel__title">Desktop Server</div>
+        <button
+          type="button"
+          className="debug-panel__collapse-button"
+          onClick={() => setIsCollapsed(true)}
+          aria-expanded="true"
+        >
+          折りたたむ
+        </button>
+      </div>
       <p className="debug-panel__hint">{stateMessage}</p>
 
       {status && (

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -24,6 +24,7 @@ export type TerminalPaneHandle = {
 type TerminalPaneProps = {
   className: string;
   onData: (data: string) => void;
+  onFocusChange: (focused: boolean) => void;
   onResize: (size: PtySize) => void;
   onPendingOutputFlushed: () => void;
   pendingOutput: string;
@@ -35,7 +36,7 @@ function trimTerminalOutput(value: string): string {
 }
 
 const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function TerminalPane(
-  { className, onData, onResize, onPendingOutputFlushed, pendingOutput, theme },
+  { className, onData, onFocusChange, onResize, onPendingOutputFlushed, pendingOutput, theme },
   ref
 ) {
   const hostRef = useRef<HTMLDivElement | null>(null);
@@ -143,10 +144,14 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
     const handlePaste = () => {
       terminalInputGateRef.current.notePaste();
     };
+    const handleFocus = () => onFocusChange(true);
+    const handleBlur = () => onFocusChange(false);
 
     textarea?.addEventListener("compositionstart", handleCompositionStart);
     textarea?.addEventListener("compositionend", handleCompositionEnd);
     textarea?.addEventListener("paste", handlePaste);
+    textarea?.addEventListener("focus", handleFocus);
+    textarea?.addEventListener("blur", handleBlur);
 
     if (backlogRef.current) {
       terminal.write(backlogRef.current);
@@ -174,11 +179,13 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
       textarea?.removeEventListener("compositionstart", handleCompositionStart);
       textarea?.removeEventListener("compositionend", handleCompositionEnd);
       textarea?.removeEventListener("paste", handlePaste);
+      textarea?.removeEventListener("focus", handleFocus);
+      textarea?.removeEventListener("blur", handleBlur);
       terminal.dispose();
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [onData, onResize, theme]);
+  }, [onData, onFocusChange, onResize, theme]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -197,8 +204,9 @@ const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(function 
     <div
       ref={hostRef}
       className={className}
-      onClick={() => terminalRef.current?.focus()}
-      role="presentation"
+      onMouseDown={() => terminalRef.current?.focus()}
+      aria-label="Managed Terminal の入力欄"
+      role="group"
     />
   );
 });

--- a/apps/web/src/components/WorkspaceLeft.tsx
+++ b/apps/web/src/components/WorkspaceLeft.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, type Dispatch, type RefObject, type SetStateAction } from "react";
+import { Suspense, lazy, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
 import type { LaunchDraft, LaunchPresetId } from "../lib/session-launcher";
 import type { ProfileSummary, PtySize, Style } from "../types";
 import { LauncherPanel } from "./LauncherPanel";
@@ -52,6 +52,13 @@ export function WorkspaceLeft({
   onCreateProfile,
   onDeleteProfile,
 }: WorkspaceLeftProps) {
+  const [terminalFocused, setTerminalFocused] = useState(false);
+  const inputStatus = !connected
+    ? "サーバー未接続（入力できません）"
+    : terminalFocused
+      ? "入力受付中（キーボードで直接入力できます）"
+      : "ターミナル内をクリックして入力";
+
   return (
     <div className="workspace-column workspace-column--left">
       <LauncherPanel
@@ -68,7 +75,14 @@ export function WorkspaceLeft({
           <div>
             <div className="terminal-panel__title">Managed Terminal</div>
             <div className="terminal-panel__hint">
-              現在のセッション: {currentSessionLabel} {connected ? " / 直接入力できます" : ""}
+              現在のセッション: {currentSessionLabel}
+            </div>
+            <div
+              className={`terminal-panel__input-status ${connected && terminalFocused ? "terminal-panel__input-status--active" : ""}`}
+              role="status"
+            >
+              <span className="terminal-panel__input-dot" aria-hidden="true" />
+              {inputStatus}
             </div>
           </div>
           <div className="terminal-panel__actions">
@@ -95,6 +109,7 @@ export function WorkspaceLeft({
             ref={terminalPaneRef}
             className="terminal-panel__screen terminal-panel__screen--xterm"
             onData={onTerminalData}
+            onFocusChange={setTerminalFocused}
             onResize={onTerminalResize}
             onPendingOutputFlushed={onPendingOutputFlushed}
             pendingOutput={pendingTerminalOutput}


### PR DESCRIPTION
## 結果

Managed Terminal の HUMAN ユーザーテストで見つかった6件をまとめて改善します。

- Desktop Server パネルを通常時はコンパクト表示にし、必要なときだけ展開
- ターミナルのフォーカス状態を「入力受付中／クリックして入力／未接続」で明示
- クリック時にターミナルへフォーカスし、実際にキーボード入力できることをローカル実画面で確認
- HUMAN入力待ちではない沈黙を「次の出力を待っている」と明確化
- SGRマウス制御コードをタスク文脈から除去し、優しい解説への文字化け混入を防止
- PTY／プロファイルエラーに具体的な次の操作を追加

改行・折り返しについては main に入った #396 のPTYサイズ同期を前提とし、本PRの実画面確認でも `stty size` が画面幅に応じた `30 100` を返すことを確認しました。

## 原因

- v0.2.1 にはPTYサイズ同期が未収録
- xtermのマウス報告 `ESC[<...M` がHUMAN入力としてセッション目的へ混入
- 沈黙による待機とHUMAN入力待ちが同じ文型になっていた
- 固定配置の診断パネルと、入力状態を示さないターミナルUIが実況・操作を分かりにくくしていた

## HUMAN向け解説

利用者が「今は待てばよいのか、入力が必要なのか」「ターミナルに入力できる状態か」「エラー後に何をすればよいか」を画面だけで判断できるようにする修正です。通常時の診断パネルは小さくなるため、実況欄も隠れにくくなります。

## 検証

- Server: 48 suites / 659 tests passed
- Web: 12 suites / 104 tests passed
- Server build passed
- Web build passed
- Web ESLint passed
- `git diff --check` passed
- ローカル実画面: フォーカス表示切替、ターミナル入力、PTY `30 100` 同期、ブラウザコンソールエラー0件

## 次にお願いしたいこと

修正版デスクトップアプリで HUMAN ユーザーテスト「1. Managed Terminal」を再実施し、6項目が解消したか確認してください。

Closes #399