### PR TITLE
fix(web): 分割マウス報告の実況混入を防ぐ

### DIFF
--- a/apps/server/src/session-context.test.ts
+++ b/apps/server/src/session-context.test.ts
@@ -63,6 +63,34 @@ describe("SessionContext", () => {
     });
   });
 
+  it("does not leak split terminal mouse reports into a task objective", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true });
+    context.observeInput("\u001b[<35;1");
+    context.observeInput("06;28M\u001b[<35;108;");
+    context.observeInput("28M実況の流れを確認してください\r");
+
+    expect(context.snapshot().task).toMatchObject({
+      objective: "実況の流れを確認してください",
+      userPrompt: "実況の流れを確認してください",
+      source: "human_input",
+    });
+  });
+
+  it("does not treat a split terminal mouse report followed by Enter as a new task", () => {
+    const context = createSessionContext();
+    context.reset({ acceptsHumanInput: true });
+    context.observeInput("\u001b[<35;106;");
+    const result = context.observeInput("28M\r");
+
+    expect(result).toEqual({ newTask: false });
+    expect(context.snapshot().task).toMatchObject({
+      objective: null,
+      userPrompt: null,
+      source: null,
+    });
+  });
+
   it("strips terminal escapes from explicitly supplied task context", () => {
     const context = createSessionContext();
     context.setTaskContext({

--- a/apps/server/src/session-context.ts
+++ b/apps/server/src/session-context.ts
@@ -3,7 +3,7 @@ import { tokenizeShellCommand, unwrapCommandDetail } from "./command-analysis.js
 import { redact } from "./redact.js";
 import { getEventPriority } from "./event-priority.js";
 import { getGlossaryNotes } from "./commentary/glossary.js";
-import { stripTerminalEscapes } from "./terminal-escapes.js";
+import { createEscapeCarry, stripTerminalEscapes } from "./terminal-escapes.js";
 
 export type SessionPhase =
   | "unknown"
@@ -371,6 +371,7 @@ export function createSessionContext(options?: {
   const progressSpeechIntervalMs =
     options?.progressSpeechIntervalMs ?? DEFAULT_PROGRESS_SPEECH_INTERVAL_MS;
   let state = initialState();
+  let carryInputEscape = createEscapeCarry();
 
   return {
     setTaskContext(input) {
@@ -387,7 +388,7 @@ export function createSessionContext(options?: {
     observeInput(data) {
       if (!state.acceptsHumanInput || state.task.source === "fixture") return { newTask: false };
       let newTask = false;
-      state.inputBuffer = appendTerminalInput(state.inputBuffer, data);
+      state.inputBuffer = appendTerminalInput(state.inputBuffer, carryInputEscape(data));
       if (state.inputBuffer.length > MAX_INPUT_BUFFER_LENGTH) {
         state.inputBuffer = state.inputBuffer.slice(-MAX_INPUT_BUFFER_LENGTH);
       }
@@ -477,6 +478,7 @@ export function createSessionContext(options?: {
 
     reset(resetOptions) {
       state = initialState();
+      carryInputEscape = createEscapeCarry();
       state.acceptsHumanInput = resetOptions?.acceptsHumanInput ?? false;
       const presetName = limited(resetOptions?.presetName, MAX_CONTEXT_LENGTH);
       if (presetName) {


### PR DESCRIPTION
## HUMAN向け解説

結果: マウスを動かした情報が途中で分割されても、作業指示として取り込まれないようにしました。

HUMAN向け解説: これにより、マウス操作だけで実況の作業目的が入れ替わる誤動作を防ぎます。画面・音声・レイアウトは変更していません。

次にお願いしたいこと: 自動チェック完了後、Issue #415の範囲だけの変更になっているか確認してください。

## Summary

- 入力チャンク間で未完了のターミナルエスケープを保持し、次チャンクと結合してから除去
- SessionContextのreset時に入力側のcarry状態も初期化
- 分割マウス報告が指示文へ混入しないケースと、マウス報告＋Enterが新規タスクにならないケースを回帰テスト化
- docs更新は不要: 入力のエスケープ除去を既存の出力側方式へ揃える限定的な不具合修正で、公開仕様・設定・運用手順は変更しない

## Related Issues

Closes #415

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test Plan

- `pnpm -C apps/server exec vitest run src/session-context.test.ts`
- `pnpm -C apps/server test`
- `pnpm -C apps/server exec tsc --noEmit`
- `node --test ./scripts/check-doc-sync.test.mjs`
- `node ./scripts/check-doc-sync.mjs`
- `git diff --check`

すべてローカル合格。