### PR TITLE
test(commentary): add real classification regression cases

### DIFF
--- a/apps/server/src/tests/real-classification-regression.test.ts
+++ b/apps/server/src/tests/real-classification-regression.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it } from "vitest";
+import { extractEvents, resetExtractionState } from "../extract.js";
+import type { EventType, Source } from "../types.js";
+
+type ExpectedEvent = {
+  type: EventType;
+  summary: string;
+};
+
+type RegressionCase = {
+  id: string;
+  category: string;
+  source: Exclude<Source, "auto">;
+  provenance: string;
+  input: string;
+  expected: ExpectedEvent[];
+};
+
+type RegressionFixture = {
+  notice: string[];
+  observedPrefixes: Record<string, string[]>;
+  cases: RegressionCase[];
+};
+
+const fixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../test/fixtures/real-classification-regression.json"
+);
+
+function loadFixture(): RegressionFixture {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf8")) as RegressionFixture;
+}
+
+describe("real classification regression cases", () => {
+  beforeEach(() => {
+    resetExtractionState();
+  });
+
+  it("keeps the six HUMAN-requested categories in one provenance table", () => {
+    const fixture = loadFixture();
+
+    expect(fixture.cases.map(({ category }) => category)).toEqual([
+      "normal explanation",
+      "real error",
+      "HUMAN input wait",
+      "Git operation",
+      "command execution",
+      "long explanation",
+    ]);
+    expect(fixture.cases.every(({ provenance }) => provenance.length > 0)).toBe(true);
+    expect(fixture.observedPrefixes).toEqual({
+      humanManagedTerminal20260809: ["•", "└"],
+      existingSanitizedRealCaptures: ["⏺", "⎿"],
+    });
+  });
+
+  it.each(loadFixture().cases)("keeps $id classified by type", ({ source, input, expected }) => {
+    const actual = extractEvents(input, source).map(({ type, summary }) => ({ type, summary }));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("does not retain the local identity from the HUMAN capture", () => {
+    const raw = fs.readFileSync(fixturePath, "utf8");
+
+    expect(raw).not.toContain("/Users/home");
+    expect(raw).not.toContain("gatyoukatyou");
+    expect(raw).not.toMatch(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+    expect(raw).toContain("/Users/USER/PROJECT");
+  });
+});

--- a/apps/server/src/tests/real-classification-regression.test.ts
+++ b/apps/server/src/tests/real-classification-regression.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it } from "vitest";
 import { extractEvents, resetExtractionState } from "../extract.js";
-import type { EventType, Source } from "../types.js";
+import type { DetectedSource, EventType } from "../types.js";
 
 type ExpectedEvent = {
   type: EventType;
@@ -13,7 +13,7 @@ type ExpectedEvent = {
 type RegressionCase = {
   id: string;
   category: string;
-  source: Exclude<Source, "auto">;
+  source: DetectedSource;
   provenance: string;
   input: string;
   expected: ExpectedEvent[];

--- a/apps/server/test/fixtures/real-classification-regression.json
+++ b/apps/server/test/fixtures/real-classification-regression.json
@@ -1,0 +1,72 @@
+{
+  "notice": [
+    "Cases are minimal excerpts from HUMAN-observed Managed Terminal output or existing sanitized real TUI captures.",
+    "Local paths, timestamps, identifiers, and user-authored details were removed or replaced before committing."
+  ],
+  "observedPrefixes": {
+    "humanManagedTerminal20260809": ["•", "└"],
+    "existingSanitizedRealCaptures": ["⏺", "⎿"]
+  },
+  "cases": [
+    {
+      "id": "normal-explanation",
+      "category": "normal explanation",
+      "source": "codex",
+      "provenance": "HUMAN Managed Terminal capture 2026-08-09 (sanitized excerpt)",
+      "input": "• リポジトリのルートへ移動し、指定のマーカーとGitリモートで cli-commentator だと確認します。",
+      "expected": [
+        { "type": "stdout", "summary": "Codexが説明している" }
+      ]
+    },
+    {
+      "id": "real-error",
+      "category": "real error",
+      "source": "codex",
+      "provenance": "Existing sanitized Codex lifecycle-error capture",
+      "input": "Command failed with exit code 1",
+      "expected": [
+        { "type": "error", "summary": "終了コードで失敗している" }
+      ]
+    },
+    {
+      "id": "human-input-wait",
+      "category": "HUMAN input wait",
+      "source": "codex",
+      "provenance": "Existing sanitized Codex approval capture",
+      "input": "Would you like to run the following command?\npnpm test -- --runInBand",
+      "expected": [
+        { "type": "stdout", "summary": "コマンド実行の確認待ち" }
+      ]
+    },
+    {
+      "id": "git-operation",
+      "category": "Git operation",
+      "source": "codex",
+      "provenance": "Existing sanitized real Codex tool-call capture",
+      "input": "ToolCall: exec_command {\"cmd\":\"git status -sb\",\"workdir\":\"/Users/USER/PROJECT\"}",
+      "expected": [
+        { "type": "git", "summary": "Git操作をしている" }
+      ]
+    },
+    {
+      "id": "command-execution",
+      "category": "command execution",
+      "source": "codex",
+      "provenance": "HUMAN-observed commentary detail from Managed Terminal output 2026-08-09 (sanitized excerpt)",
+      "input": "⏺ Bash(pwd)",
+      "expected": [
+        { "type": "stdout", "summary": "コマンドを実行している" }
+      ]
+    },
+    {
+      "id": "long-explanation",
+      "category": "long explanation",
+      "source": "codex",
+      "provenance": "HUMAN Managed Terminal capture 2026-08-09 (sanitized excerpt)",
+      "input": "• 結論からいうと、cli-commentator は動くMVPが完成済みで、現在は日常的に安心して使えるデスクトップアプリへ仕上げている段階です。一般公開できる完成版には、まだ実機検証・使いやすさ改善・署名付き配布などが残っています。主要機能は揃っていますが、安心して一般公開するための品質確認と磨き込みを続けています。",
+      "expected": [
+        { "type": "stdout", "summary": "Codexが説明している" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 🧑 HUMAN向け（先に読む）
- やったこと: 実際の利用場面6種類を、今後の修正で取り違えないための自動確認を追加しました。
- なぜ必要か: 要対応表示などを直す際に、正常な説明をエラー扱いしたり、本当のエラーを見逃したりする退行を検知するためです。
- あなたの操作: CI完了後、このPRのfixtureに生ログや個人情報が残っていないことを確認し、merge可否を判断してください。

## 何をしたか

- 匿名化済みの実観測抜粋を1つのfixture表へ集約
- 次の6分類を現在の判定タイプで固定
  - 正常な説明
  - 実エラー
  - HUMAN入力待ち
  - Git操作
  - コマンド実行
  - 長文説明
- fixtureに生のローカルパス・Git接続先・メールアドレスが残らないことをテスト
- HUMAN観測の `•` / `└` と既存実キャプチャの `⏺` / `⎿` を由来情報として記録

## 変更しないもの

- 判定ロジック
- 実況文言
- TTS
- バナーUI
- レイアウト

今回見つかったUI・誤判定の問題は、このPRへ混ぜず別Issueで扱います。

## 検証

- `real-classification-regression.test.ts`: 8 tests passed
- server TypeScript build: passed
- 差分: fixture 1ファイル + テスト 1ファイルのみ
- ローカルの全serverテストは環境依存の `node-pty` ネイティブ部品が未ビルドのため完走できず。Draft PRのCIで既存テスト全体を確認する

Closes #405