### PR TITLE
fix(commentary): distinguish historical failure prose from current errors

### DIFF
--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -5,7 +5,7 @@ const CLAUDE_COMMAND_RE = /^⎿\s*\$\s*\S/u;
 const CLAUDE_ASSISTANT_RE = /^⏺\s*(?!Read\(|Glob\(|Grep\(|Update\(|Edit\(|Write\(|Bash\()[\p{L}\p{N}]/u;
 const CLAUDE_SUMMARY_RE = /^Listed \d+ director(?:y|ies), ran \d+ shell commands?$/iu;
 const CLAUDE_CURRENT_ERROR_RE =
-  /\b(?:execution error|uncaught exception|failed with exit code|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|\bTS\d{4,5}:/i;
+  /\b(?:execution error|uncaught exception|failed with exit code|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|^\s*(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*(?:Error|Exception):\s|\bTS\d{4,5}:/i;
 
 export const claudeRuleset: RuleSet = {
   id: "claude",

--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -4,6 +4,8 @@ import { isFileListExecution, isSearchExecution, isTestExecution } from "../comm
 const CLAUDE_COMMAND_RE = /^⎿\s*\$\s*\S/u;
 const CLAUDE_ASSISTANT_RE = /^⏺\s*(?!Read\(|Glob\(|Grep\(|Update\(|Edit\(|Write\(|Bash\()[\p{L}\p{N}]/u;
 const CLAUDE_SUMMARY_RE = /^Listed \d+ director(?:y|ies), ran \d+ shell commands?$/iu;
+const CLAUDE_CURRENT_ERROR_RE =
+  /\b(?:execution error|uncaught exception|failed with exit code|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|\bTS\d{4,5}:/i;
 
 export const claudeRuleset: RuleSet = {
   id: "claude",
@@ -38,6 +40,6 @@ export const claudeRuleset: RuleSet = {
     { id: "claude.command", priority: 15, re: CLAUDE_COMMAND_RE, type: "stdout", summary: "コマンドを実行している" },
 
     { id: "claude.readonly", priority: 12, re: /\bread[-\s]?only mode\b|\bwrite is disabled\b/i, type: "error", summary: "書き込みが制限されている" },
-    { id: "claude.error", priority: 10, re: /execution error|error|failed|exception|TS\d{5}/i, type: "error", summary: "エラーが出ている" }
+    { id: "claude.error", priority: 10, re: CLAUDE_CURRENT_ERROR_RE, type: "error", summary: "エラーが出ている" }
   ]
 };

--- a/apps/server/src/rulesets/claude.ts
+++ b/apps/server/src/rulesets/claude.ts
@@ -5,7 +5,7 @@ const CLAUDE_COMMAND_RE = /^⎿\s*\$\s*\S/u;
 const CLAUDE_ASSISTANT_RE = /^⏺\s*(?!Read\(|Glob\(|Grep\(|Update\(|Edit\(|Write\(|Bash\()[\p{L}\p{N}]/u;
 const CLAUDE_SUMMARY_RE = /^Listed \d+ director(?:y|ies), ran \d+ shell commands?$/iu;
 const CLAUDE_CURRENT_ERROR_RE =
-  /\b(?:execution error|uncaught exception|failed with exit code|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|^\s*(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*(?:Error|Exception):\s|\bTS\d{4,5}:/i;
+  /\b(?:execution error|uncaught exception|failed with exit code|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|^\s*(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*(?:Error|Exception):\s|^(?:tests?|test files?|suites?|specs?)\b[^\n]*?\b(?!0+\b)\d+\s+failed\b|\bproblems?\s*\(\s*(?!0+\b)\d+\s+errors?\b|\bexited with (?:code|status)\s+(?!0+\b)\d+\b|\bTS\d{4,5}:/i;
 
 export const claudeRuleset: RuleSet = {
   id: "claude",

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -73,6 +73,23 @@ describe("Claude TUI supervision detection", () => {
     ]);
   });
 
+  it("distinguishes historical failure prose from a current error", () => {
+    expect(extractEvents("The previous attempt failed, so I changed the approach.", "claude")).toEqual([]);
+    expect(extractEvents("Error: the current command failed.", "claude")).toEqual([
+      expect.objectContaining({ type: "error", summary: "エラーが出ている" }),
+    ]);
+  });
+
+  it("does not treat a HUMAN input prompt as an error", () => {
+    expect(extractEvents(loadChunks("question.json"), "claude")).toEqual([
+      expect.objectContaining({ type: "stdout", summary: "質問への回答を待っている" }),
+    ]);
+  });
+
+  it("does not treat a warning-only line as an error", () => {
+    expect(extractEvents("Warning: this option is deprecated.", "claude")).toEqual([]);
+  });
+
   it.each([
     "The documentation explains when approval is required.",
     "The task is complete only after a reviewer approves it.",

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -75,7 +75,15 @@ describe("Claude TUI supervision detection", () => {
 
   it("distinguishes historical failure prose from a current error", () => {
     expect(extractEvents("The previous attempt failed, so I changed the approach.", "claude")).toEqual([]);
-    expect(extractEvents("Error: the current command failed.", "claude")).toEqual([
+  });
+
+  it.each([
+    "Error: the current command failed.",
+    "TypeError: Cannot read properties of undefined",
+    "ReferenceError: value is not defined",
+    "SyntaxError: Unexpected token",
+  ])("detects a structured current error: %s", (line) => {
+    expect(extractEvents(line, "claude")).toEqual([
       expect.objectContaining({ type: "error", summary: "エラーが出ている" }),
     ]);
   });

--- a/apps/server/src/tests/claude.supervision.test.ts
+++ b/apps/server/src/tests/claude.supervision.test.ts
@@ -82,10 +82,23 @@ describe("Claude TUI supervision detection", () => {
     "TypeError: Cannot read properties of undefined",
     "ReferenceError: value is not defined",
     "SyntaxError: Unexpected token",
+    "Tests: 2 failed, 5 passed",
+    "Test Files  1 failed (1)",
+    "✖ 3 problems (3 errors, 0 warnings)",
+    "Process exited with code 1",
   ])("detects a structured current error: %s", (line) => {
     expect(extractEvents(line, "claude")).toEqual([
       expect.objectContaining({ type: "error", summary: "エラーが出ている" }),
     ]);
+  });
+
+  it.each([
+    "Tests: 0 failed, 7 passed",
+    "Test Files  0 failed (7)",
+    "✖ 3 problems (0 errors, 3 warnings)",
+    "Process exited with code 0",
+  ])("does not detect a zero-failure summary: %s", (line) => {
+    expect(extractEvents(line, "claude")).toEqual([]);
   });
 
   it("does not treat a HUMAN input prompt as an error", () => {


### PR DESCRIPTION
🧑 HUMAN向け（先に読む）
・やったこと: 過去の失敗説明を、いま起きているエラーとして扱わないよう修正しました。
・なぜ必要か: 正常な説明に誤った「要対応」が出るのを防ぎ、実際のエラーだけを知らせるためです。
・あなたの操作: この下書きの変更内容を開き、過去の失敗説明と現在のエラーの見分け方が意図どおりか確認してください。

## 結果

Claudeの出力に単語 `failed` が含まれるだけでは、現在のエラーとして扱わなくなりました。現在の失敗は、エラーの明示、終了コード、command not found、TypeScriptエラーなど、実行中の失敗と判断できる形だけを検出します。

## 変更点

- Claude rulesetの包括的な単語一致を、現在のエラーを示す明示的な形式へ限定
- 過去の失敗説明、現在の実エラー、HUMAN入力待ち、警告のみを分ける回帰テストを追加
- バナーUI、TTS、解説カード、原文表示、レイアウトは変更なし

## 検証

修正前に追加テストが失敗し、過去の説明文をエラーにしていたことを再現しました。修正後は次を実行して成功しています。

- `pnpm -C apps/server test -- src/tests/claude.supervision.test.ts`
- `pnpm -C apps/server test`
- `pnpm -C apps/server exec tsc --noEmit`
- `pnpm -C apps/server build`
- `git diff --check`

## HUMANが確認する点

- 過去の失敗を説明する正常文で「要対応」が出ないこと
- 現在の明示的なエラーは従来どおり検出されること
- Issue #401以外の表示・読み上げ・レイアウト変更が混ざっていないこと

Closes #401