### PR TITLE
fix(managed-terminal): deliver initial commentary after WebSocket connect

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -56,6 +56,7 @@ import {
   broadcastIfCurrentGeneration,
   createCommentaryGeneration,
 } from "./runtime/commentary-generation.js";
+import { createInitialStartDelivery } from "./runtime/initial-start-delivery.js";
 
 const PORT = Number(process.env.CLI_COMMENTATOR_PORT ?? process.env.PORT ?? 8787);
 const COMMENT_EXIT_TIMEOUT_MS = parseInt(process.env.COMMENT_EXIT_TIMEOUT_MS ?? "1500", 10);
@@ -110,6 +111,7 @@ const commentaryGate = createCommentaryGate({ intervalMs: 2000 });
 const repeatedErrorDetector = createRepeatedErrorDetector();
 const sessionContext = createSessionContext();
 const commentaryGeneration = createCommentaryGeneration();
+const initialStartDelivery = createInitialStartDelivery();
 
 // --- HTTP + WS ---
 const server = http.createServer((req, res) => {
@@ -302,6 +304,7 @@ function createAdHocPTYConfig(input: LaunchSessionInput): PTYConfig {
 }
 
 async function launchAdHocSession(input: LaunchSessionInput): Promise<void> {
+  initialStartDelivery.invalidate();
   commentaryGeneration.invalidate();
   const config = createAdHocPTYConfig(input);
   const nextStyle = isStyle(input.style) ? input.style : currentStyle;
@@ -452,8 +455,12 @@ function broadcast(msg: WsOutgoing) {
   }
 }
 
+function createCommentaryMessage(ts: number, ev: Event, payload: CommentaryPayload): Extract<WsOutgoing, { kind: "commentary" }> {
+  return { kind: "commentary", ts, ev, ...payload };
+}
+
 function broadcastCommentary(ts: number, ev: Event, payload: CommentaryPayload): void {
-  broadcast({ kind: "commentary", ts, ev, ...payload });
+  broadcast(createCommentaryMessage(ts, ev, payload));
 }
 
 function broadcastSource(nextDetected: SourceState["detected"]) {
@@ -575,7 +582,14 @@ function setupPTY(
     detail: `${config.cmd} ${config.args.join(" ")}`,
   });
   const context = sessionContext.observeEvent(startEvent);
-  broadcast({ kind: "event", ev: startEvent });
+  const initialStart = initialStartDelivery.begin(
+    generation,
+    { kind: "event", ev: startEvent },
+    wss.clients.size === 0,
+  );
+  if (initialStart !== "buffered") {
+    broadcast({ kind: "event", ev: startEvent });
+  }
 
   // Send commentary for start event
   broadcastIfCurrentGeneration(
@@ -583,15 +597,27 @@ function setupPTY(
     commentaryGeneration,
     generation,
     (payload) => {
-      broadcastCommentary(Date.now(), startEvent, payload);
+      const message = createCommentaryMessage(Date.now(), startEvent, payload);
+      if (initialStart === "buffered") {
+        initialStartDelivery.setCommentary(generation, message);
+        deliverPendingInitialStart();
+      } else {
+        broadcast(message);
+      }
     },
     (err) => {
       if (!commentaryGeneration.isCurrent(generation)) return;
       // Fallback: show basic start message if LLM fails
-      broadcastCommentary(Date.now(), startEvent, applySpeechContract({
+      const message = createCommentaryMessage(Date.now(), startEvent, applySpeechContract({
         narration: `開始: ${startEvent.detail}`,
         meta: { narrationProvider: "fallback", mode: "narration" },
       }, startEvent, context));
+      if (initialStart === "buffered") {
+        initialStartDelivery.setCommentary(generation, message);
+        deliverPendingInitialStart();
+      } else {
+        broadcast(message);
+      }
       console.error("start commentary failed:", err);
     },
   );
@@ -602,6 +628,7 @@ function setupPTY(
  * Serialized to prevent race conditions from rapid profile switches
  */
 async function restartPTY(profileId: string | null, force = false): Promise<void> {
+  initialStartDelivery.invalidate();
   commentaryGeneration.invalidate();
   // If a restart is already in progress, queue this request (only keep the latest)
   if (restartInFlight) {
@@ -792,6 +819,15 @@ function sendTo(client: typeof wss.clients extends Set<infer T> ? T : never, msg
   }
 }
 
+function deliverPendingInitialStart(): void {
+  initialStartDelivery.tryDeliver(
+    Array.from(wss.clients, (client) => ({
+      isOpen: () => client.readyState === 1,
+      send: (message: WsOutgoing) => sendTo(client, message),
+    })),
+  );
+}
+
 wss.on("connection", async (ws) => {
   // Send initial state including profiles
   const profiles = await profileManager.list();
@@ -803,6 +839,7 @@ wss.on("connection", async (ws) => {
   if (!ptyAvailable && ptyInitError) {
     sendTo(ws, createPtyUnavailableMessage(ptyInitError));
   }
+  deliverPendingInitialStart();
 
   ws.on("message", async (buf) => {
     try {
@@ -944,6 +981,7 @@ wss.on("connection", async (ws) => {
  * @see Issue #40
  */
 function setupFileTail(filePath: string, options?: { fatal?: boolean; presetName?: string }): void {
+  initialStartDelivery.invalidate();
   const generation = commentaryGeneration.invalidate();
   const fatal = options?.fatal ?? true;
   if (!filePath) {

--- a/apps/server/src/runtime/initial-start-delivery.ts
+++ b/apps/server/src/runtime/initial-start-delivery.ts
@@ -1,0 +1,87 @@
+import type { WsOutgoing } from "../types.js";
+
+export type InitialStartEvent = Extract<WsOutgoing, { kind: "event" }>;
+export type InitialStartCommentary = Extract<WsOutgoing, { kind: "commentary" }>;
+export type InitialStartMessage = InitialStartEvent | InitialStartCommentary;
+
+export type InitialStartClient = {
+  isOpen: () => boolean;
+  send: (message: InitialStartMessage) => void;
+};
+
+export type InitialStartBeginResult = "buffered" | "immediate" | "not-initial";
+
+type PendingStart = {
+  generation: number;
+  event: InitialStartEvent;
+  commentary?: InitialStartCommentary;
+};
+
+/**
+ * Holds only the first PTY start event and its commentary until a WebSocket
+ * client is ready. Later sessions keep the normal immediate broadcast path.
+ */
+export type InitialStartDelivery = {
+  begin: (
+    generation: number,
+    event: InitialStartEvent,
+    shouldBuffer: boolean,
+  ) => InitialStartBeginResult;
+  setCommentary: (generation: number, commentary: InitialStartCommentary) => void;
+  invalidate: (generation?: number) => void;
+  tryDeliver: (clients: readonly InitialStartClient[]) => boolean;
+  isStarted: () => boolean;
+  isConsumed: () => boolean;
+  pendingGeneration: () => number | null;
+};
+
+export function createInitialStartDelivery(): InitialStartDelivery {
+  let started = false;
+  let consumed = false;
+  let pending: PendingStart | null = null;
+
+  return {
+    begin(generation, event, shouldBuffer) {
+      if (started) return "not-initial";
+      started = true;
+      if (!shouldBuffer) {
+        consumed = true;
+        return "immediate";
+      }
+      consumed = false;
+      pending = { generation, event };
+      return "buffered";
+    },
+
+    setCommentary(generation, commentary) {
+      if (consumed || pending?.generation !== generation) return;
+      pending.commentary = commentary;
+    },
+
+    invalidate(generation) {
+      if (generation !== undefined && pending?.generation !== generation) return;
+      pending = null;
+      consumed = true;
+    },
+
+    tryDeliver(clients) {
+      const current = pending;
+      if (consumed || !current?.commentary) return false;
+
+      const client = clients.find((candidate) => candidate.isOpen());
+      if (!client) return false;
+
+      // Mark consumed before sending so a reconnect cannot replay the event if
+      // the second send observes a closing socket.
+      consumed = true;
+      pending = null;
+      client.send(current.event);
+      client.send(current.commentary);
+      return true;
+    },
+
+    isStarted: () => started,
+    isConsumed: () => consumed,
+    pendingGeneration: () => pending?.generation ?? null,
+  };
+}

--- a/apps/server/src/tests/initial-commentary-delivery.integration.test.ts
+++ b/apps/server/src/tests/initial-commentary-delivery.integration.test.ts
@@ -1,0 +1,208 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { isNodePtyAvailable } from "../pty/manager.js";
+
+const canRun = process.platform !== "win32" && isNodePtyAvailable();
+const MOCK_CLI_SCRIPT =
+  "process.on('SIGINT', () => process.exit(130)); console.log('mock-ready'); setInterval(() => {}, 1000)";
+
+type ServerMessage = {
+  kind?: string;
+  ev?: { type?: string; summary?: string; detail?: string };
+  narration?: string;
+  explanation?: string;
+  speech?: { disposition?: string; text?: string };
+  meta?: { narrationProvider?: string };
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const listener = net.createServer();
+    listener.once("error", reject);
+    listener.listen(0, "127.0.0.1", () => {
+      const address = listener.address();
+      if (!address || typeof address === "string") {
+        listener.close();
+        reject(new Error("Failed to resolve a free port"));
+        return;
+      }
+      listener.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function isHealthy(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const request = http.get(
+      { host: "127.0.0.1", port, path: "/healthz", timeout: 300 },
+      (response) => {
+        response.resume();
+        resolve(response.statusCode === 200);
+      },
+    );
+    request.on("error", () => resolve(false));
+    request.on("timeout", () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForHealth(port: number, child: ChildProcess): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    if (child.exitCode !== null) {
+      throw new Error(`Server exited before health check with code ${child.exitCode}`);
+    }
+    if (await isHealthy(port)) return;
+    await delay(50);
+  }
+  throw new Error("Server health check timed out");
+}
+
+async function waitForMessage(
+  messages: ServerMessage[],
+  predicate: (message: ServerMessage) => boolean,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 5_000) {
+    if (messages.some(predicate)) return;
+    await delay(25);
+  }
+  throw new Error("Timed out waiting for WebSocket message");
+}
+
+async function startServer(options: { provider: "disabled" | "mock"; failCommentary?: boolean }): Promise<{
+  child: ChildProcess;
+  port: number;
+}> {
+  const port = await getFreePort();
+  const child = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CLI_COMMENTATOR_PORT: String(port),
+      CLI_COMMENTATOR_MANAGED_SERVER: "1",
+      INPUT_MODE: "pty",
+      TARGET_CMD: process.execPath,
+      TARGET_ARGS_JSON: JSON.stringify(["-e", MOCK_CLI_SCRIPT]),
+      TARGET_CWD: process.cwd(),
+      LLM_PROVIDER: options.provider,
+      MOCK_LLM_MODE: options.failCommentary ? "error" : undefined,
+    },
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  await waitForHealth(port, child);
+  return { child, port };
+}
+
+async function stopServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    delay(5_000),
+  ]);
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+}
+
+async function connect(port: number): Promise<{ ws: WebSocket; messages: ServerMessage[] }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const messages: ServerMessage[] = [];
+  ws.on("message", (data) => {
+    messages.push(JSON.parse(data.toString()) as ServerMessage);
+  });
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  return { ws, messages };
+}
+
+function startEvents(messages: ServerMessage[]): ServerMessage[] {
+  return messages.filter((message) => message.kind === "event" && message.ev?.type === "start");
+}
+
+function startCommentaries(messages: ServerMessage[]): ServerMessage[] {
+  return messages.filter((message) => message.kind === "commentary" && message.ev?.type === "start");
+}
+
+function expectStartCommentary(message: ServerMessage, provider?: string): void {
+  expect(message.narration).toBeTypeOf("string");
+  expect(message.narration?.trim()).not.toBe("");
+  expect(message.explanation).toBeTypeOf("string");
+  expect(message.explanation?.trim()).not.toBe("");
+  expect(message.speech?.disposition).toBe("speak");
+  expect(message.speech?.text).toBeTypeOf("string");
+  expect(message.speech?.text?.trim()).not.toBe("");
+  if (provider) expect(message.meta?.narrationProvider).toBe(provider);
+}
+
+describe.skipIf(!canRun)("initial managed PTY commentary delivery", () => {
+  it("delivers the pre-connection start pair once and preserves connected restart delivery", async () => {
+    const { child, port } = await startServer({ provider: "disabled" });
+    let ws: WebSocket | undefined;
+    let reconnect: WebSocket | undefined;
+    try {
+      const first = await connect(port);
+      ws = first.ws;
+      await waitForMessage(first.messages, (message) => message.kind === "commentary" && message.ev?.type === "start");
+
+      expect(startEvents(first.messages)).toHaveLength(1);
+      expect(startCommentaries(first.messages)).toHaveLength(1);
+      expectStartCommentary(startCommentaries(first.messages)[0]);
+
+      ws.close();
+      await delay(100);
+      const second = await connect(port);
+      reconnect = second.ws;
+      await delay(300);
+      expect(startEvents(second.messages)).toHaveLength(0);
+      expect(startCommentaries(second.messages)).toHaveLength(0);
+
+      second.ws.send(JSON.stringify({
+        kind: "launchSession",
+        session: {
+          name: "mock CLI restart",
+          cmd: process.execPath,
+          args: ["-e", MOCK_CLI_SCRIPT],
+          cwd: process.cwd(),
+          style: "kansai",
+          logSource: "generic",
+        },
+      }));
+      await waitForMessage(second.messages, (message) => message.kind === "commentary" && message.ev?.type === "start");
+
+      expect(startEvents(second.messages)).toHaveLength(1);
+      expect(startCommentaries(second.messages)).toHaveLength(1);
+      expectStartCommentary(startCommentaries(second.messages)[0]);
+    } finally {
+      ws?.close();
+      reconnect?.close();
+      await stopServer(child);
+    }
+  }, 25_000);
+
+  it("delivers one rules fallback with a voice payload when commentary generation fails", async () => {
+    const { child, port } = await startServer({ provider: "mock", failCommentary: true });
+    let ws: WebSocket | undefined;
+    try {
+      const connected = await connect(port);
+      ws = connected.ws;
+      await waitForMessage(connected.messages, (message) => message.kind === "commentary" && message.ev?.type === "start");
+
+      expect(startEvents(connected.messages)).toHaveLength(1);
+      expect(startCommentaries(connected.messages)).toHaveLength(1);
+      expectStartCommentary(startCommentaries(connected.messages)[0], "rules");
+    } finally {
+      ws?.close();
+      await stopServer(child);
+    }
+  }, 20_000);
+});

--- a/apps/server/src/tests/initial-start-delivery.test.ts
+++ b/apps/server/src/tests/initial-start-delivery.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type {
+  InitialStartClient,
+  InitialStartCommentary,
+  InitialStartEvent,
+} from "../runtime/initial-start-delivery.js";
+import { createInitialStartDelivery } from "../runtime/initial-start-delivery.js";
+
+const startEvent: InitialStartEvent = {
+  kind: "event",
+  ev: { ts: 1, type: "start", summary: "開始", detail: "mock CLI" },
+};
+
+const startCommentary: InitialStartCommentary = {
+  kind: "commentary",
+  ts: 2,
+  ev: startEvent.ev,
+  narration: "開始しています。",
+  explanation: "mock CLIを開始しました。",
+  speech: { disposition: "speak", reason: "progress_refresh", text: "開始しています。" },
+};
+
+function client(open = true): { client: InitialStartClient; sent: InitialStartEvent[] | InitialStartCommentary[] } {
+  const sent: Array<InitialStartEvent | InitialStartCommentary> = [];
+  return {
+    client: {
+      isOpen: () => open,
+      send: (message) => sent.push(message),
+    },
+    sent: sent as InitialStartEvent[] | InitialStartCommentary[],
+  };
+}
+
+describe("initial start delivery", () => {
+  it("holds the event until commentary resolves, then delivers both once", () => {
+    const delivery = createInitialStartDelivery();
+    const first = client();
+
+    expect(delivery.begin(1, startEvent, true)).toBe("buffered");
+    expect(delivery.tryDeliver([first.client])).toBe(false);
+    delivery.setCommentary(1, startCommentary);
+
+    expect(delivery.tryDeliver([first.client])).toBe(true);
+    expect(first.sent).toEqual([startEvent, startCommentary]);
+    expect(delivery.tryDeliver([first.client])).toBe(false);
+    expect(delivery.isConsumed()).toBe(true);
+  });
+
+  it("delivers commentary that resolved before the first connection", () => {
+    const delivery = createInitialStartDelivery();
+    const first = client();
+
+    expect(delivery.begin(1, startEvent, true)).toBe("buffered");
+    delivery.setCommentary(1, startCommentary);
+    expect(delivery.tryDeliver([first.client])).toBe(true);
+    expect(first.sent).toHaveLength(2);
+  });
+
+  it("does not replay consumed payloads after reconnect", () => {
+    const delivery = createInitialStartDelivery();
+    const first = client();
+    const reconnect = client();
+
+    delivery.begin(1, startEvent, true);
+    delivery.setCommentary(1, startCommentary);
+    expect(delivery.tryDeliver([first.client])).toBe(true);
+    expect(delivery.tryDeliver([reconnect.client])).toBe(false);
+    expect(reconnect.sent).toEqual([]);
+  });
+
+  it("drops an old generation before its delayed commentary resolves", () => {
+    const delivery = createInitialStartDelivery();
+    const first = client();
+
+    delivery.begin(1, startEvent, true);
+    expect(delivery.pendingGeneration()).toBe(1);
+    delivery.invalidate(1);
+    delivery.setCommentary(1, startCommentary);
+
+    expect(delivery.pendingGeneration()).toBeNull();
+    expect(delivery.tryDeliver([first.client])).toBe(false);
+    expect(first.sent).toEqual([]);
+  });
+
+  it("skips buffering when a client already exists, preserving immediate delivery", () => {
+    const delivery = createInitialStartDelivery();
+    const first = client();
+
+    expect(delivery.begin(1, startEvent, false)).toBe("immediate");
+    delivery.setCommentary(1, startCommentary);
+    expect(delivery.tryDeliver([first.client])).toBe(false);
+    expect(first.sent).toEqual([]);
+  });
+
+  it("waits for a reconnect when the first client is closed", () => {
+    const delivery = createInitialStartDelivery();
+    const closed = client(false);
+    const reconnect = client();
+
+    delivery.begin(1, startEvent, true);
+    delivery.setCommentary(1, startCommentary);
+    expect(delivery.tryDeliver([closed.client])).toBe(false);
+    expect(delivery.tryDeliver([closed.client, reconnect.client])).toBe(true);
+    expect(closed.sent).toEqual([]);
+    expect(reconnect.sent).toEqual([startEvent, startCommentary]);
+  });
+});


### PR DESCRIPTION
## HUMAN向け

Managed Terminalの初回起動時に、WebSocket接続前に生成された開始実況が失われていました。初回の画面実況と音声対象payloadを接続後に1回だけ届けるようにしました。

## 原因

初回PTYとstart event／start commentaryがWebSocket clientの接続より先に生成され、接続後に再送されていませんでした。

## 対応設計

- 初回PTYだけを対象に、start eventとstart commentary／rules fallbackを1スロットで一時保持
- eventとcommentaryが揃った時点で、最初の接続済みclientへevent→commentaryの順に1回だけ送信
- 消費済み状態を保持し、WebSocket再接続では再送しない
- PTY generation切替時に保留payloadを破棄し、PR #428のgeneration guardを維持
- 通常のevent履歴、無制限キュー、通常実況のbroadcast頻度は変更していない

## 変更ファイル

- `apps/server/src/index.ts`
- `apps/server/src/runtime/initial-start-delivery.ts`
- `apps/server/src/tests/initial-start-delivery.test.ts`
- `apps/server/src/tests/initial-commentary-delivery.integration.test.ts`

## 新規テスト

- delivery unit test: 6件
  - 接続前／接続後のcommentary解決
  - eventとcommentaryの1回配送
  - WebSocket再接続時の重複防止
  - generation切替時の旧payload破棄
  - 接続済みPTYの即時配送維持
  - 切断clientから再接続clientへの配送
- mock CLI integration test: 2件
  - 初回起動、再接続、接続後のPTY再起動
  - mock LLM失敗時のrules fallbackと音声payload

## ローカル検証

- Server全テスト: PASS（63 files / 917 tests）
- Server typecheck: PASS
- Server build: PASS
- Web全テスト: PASS（13 files / 106 tests）
- Web lint: PASS
- Web build: PASS
- Desktop sidecar runtime tests: PASS（9 tests）
- Local readiness: PASS（7 / 7）
- docs drift guard tests/check: PASS
- actionlint: PASS
- Rust cargo check: PASS
- Rust cargo test: PASS（12 tests）
- Desktop bundle artifact verification: PASS
- Desktop distribution runtime smoke: PASS

## HUMAN実機確認項目

HUMANが新規起動したManaged Terminalで、次を確認してください。

1. 初回CLI起動時に開始実況が画面へ1回表示される
2. 同じ開始実況の音声が1回読み上げられる
3. 初回接続後のCLI再起動でstart event／実況／音声が各1回である
4. WebSocket再接続で初回実況が重複しない
5. Ctrl+C後の既存のServer維持・CLI再開動作が変わっていない

## 非対象

- 実況文の内容・表現品質
- TTS途中切れ問題
- Ctrl+C後のServer維持・CLI再開契約
- Web UIレイアウト、スクロール、release、署名、publish
- 無関係なIssueやリファクタリング

Closes #429
