### PR TITLE
fix(desktop): keep managed server alive after terminal interrupt

### DIFF
--- a/apps/desktop/src-tauri/src/server.rs
+++ b/apps/desktop/src-tauri/src/server.rs
@@ -18,6 +18,7 @@ use process_wrap::std::ProcessGroup;
 use process_wrap::std::JobObject;
 
 const DEFAULT_PORT: u16 = 8787;
+const MANAGED_SERVER_ENV: &str = "CLI_COMMENTATOR_MANAGED_SERVER";
 const HEALTH_CHECK_TIMEOUT_MS: u64 = 500;
 const PORT_SCAN_ATTEMPTS: u16 = 64;
 
@@ -458,6 +459,7 @@ fn spawn_server_process(
         cmd.arg(&server_entry)
             .current_dir(&server_working_dir)
             .env("CLI_COMMENTATOR_PORT", port.to_string())
+            .env(MANAGED_SERVER_ENV, "1")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
     });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -51,12 +51,14 @@ import { createCommentaryGate, withEventPriority } from "./event-priority.js";
 import { createRepeatedErrorDetector } from "./repeated-error-detector.js";
 import { createSessionContext } from "./session-context.js";
 import { applySpeechContract } from "./commentary/speech-policy.js";
+import { isManagedServer } from "./runtime/managed-server.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
 const SILENCE_TIMEOUT_MS = parseSilenceTimeoutMs(process.env.SILENCE_TIMEOUT_MS);
 
 const INPUT_MODE_RAW = process.env.INPUT_MODE; // For debugging
+const MANAGED_SERVER = isManagedServer();
 
 function parseInputMode(value?: string): InputMode {
   const normalized = (value ?? "").trim().toLowerCase();
@@ -489,7 +491,7 @@ function setupPTY(
   });
 
   // Handle PTY exit - only trigger cleanup for final exit, not for profile switch
-  term.onExit(({ exitCode }) => {
+  term.onExit(({ exitCode, signal }) => {
     if (ptyManager.current !== term) {
       return;
     }
@@ -504,8 +506,29 @@ function setupPTY(
     const context = sessionContext.observeEvent(ev);
     broadcast({ kind: "event", ev });
 
-    // 安全タイマー付き二重化（comment()がsettleしなくてもcleanup確実実行）
     const exitWithCode = exitCode ?? 0;
+    if (MANAGED_SERVER) {
+      ptyManager.releaseIfCurrent(term);
+      currentlyRunningProfileId = null;
+      transitionServerState("pty_exit", "pty_idle", {
+        inputMode: "pty",
+        profileId: null,
+        detail: `exit_code=${exitWithCode}`,
+        context: {
+          exitCode: exitWithCode,
+          signal: signal ?? undefined,
+          managedServer: true,
+        },
+      });
+      void comment(ev, currentStyle, currentCommentaryProviders, context)
+        .then((payload) => {
+          broadcastCommentary(ev.ts, ev, payload);
+        })
+        .catch(() => {});
+      return;
+    }
+
+    // 安全タイマー付き二重化（comment()がsettleしなくてもcleanup確実実行）
     let exited = false;
     const safeCleanup = () => {
       if (exited) return;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -52,6 +52,10 @@ import { createRepeatedErrorDetector } from "./repeated-error-detector.js";
 import { createSessionContext } from "./session-context.js";
 import { applySpeechContract } from "./commentary/speech-policy.js";
 import { isManagedServer } from "./runtime/managed-server.js";
+import {
+  broadcastIfCurrentGeneration,
+  createCommentaryGeneration,
+} from "./runtime/commentary-generation.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -105,6 +109,7 @@ function markPtyUnavailable(error: string): void {
 const commentaryGate = createCommentaryGate({ intervalMs: 2000 });
 const repeatedErrorDetector = createRepeatedErrorDetector();
 const sessionContext = createSessionContext();
+const commentaryGeneration = createCommentaryGeneration();
 
 // --- HTTP + WS ---
 const server = http.createServer((req, res) => {
@@ -297,6 +302,7 @@ function createAdHocPTYConfig(input: LaunchSessionInput): PTYConfig {
 }
 
 async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
+  commentaryGeneration.invalidate();
   const config = createAdHocPTYConfig(input);
   const nextStyle = isStyle(input.style) ? input.style : currentStyle;
   const nextSourceMode = normalizeSource(input.logSource);
@@ -376,7 +382,11 @@ const carryEscape = createEscapeCarry();
  * Process incoming data from any input source (PTY or FileTail).
  * This is the common data processing pipeline.
  */
-function processInputData(data: string, writeToStdout: boolean = true): void {
+function processInputData(
+  data: string,
+  writeToStdout: boolean = true,
+  generation = commentaryGeneration.current(),
+): void {
   silenceTimer.activity();
 
   // Write raw data to local terminal (only for PTY mode or when requested)
@@ -399,11 +409,11 @@ function processInputData(data: string, writeToStdout: boolean = true): void {
   broadcast({ kind: "raw", data: clean });
 
   for (const ev of evs) {
-    emitEvent(ev);
+    emitEvent(ev, generation);
   }
 }
 
-function emitEvent(ev: Event): void {
+function emitEvent(ev: Event, generation = commentaryGeneration.current()): void {
   const prioritizedEvent = withEventPriority(repeatedErrorDetector.observe(ev));
   const shouldEmitCommentary = commentaryGate.shouldEmit(prioritizedEvent.priority);
   const context = sessionContext.observeEvent(prioritizedEvent, {
@@ -412,11 +422,14 @@ function emitEvent(ev: Event): void {
   // The rule-based event reaches clients immediately; LLM commentary follows asynchronously.
   broadcast({ kind: "event", ev: prioritizedEvent });
   if (shouldEmitCommentary) {
-    void comment(prioritizedEvent, currentStyle, currentCommentaryProviders, context)
-      .then((payload) => {
+    broadcastIfCurrentGeneration(
+      comment(prioritizedEvent, currentStyle, currentCommentaryProviders, context),
+      commentaryGeneration,
+      generation,
+      (payload) => {
         broadcastCommentary(prioritizedEvent.ts, prioritizedEvent, payload);
-      })
-      .catch(() => {});
+      },
+    );
   }
 }
 
@@ -458,6 +471,7 @@ function setupPTY(
   profileId: string | null,
   sessionOptions?: { presetName?: string }
 ): void {
+  const generation = commentaryGeneration.invalidate();
   sessionContext.reset({
     presetName: sessionOptions?.presetName,
     acceptsHumanInput: /(?:^|[/\\])(?:codex|claude)(?:$|\s)/i.test(config.cmd),
@@ -487,7 +501,7 @@ function setupPTY(
   term.onData((data) => {
     if (ptyManager.current !== term) return;
     ptyCapture?.write(data);
-    processInputData(data, true);
+    processInputData(data, true, generation);
   });
 
   // Handle PTY exit - only trigger cleanup for final exit, not for profile switch
@@ -520,11 +534,14 @@ function setupPTY(
           managedServer: true,
         },
       });
-      void comment(ev, currentStyle, currentCommentaryProviders, context)
-        .then((payload) => {
+      broadcastIfCurrentGeneration(
+        comment(ev, currentStyle, currentCommentaryProviders, context),
+        commentaryGeneration,
+        generation,
+        (payload) => {
           broadcastCommentary(ev.ts, ev, payload);
-        })
-        .catch(() => {});
+        },
+      );
       return;
     }
 
@@ -561,18 +578,23 @@ function setupPTY(
   broadcast({ kind: "event", ev: startEvent });
 
   // Send commentary for start event
-  void comment(startEvent, currentStyle, currentCommentaryProviders, context)
-    .then((payload) => {
+  broadcastIfCurrentGeneration(
+    comment(startEvent, currentStyle, currentCommentaryProviders, context),
+    commentaryGeneration,
+    generation,
+    (payload) => {
       broadcastCommentary(Date.now(), startEvent, payload);
-    })
-    .catch((err) => {
+    },
+    (err) => {
+      if (!commentaryGeneration.isCurrent(generation)) return;
       // Fallback: show basic start message if LLM fails
       broadcastCommentary(Date.now(), startEvent, applySpeechContract({
         narration: `開始: ${startEvent.detail}`,
         meta: { narrationProvider: "fallback", mode: "narration" },
       }, startEvent, context));
       console.error("start commentary failed:", err);
-    });
+    },
+  );
 }
 
 /**
@@ -580,6 +602,7 @@ function setupPTY(
  * Serialized to prevent race conditions from rapid profile switches
  */
 async function restartPTY(profileId: string | null, force = false): Promise<void> {
+  commentaryGeneration.invalidate();
   // If a restart is already in progress, queue this request (only keep the latest)
   if (restartInFlight) {
     queuedProfileId = profileId;
@@ -921,6 +944,7 @@ wss.on("connection", async (ws) => {
  * @see Issue #40
  */
 function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName?: string }): void {
+  const generation = commentaryGeneration.invalidate();
   const fatal = options?.fatal ?? true;
   if (!filePath) {
     transitionServerState("file_tail_setup_failed", "failed", {
@@ -957,7 +981,7 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName
   fileTail = tail;
 
   // Process data through common pipeline (no stdout echo for file mode)
-  tail.on("data", (data) => processInputData(data, false));
+  tail.on("data", (data) => processInputData(data, false, generation));
 
   // Handle errors
   tail.on("error", (err) => {
@@ -986,14 +1010,21 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName
     const context = sessionContext.observeEvent(ev);
     broadcast({ kind: "event", ev });
 
-    void comment(ev, currentStyle, currentCommentaryProviders, context)
-      .then((payload) => {
-        broadcastCommentary(ev.ts, ev, payload);
-      })
-      .catch(() => {})
-      .finally(() => {
+    const finishFileTail = () => {
+      if (commentaryGeneration.isCurrent(generation)) {
         cleanup(code ?? 0);
-      });
+      }
+    };
+    broadcastIfCurrentGeneration(
+      comment(ev, currentStyle, currentCommentaryProviders, context),
+      commentaryGeneration,
+      generation,
+      (payload) => {
+        broadcastCommentary(ev.ts, ev, payload);
+        finishFileTail();
+      },
+      finishFileTail,
+    );
   });
 
   // Start tailing
@@ -1018,17 +1049,22 @@ function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName
     const context = sessionContext.observeEvent(startEvent);
     broadcast({ kind: "event", ev: startEvent });
 
-    void comment(startEvent, currentStyle, currentCommentaryProviders, context)
-      .then((payload) => {
+    broadcastIfCurrentGeneration(
+      comment(startEvent, currentStyle, currentCommentaryProviders, context),
+      commentaryGeneration,
+      generation,
+      (payload) => {
         broadcastCommentary(Date.now(), startEvent, payload);
-      })
-      .catch((err) => {
+      },
+      (err) => {
+        if (!commentaryGeneration.isCurrent(generation)) return;
         broadcastCommentary(Date.now(), startEvent, applySpeechContract({
           narration: `ファイル監視開始: ${filePath}`,
           meta: { narrationProvider: "fallback", mode: "narration" },
         }, startEvent, context));
         console.error("start commentary failed:", err);
-      });
+      },
+    );
   } catch (err) {
     transitionServerState("file_tail_setup_failed", "failed", {
       level: "error",

--- a/apps/server/src/pty/manager.ts
+++ b/apps/server/src/pty/manager.ts
@@ -138,6 +138,7 @@ export function resolveUseConpty(options?: {
 export type PTYManager = {
   readonly current: IPty | null;
   spawn: (config: PTYConfig) => IPty;
+  releaseIfCurrent: (pty: IPty) => boolean;
   kill: () => void;
   resize: (cols: number, rows: number) => void;
   write: (data: string) => void;
@@ -189,6 +190,12 @@ export function createPTYManager(): PTYManager {
       currentPty = pty.spawn(config.cmd, config.args, options);
 
       return currentPty;
+    },
+
+    releaseIfCurrent(pty: IPty) {
+      if (currentPty !== pty) return false;
+      currentPty = null;
+      return true;
     },
 
     kill() {

--- a/apps/server/src/runtime/commentary-generation.ts
+++ b/apps/server/src/runtime/commentary-generation.ts
@@ -1,0 +1,36 @@
+export type CommentaryGeneration = {
+  current: () => number;
+  invalidate: () => number;
+  isCurrent: (generation: number) => boolean;
+};
+
+export function createCommentaryGeneration(): CommentaryGeneration {
+  let generation = 0;
+
+  return {
+    current: () => generation,
+    invalidate: () => {
+      generation += 1;
+      return generation;
+    },
+    isCurrent: (candidate) => candidate === generation,
+  };
+}
+
+export function broadcastIfCurrentGeneration<T>(
+  commentary: Promise<T>,
+  generation: CommentaryGeneration,
+  expectedGeneration: number,
+  broadcast: (payload: T) => void,
+  onError?: (error: unknown) => void,
+): void {
+  void commentary
+    .then((payload) => {
+      if (generation.isCurrent(expectedGeneration)) {
+        broadcast(payload);
+      }
+    })
+    .catch((error) => {
+      onError?.(error);
+    });
+}

--- a/apps/server/src/runtime/managed-server.ts
+++ b/apps/server/src/runtime/managed-server.ts
@@ -1,0 +1,5 @@
+export function isManagedServer(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.CLI_COMMENTATOR_MANAGED_SERVER?.trim() === "1";
+}

--- a/apps/server/src/runtime/state-event.ts
+++ b/apps/server/src/runtime/state-event.ts
@@ -2,6 +2,7 @@ export type ServerRuntimeState =
   | "booting"
   | "starting"
   | "pty_running"
+  | "pty_idle"
   | "file_running"
   | "restarting"
   | "failed"

--- a/apps/server/src/tests/commentary-generation.test.ts
+++ b/apps/server/src/tests/commentary-generation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  broadcastIfCurrentGeneration,
+  createCommentaryGeneration,
+} from "../runtime/commentary-generation.js";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("commentary generation", () => {
+  it("suppresses delayed managed PTY exit commentary after same-CLI restart", async () => {
+    const generations = createCommentaryGeneration();
+    const sent: string[] = [];
+    const oldCommentary = deferred<string>();
+    const oldGeneration = generations.invalidate();
+
+    broadcastIfCurrentGeneration(oldCommentary.promise, generations, oldGeneration, (payload) => {
+      sent.push(payload);
+    });
+
+    // Managed PTY exit has started commentary; restarting the same CLI invalidates it
+    // before ptyRestart is sent and before the replacement PTY is created.
+    generations.invalidate();
+    generations.invalidate();
+    oldCommentary.resolve("old session done");
+    await flushPromises();
+
+    expect(sent).toEqual([]);
+  });
+
+  it("broadcasts new-session commentary and one non-restarted managed exit commentary", async () => {
+    const generations = createCommentaryGeneration();
+    const sent: string[] = [];
+    const oldCommentary = deferred<string>();
+    const oldGeneration = generations.invalidate();
+
+    broadcastIfCurrentGeneration(oldCommentary.promise, generations, oldGeneration, (payload) => {
+      sent.push(payload);
+    });
+    oldCommentary.resolve("old session done");
+    await flushPromises();
+    expect(sent).toEqual(["old session done"]);
+
+    const newGeneration = generations.invalidate();
+    const newCommentary = deferred<string>();
+    broadcastIfCurrentGeneration(newCommentary.promise, generations, newGeneration, (payload) => {
+      sent.push(payload);
+    });
+    newCommentary.resolve("new session started");
+    await flushPromises();
+
+    expect(sent).toEqual(["old session done", "new session started"]);
+  });
+});

--- a/apps/server/src/tests/managed-server.test.ts
+++ b/apps/server/src/tests/managed-server.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isManagedServer } from "../runtime/managed-server.js";
+
+describe("isManagedServer", () => {
+  it("enables managed lifecycle only for the explicit desktop flag", () => {
+    expect(isManagedServer({ CLI_COMMENTATOR_MANAGED_SERVER: "1" })).toBe(true);
+    expect(isManagedServer({ CLI_COMMENTATOR_MANAGED_SERVER: " 1 " })).toBe(true);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "0",
+    "true",
+    "yes",
+  ])("keeps standalone lifecycle for flag %j", (value) => {
+    expect(isManagedServer({ CLI_COMMENTATOR_MANAGED_SERVER: value })).toBe(false);
+  });
+});

--- a/apps/server/src/tests/managed-terminal-interrupt.integration.test.ts
+++ b/apps/server/src/tests/managed-terminal-interrupt.integration.test.ts
@@ -1,0 +1,200 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { isNodePtyAvailable } from "../pty/manager.js";
+
+const canRun = process.platform !== "win32" && isNodePtyAvailable();
+const MOCK_CLI_SCRIPT =
+  "process.on('SIGINT', () => process.exit(130)); console.log('mock-ready'); setInterval(() => {}, 1000)";
+
+type ServerMessage = {
+  kind?: string;
+  ev?: { type?: string };
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Failed to resolve a free port"));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+    server.on("error", reject);
+  });
+}
+
+async function isHealthy(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const request = http.get(
+      { host: "127.0.0.1", port, path: "/healthz", timeout: 300 },
+      (response) => {
+        response.resume();
+        resolve(response.statusCode === 200);
+      },
+    );
+    request.on("error", () => resolve(false));
+    request.on("timeout", () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForHealth(port: number, child: ChildProcess): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    if (child.exitCode !== null) {
+      throw new Error(`Server exited before health check with code ${child.exitCode}`);
+    }
+    if (await isHealthy(port)) return;
+    await delay(50);
+  }
+  throw new Error("Server health check timed out");
+}
+
+async function waitForMessage(
+  messages: ServerMessage[],
+  predicate: (message: ServerMessage) => boolean,
+): Promise<ServerMessage> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 5_000) {
+    const message = messages.find(predicate);
+    if (message) return message;
+    await delay(50);
+  }
+  throw new Error("Timed out waiting for WebSocket message");
+}
+
+async function waitForExit(child: ChildProcess): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function stopServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGTERM");
+  }
+  await Promise.race([waitForExit(child), delay(5_000)]);
+}
+
+async function startServer(managed: boolean): Promise<{
+  child: ChildProcess;
+  port: number;
+  stdout: () => string;
+}> {
+  const port = await getFreePort();
+  const child = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CLI_COMMENTATOR_PORT: String(port),
+      CLI_COMMENTATOR_MANAGED_SERVER: managed ? "1" : undefined,
+      INPUT_MODE: "pty",
+      TARGET_CMD: process.execPath,
+      TARGET_ARGS_JSON: JSON.stringify(["-e", MOCK_CLI_SCRIPT]),
+      TARGET_CWD: process.cwd(),
+      LLM_PROVIDER: "disabled",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  await waitForHealth(port, child);
+  return { child, port, stdout: () => output };
+}
+
+async function connect(port: number): Promise<{ ws: WebSocket; messages: ServerMessage[] }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const messages: ServerMessage[] = [];
+  ws.on("message", (data) => {
+    messages.push(JSON.parse(data.toString()) as ServerMessage);
+  });
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  return { ws, messages };
+}
+
+describe.skipIf(!canRun)("managed terminal interrupt lifecycle", () => {
+  it("keeps the managed server and WebSocket alive, releases the PTY, and relaunches it", async () => {
+    const { child, port, stdout } = await startServer(true);
+    const { ws, messages } = await connect(port);
+
+    try {
+      await delay(300);
+      ws.send(JSON.stringify({ kind: "writeInput", data: "\u0003" }));
+      await waitForMessage(messages, (message) => message.kind === "event" && message.ev?.type === "done");
+      expect(messages.filter((message) => message.kind === "event" && message.ev?.type === "done")).toHaveLength(1);
+
+      expect(child.exitCode).toBeNull();
+      expect(await isHealthy(port)).toBe(true);
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      expect(stdout()).not.toContain("cleanup_begin");
+
+      messages.length = 0;
+      ws.send(
+        JSON.stringify({
+          kind: "launchSession",
+          session: {
+            name: "mock CLI",
+            cmd: process.execPath,
+            args: ["-e", MOCK_CLI_SCRIPT],
+            cwd: process.cwd(),
+            style: "kansai",
+            logSource: "generic",
+          },
+        }),
+      );
+      await waitForMessage(messages, (message) => message.kind === "ptyRestart");
+      await waitForMessage(messages, (message) => message.kind === "event" && message.ev?.type === "start");
+      expect(await isHealthy(port)).toBe(true);
+
+      await delay(300);
+      ws.send(JSON.stringify({ kind: "writeInput", data: "\u0003" }));
+      await waitForMessage(messages, (message) => message.kind === "event" && message.ev?.type === "done");
+      expect(messages.filter((message) => message.kind === "event" && message.ev?.type === "done")).toHaveLength(1);
+    } finally {
+      ws.close();
+      await stopServer(child);
+    }
+  }, 20_000);
+
+  it("keeps standalone cleanup behavior for the same foreground exit", async () => {
+    const { child, port } = await startServer(false);
+    const { ws, messages } = await connect(port);
+
+    try {
+      await delay(300);
+      ws.send(JSON.stringify({ kind: "writeInput", data: "\u0003" }));
+      const exit = await waitForExit(child);
+
+      expect(exit.code).toBe(130);
+      expect(await isHealthy(port)).toBe(false);
+    } finally {
+      ws.close();
+      await stopServer(child);
+      expect(messages.some((message) => message.kind === "event" && message.ev?.type === "done")).toBe(true);
+    }
+  }, 20_000);
+});

--- a/apps/server/src/tests/pty.manager.test.ts
+++ b/apps/server/src/tests/pty.manager.test.ts
@@ -207,15 +207,26 @@ describe("pty/manager", () => {
     it("resizes the active PTY and ignores resize requests after it is killed", async () => {
       vi.resetModules();
       const originalForceNoPty = process.env.CLI_COMMENTATOR_FORCE_NO_PTY;
-      const resize = vi.fn();
-      const term = {
+      const firstResize = vi.fn();
+      const firstTerm = {
         onData: vi.fn(),
         onExit: vi.fn(),
         write: vi.fn(),
         kill: vi.fn(),
-        resize,
+        resize: firstResize,
       };
-      const spawn = vi.fn(() => term);
+      const secondResize = vi.fn();
+      const secondTerm = {
+        onData: vi.fn(),
+        onExit: vi.fn(),
+        write: vi.fn(),
+        kill: vi.fn(),
+        resize: secondResize,
+      };
+      const spawn = vi
+        .fn()
+        .mockReturnValueOnce(firstTerm)
+        .mockReturnValueOnce(secondTerm);
 
       delete process.env.CLI_COMMENTATOR_FORCE_NO_PTY;
 
@@ -234,11 +245,21 @@ describe("pty/manager", () => {
         manager.spawn({ cmd: "bash", args: [], cwd: process.cwd() });
 
         manager.resize(96, 32);
-        expect(resize).toHaveBeenCalledWith(96, 32);
+        expect(firstResize).toHaveBeenCalledWith(96, 32);
 
-        manager.kill();
+        expect(manager.releaseIfCurrent(firstTerm)).toBe(true);
+        expect(manager.current).toBeNull();
+
+        manager.spawn({ cmd: "bash", args: [], cwd: process.cwd() });
+        expect(manager.current).toBe(secondTerm);
+        expect(manager.releaseIfCurrent(firstTerm)).toBe(false);
+        expect(manager.current).toBe(secondTerm);
+
         manager.resize(120, 40);
-        expect(resize).toHaveBeenCalledTimes(1);
+        expect(secondResize).toHaveBeenCalledWith(120, 40);
+        manager.kill();
+        manager.resize(144, 48);
+        expect(secondResize).toHaveBeenCalledTimes(1);
       } finally {
         if (originalForceNoPty === undefined) {
           delete process.env.CLI_COMMENTATOR_FORCE_NO_PTY;

--- a/apps/web/src/components/WorkspaceLeft.tsx
+++ b/apps/web/src/components/WorkspaceLeft.tsx
@@ -4,6 +4,10 @@ import type { ProfileSummary, PtySize, Style } from "../types";
 import { LauncherPanel } from "./LauncherPanel";
 import { ProfileSelector } from "./ProfileSelector";
 import type { TerminalPaneHandle, TerminalPaneTheme } from "./TerminalPane";
+import {
+  TERMINAL_INTERRUPT_LABEL,
+  sendTerminalInterrupt,
+} from "../lib/terminal-interrupt";
 
 const TerminalPane = lazy(() => import("./TerminalPane"));
 
@@ -96,9 +100,11 @@ export function WorkspaceLeft({
             <button
               type="button"
               className="debug-panel__btn debug-panel__btn--secondary"
-              onClick={() => onTerminalData("\u0003")}
+              onClick={() => sendTerminalInterrupt(onTerminalData)}
+              aria-label={TERMINAL_INTERRUPT_LABEL}
+              title={`${TERMINAL_INTERRUPT_LABEL}。文字のコピーは⌘C`}
             >
-              Ctrl+C
+              {TERMINAL_INTERRUPT_LABEL}
             </button>
           </div>
         </div>

--- a/apps/web/src/lib/terminal-interrupt.test.ts
+++ b/apps/web/src/lib/terminal-interrupt.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TERMINAL_INTERRUPT_LABEL,
+  TERMINAL_INTERRUPT_SEQUENCE,
+  sendTerminalInterrupt,
+} from "./terminal-interrupt";
+
+describe("terminal interrupt control", () => {
+  it("sends exactly one Ctrl+C sequence", () => {
+    const send = vi.fn();
+
+    sendTerminalInterrupt(send);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(TERMINAL_INTERRUPT_SEQUENCE);
+  });
+
+  it("uses a label that distinguishes interruption from copying", () => {
+    expect(TERMINAL_INTERRUPT_LABEL).toContain("実行を中断");
+    expect(TERMINAL_INTERRUPT_LABEL).toContain("Ctrl+C");
+    expect(TERMINAL_INTERRUPT_LABEL).not.toContain("コピー");
+  });
+});

--- a/apps/web/src/lib/terminal-interrupt.ts
+++ b/apps/web/src/lib/terminal-interrupt.ts
@@ -1,0 +1,6 @@
+export const TERMINAL_INTERRUPT_SEQUENCE = "\u0003";
+export const TERMINAL_INTERRUPT_LABEL = "実行を中断（Ctrl+C）";
+
+export function sendTerminalInterrupt(onTerminalData: (data: string) => void): void {
+  onTerminalData(TERMINAL_INTERRUPT_SEQUENCE);
+}

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -72,6 +72,8 @@ When startup fails, the Desktop Server panel shows a recovery card. It includes 
 
 Note: In desktop managed mode, if `8787` is occupied, desktop automatically falls back to `8788+` and the UI WebSocket target follows automatically.
 
+In Managed Terminal, `実行を中断（Ctrl+C）` ends only the foreground CLI running inside Managed Terminal. The Desktop Server stays `running`, and you can resume by selecting the same launch settings. standalone server shutdown behavior is unchanged. `CLI_COMMENTATOR_MANAGED_SERVER` is an identifier configured internally by the Tauri sidecar; normal users should not set it manually.
+
 ## Run in Web Mode (server + web)
 
 ```bash

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -68,6 +68,8 @@ Desktop Server パネルで server の状態を操作します（`Start` / `Stop
 
 補足: Desktop managed モードでは、既定ポート `8787` が使用中なら `8788` 以降へ自動退避し、UI の接続先も自動追従します。
 
+Managed Terminal の `実行を中断（Ctrl+C）` は、Managed Terminal 内で動作している前景 CLI だけを終了します。Desktop Server は `running` のまま維持され、同じ起動設定を選んで再開できます。standalone server の終了動作は変更されません。`CLI_COMMENTATOR_MANAGED_SERVER` は Tauri sidecar が内部設定する識別値であり、通常の利用者が手動設定するものではありません。
+
 ## Web モードで起動（server + web）
 
 ```bash


### PR DESCRIPTION
## 結果

Desktop管理モードでは、Ctrl+Cで前景CLIだけを終了し、Desktop ServerとWebSocketを生存させるようにしました。終了後は同じ設定のCLIを再起動できます。追加修正では、再起動後に旧セッションの終了実況が混入しないようにしました。standalone起動時の既存の終了契約は維持しています。

## HUMAN向け解説

これまで「Ctrl+C」を押すと、CLIの終了をきっかけにServer全体も終了し、画面操作や再起動ができなくなることがありました。今回、Desktopが管理しているServerではCLIとServerの寿命を分離しました。

さらに、CLI終了後の実況生成中に再起動すると、旧実況が新しいセッションへ遅れて表示・読み上げされる競合がありました。PTYごとのgenerationを使い、再起動開始時点で旧generationを無効化して混入を防止しています。

HUMAN確認では、CLIだけが止まり、ServerがRunningのまま再起動できることを確認してください。

## 現行挙動の再現

実CLIや認証情報は使わず、SIGINTで終了コード130になる隔離mock CLIで再現しました。現行コードではPTYの終了処理がServerのcleanup()を呼び、HTTP/WebSocketを閉じてServer childも終了しました。

## 原因と対応

原因は、PTYのonExit処理がstandalone起動とDesktop管理起動を区別せずcleanup()を実行していたこと、および終了実況のPromise完了時にセッション世代を確認していなかったことです。

- Tauri sidecar起動時にCLI_COMMENTATOR_MANAGED_SERVER=1を渡す
- Server管理モードではPTY終了時にPTY参照だけを解放し、Server cleanup()は呼ばない
- 古いPTYの遅延onExitが新しいPTYを解放しないよう、同一インスタンスだけを解放する
- Server状態にpty_idleを追加し、次のlaunchSessionで同じCLIを再起動できるようにする
- launchAdHocSession／restartPTYの開始時と新PTY生成時にgenerationを更新する
- 非同期実況完了時にgenerationが現行の場合だけWebSocketへ送信する
- ボタン表示とaccessible nameを「実行を中断（Ctrl+C）」へ変更し、送信するCtrl+Cは1回だけにする
- Server自体の異常終了や起動失敗をfailed扱いにする既存処理は変更しない

## 変更ファイル

- apps/desktop/src-tauri/src/server.rs
- apps/server/src/index.ts
- apps/server/src/pty/manager.ts
- apps/server/src/runtime/managed-server.ts
- apps/server/src/runtime/commentary-generation.ts
- apps/server/src/runtime/state-event.ts
- apps/server/src/tests/managed-server.test.ts
- apps/server/src/tests/managed-terminal-interrupt.integration.test.ts
- apps/server/src/tests/commentary-generation.test.ts
- apps/server/src/tests/pty.manager.test.ts
- apps/web/src/components/WorkspaceLeft.tsx
- apps/web/src/lib/terminal-interrupt.ts
- apps/web/src/lib/terminal-interrupt.test.ts
- docs/getting-started.ja.md
- docs/getting-started.en.md

追加commit: 066c361（stale commentary suppression and documentation drift fix）

## 自動検証

### ローカル

- Server: 61 suites / 909 tests passed
- Server typecheck (tsc --noEmit) passed
- Server build passed
- 遅延Promiseによるgeneration競合テスト: 2 tests passed
- Managed/standalone mock CLI integration passed
- Web: 13 suites / 106 tests passed
- Web build and lint passed
- docs_drift_guard相当のnode ./scripts/check-doc-sync.mjs passed
- Desktop sidecar runtime tests: 9 passed
- Local readiness tests: 13 passed
- pnpm prepare:desktop-sidecar passed
- cargo check passed
- cargo test: 12 passed

### GitHub Actions（commit 066c361）

- ci / test: success
- ci / docs_drift_guard: success
- ci / desktop_distribution_smoke: success
- ci / failure_regression: success
- ci / desktop_check: success
- ci / test_windows: success
- ci / actionlint: success
- CodeQL / Analyze: success

## HUMAN確認手順

1. CLI Commentatorを起動する
2. Managed TerminalでCodexまたはClaude Code、または同等のmock CLIを起動する
3. 実行中に「実行を中断（Ctrl+C）」を押す
4. 前景CLIだけが終了することを確認する
5. Desktop ServerがRunningのままであることを確認する
6. Managed Terminalから同じCLIを再起動する
7. 再起動後に文字入力と実況が再開することを確認する
8. 選択文字を⌘Cでコピーできることを確認する
9. アプリを終了して再起動し、通常起動も壊れていないことを確認する

## 非対象

#404、#403、#407、#419、#421、#422、#423、#405のfixture/期待値変更、release、署名、公開は対象外です。

Closes #424