### PR TITLE
fix(web): state-specific action-required banner and viewport access

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -887,6 +887,18 @@
     align-items: flex-start;
     flex-direction: column;
   }
+
+  .notice__urgent-row {
+    flex-direction: column;
+  }
+
+  .notice__urgent-actions {
+    width: 100%;
+  }
+
+  .notice__urgent-actions button {
+    flex: 1 1 160px;
+  }
 }
 
 /* TTS Settings Panel */
@@ -1077,6 +1089,12 @@
   text-align: left;
 }
 
+.notices--has-attention {
+  position: sticky;
+  top: var(--space-2);
+  z-index: var(--z-sticky);
+}
+
 .notice {
   text-align: left;
 }
@@ -1095,7 +1113,8 @@
 .notice--urgent {
   border: 2px solid var(--color-danger);
   border-left-width: 6px;
-  background: color-mix(in srgb, var(--color-danger) 8%, transparent);
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-md);
 }
 
 .notice--urgent .notice__title {
@@ -1108,6 +1127,17 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.notice__urgent-content {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.notice__urgent-content .notice__code {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .notice__time {
@@ -1116,9 +1146,30 @@
 }
 
 .notice__dismiss {
-  flex-shrink: 0;
   padding: 6px 12px;
   font-size: var(--text-sm);
+}
+
+.notice__urgent-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.notice__focus-terminal {
+  padding: 6px 12px;
+  font-size: var(--text-sm);
+}
+
+.notice__status,
+.notice__summary {
+  overflow-wrap: anywhere;
+}
+
+.notice__summary {
+  font-weight: var(--font-normal);
 }
 
 .notice__title {
@@ -1160,7 +1211,11 @@
   background: var(--color-bg-tertiary);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
+  line-height: 1.45;
   overflow-x: auto;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .notice__actions {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -142,6 +142,14 @@ export default function App() {
     setAttention(null);
   }, []);
 
+  const focusTerminal = useCallback(() => {
+    document.querySelector<HTMLElement>(".terminal-panel")?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+    terminalPaneRef.current?.focus();
+  }, []);
+
   // 即時イベントで読み上げ済みのcommentaryはTTSしない（表示はする）
   const queueSpeechDeduped = useCallback(
     (item: CommentaryItem) => {
@@ -366,6 +374,7 @@ export default function App() {
       <Notices
         attention={attention}
         onDismissAttention={clearAttention}
+        onFocusTerminal={focusTerminal}
         ptyUnavailable={ptyUnavailable}
         profileError={profileError}
         ptyError={ptyError}

--- a/apps/web/src/components/Notices.test.tsx
+++ b/apps/web/src/components/Notices.test.tsx
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { Event } from "../types";
+import { toAttentionNotice } from "../lib/event-notify";
+import { Notices } from "./Notices";
+
+const baseProps = {
+  onDismissAttention: () => undefined,
+  onFocusTerminal: () => undefined,
+  ptyUnavailable: null,
+  profileError: null,
+  ptyError: null,
+  copyState: "idle" as const,
+  onCopySuggestion: () => undefined,
+};
+
+function renderAttention(event: Event): string {
+  return renderToStaticMarkup(
+    <Notices {...baseProps} attention={toAttentionNotice(event)} />
+  );
+}
+
+describe("Notices", () => {
+  it("入力待ちでは入力先とターミナル操作を表示する", () => {
+    const markup = renderAttention({
+      ts: 1234,
+      type: "stdout",
+      summary: "質問への回答を待っている",
+      detail: "Question 1/1 (1 unanswered)",
+      priority: "urgent",
+    });
+
+    expect(markup).toContain("notices--has-attention");
+    expect(markup).toContain("入力待ち");
+    expect(markup).toContain("Managed Terminalを開いて入力");
+    expect(markup).toContain("ターミナルへ移動");
+    expect(markup).toContain("確認した");
+  });
+
+  it("実行エラーでは入力を促さず、確認操作を表示する", () => {
+    const markup = renderAttention({
+      ts: 1234,
+      type: "error",
+      summary: "エラーが出ている",
+      detail: "command failed with exit code 1",
+      priority: "urgent",
+    });
+
+    expect(markup).toContain("実行エラー");
+    expect(markup).toContain("入力待ちではありません");
+    expect(markup).not.toContain("ターミナルへ移動");
+    expect(markup).toContain("エラーを確認した");
+  });
+
+  it("確認要求では承認のためのターミナル操作と確認済み操作を表示する", () => {
+    const markup = renderAttention({
+      ts: 1234,
+      type: "stdout",
+      summary: "コマンド実行の確認待ち",
+      detail: "Would you like to run the following command?\npnpm test",
+      priority: "urgent",
+    });
+
+    expect(markup).toContain("確認要求");
+    expect(markup).toContain("確認・承認が必要");
+    expect(markup).toContain("ターミナルへ移動");
+    expect(markup).toContain("確認した");
+  });
+
+  it("長文でも原文を省略し、操作領域をDOMに残す", () => {
+    const markup = renderAttention({
+      ts: 1234,
+      type: "error",
+      summary: "エラーが出ている",
+      detail: "long error ".repeat(200),
+      priority: "urgent",
+    });
+
+    expect(markup).toContain("長文のため省略");
+    expect(markup).toContain("エラーを確認した");
+    expect(markup).toContain("notice__code");
+  });
+
+  it("確認済み状態では未確認バナーを描画しない", () => {
+    const markup = renderToStaticMarkup(<Notices {...baseProps} attention={null} />);
+
+    expect(markup).toBe("");
+  });
+});

--- a/apps/web/src/components/Notices.tsx
+++ b/apps/web/src/components/Notices.tsx
@@ -1,5 +1,9 @@
 import type { PtyUnavailableNotice } from "../hooks/useCommentatorSocket";
-import type { AttentionNotice } from "../lib/event-notify";
+import {
+  getAttentionGuidance,
+  limitAttentionDetail,
+  type AttentionNotice,
+} from "../lib/event-notify";
 import { normalizeSuggestion } from "../lib/text";
 
 type CopyState = "idle" | "copied" | "failed";
@@ -7,6 +11,7 @@ type CopyState = "idle" | "copied" | "failed";
 type NoticesProps = {
   attention: AttentionNotice | null;
   onDismissAttention: () => void;
+  onFocusTerminal: () => void;
   ptyUnavailable: PtyUnavailableNotice | null;
   profileError: string | null;
   ptyError: string | null;
@@ -17,6 +22,7 @@ type NoticesProps = {
 export function Notices({
   attention,
   onDismissAttention,
+  onFocusTerminal,
   ptyUnavailable,
   profileError,
   ptyError,
@@ -27,22 +33,26 @@ export function Notices({
 
   const suggestionText = normalizeSuggestion(ptyUnavailable?.suggestion);
   const ptyUnavailableError = normalizeSuggestion(ptyUnavailable?.error);
-  const attentionDetail = normalizeSuggestion(attention?.detail);
+  const attentionDetail = limitAttentionDetail(attention?.detail);
+  const attentionGuidance = attention ? getAttentionGuidance(attention.kind) : null;
   const copyLabel = copyState === "copied" ? "Copied" : "Copy";
 
   return (
-    <div className="notices">
-      {attention && (
-        <div className="notice notice--urgent panel" role="alert">
+    <div className={`notices${attention ? " notices--has-attention" : ""}`}>
+      {attention && attentionGuidance && (
+        <div
+          className="notice notice--urgent panel"
+          role="alert"
+          aria-label={`要対応：${attentionGuidance.label}`}
+        >
           <div className="notice__urgent-row">
-            <div>
+            <div className="notice__urgent-content">
               <div className="notice__title">
-                要対応：{attention.summary}
+                要対応：<span className="notice__status">{attentionGuidance.label}</span>
+                <span className="notice__summary">（{attention.summary}）</span>
               </div>
               <div className="notice__body">
-                <p>
-                  CLI が入力を待っている可能性があります。左のターミナルをクリックし、
-                  「入力受付中」を確認してから回答を入力し、Enter キーを押してください。
+                <p>{attentionGuidance.message}
                   <span className="notice__time">
                     （{new Date(attention.ts).toLocaleTimeString()} 検出）
                   </span>
@@ -54,14 +64,25 @@ export function Notices({
                 )}
               </div>
             </div>
-            <button
-              type="button"
-              className="btn-secondary notice__dismiss"
-              onClick={onDismissAttention}
-              aria-label="要対応の通知を閉じる"
-            >
-              確認した
-            </button>
+            <div className="notice__urgent-actions">
+              {attentionGuidance.focusTerminal && (
+                <button
+                  type="button"
+                  className="btn-secondary notice__focus-terminal"
+                  onClick={onFocusTerminal}
+                >
+                  {attentionGuidance.focusLabel}
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn-secondary notice__dismiss"
+                onClick={onDismissAttention}
+                aria-label="要対応の通知を確認済みにする"
+              >
+                {attentionGuidance.dismissLabel}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/lib/event-notify.test.ts
+++ b/apps/web/src/lib/event-notify.test.ts
@@ -3,6 +3,9 @@ import {
   buildUrgentEventSpeechText,
   createSpokenEventRegistry,
   eventSpeechKey,
+  getAttentionGuidance,
+  getAttentionKind,
+  limitAttentionDetail,
   toAttentionNotice,
 } from "./event-notify";
 import type { Event } from "../types";
@@ -21,7 +24,46 @@ describe("event-notify", () => {
       eventType: "stdout",
       summary: "許可を待っている",
       detail: "Do you want to proceed?",
+      kind: "confirmation",
     });
+  });
+
+  it.each([
+    [
+      { type: "stdout", summary: "質問への回答を待っている" },
+      "input",
+    ],
+    [{ type: "error", summary: "エラーが出ている" }, "error"],
+    [{ type: "stdout", summary: "コマンド実行の確認待ち" }, "confirmation"],
+  ] as const)("既存イベントから要対応状態を分類する: %s", (event, expected) => {
+    expect(getAttentionKind(event)).toBe(expected);
+  });
+
+  it("状態ごとに入力先と次の操作を案内する", () => {
+    expect(getAttentionGuidance("input")).toMatchObject({
+      label: "入力待ち",
+      focusTerminal: true,
+      focusLabel: "ターミナルへ移動",
+    });
+    expect(getAttentionGuidance("error")).toMatchObject({
+      label: "実行エラー",
+      focusTerminal: false,
+      dismissLabel: "エラーを確認した",
+    });
+    expect(getAttentionGuidance("error").message).toContain("入力待ちではありません");
+    expect(getAttentionGuidance("confirmation")).toMatchObject({
+      label: "確認要求",
+      focusTerminal: true,
+      dismissLabel: "確認した",
+    });
+  });
+
+  it("長い原文を操作領域を失わない長さに制限する", () => {
+    const detail = "x".repeat(1300);
+    const limited = limitAttentionDetail(detail);
+
+    expect(limited).toContain("長文のため省略");
+    expect(limited?.length).toBeLessThan(detail.length);
   });
 
   it("同一イベントを ts と type で相関づけるキーを作る", () => {

--- a/apps/web/src/lib/event-notify.ts
+++ b/apps/web/src/lib/event-notify.ts
@@ -6,13 +6,82 @@ import { buildUrgentSpeechText } from "@cli-commentator/shared/urgent-speech";
  * 後続commentaryとの二重通知防止のためのヘルパー。
  */
 
+export type AttentionKind = "input" | "error" | "confirmation";
+
 /** Web UIの要対応バナーに表示する内容 */
 export type AttentionNotice = {
   ts: number;
   eventType: EventType;
   summary: string;
   detail?: string;
+  kind: AttentionKind;
 };
+
+const INPUT_WAIT_SUMMARY_RE = /(?:質問への回答を待っている|入力待ち)/u;
+const CONFIRMATION_SUMMARY_RE = /(?:許可を待っている|確認待ち|承認待ち)/u;
+
+/**
+ * 既存のイベント種別・summaryだけで、HUMANに必要な操作の違いを決める。
+ * 未知のurgentイベントは、入力を誤って促さないよう確認要求として扱う。
+ */
+export function getAttentionKind(event: Pick<Event, "type" | "summary">): AttentionKind {
+  if (event.type === "error") return "error";
+  if (INPUT_WAIT_SUMMARY_RE.test(event.summary)) return "input";
+  if (CONFIRMATION_SUMMARY_RE.test(event.summary)) return "confirmation";
+  return "confirmation";
+}
+
+export type AttentionGuidance = {
+  label: string;
+  message: string;
+  focusTerminal: boolean;
+  focusLabel: string;
+  dismissLabel: string;
+};
+
+export function getAttentionGuidance(kind: AttentionKind): AttentionGuidance {
+  switch (kind) {
+    case "input":
+      return {
+        label: "入力待ち",
+        message:
+          "HUMANの回答が必要です。左のManaged Terminalを開いて入力し、Enterキーを押してください。",
+        focusTerminal: true,
+        focusLabel: "ターミナルへ移動",
+        dismissLabel: "確認した",
+      };
+    case "error":
+      return {
+        label: "実行エラー",
+        message:
+          "入力待ちではありません。ターミナルに入力するだけでは解決しないため、エラー内容を確認して失敗した処理や設定を見直してください。",
+        focusTerminal: false,
+        focusLabel: "",
+        dismissLabel: "エラーを確認した",
+      };
+    case "confirmation":
+      return {
+        label: "確認要求",
+        message:
+          "HUMANの確認・承認が必要です。左のManaged Terminalで内容を確認し、必要な許可・承認操作を行ってください。",
+        focusTerminal: true,
+        focusLabel: "ターミナルへ移動",
+        dismissLabel: "確認した",
+      };
+  }
+}
+
+export const MAX_ATTENTION_DETAIL_LENGTH = 1200;
+
+export function limitAttentionDetail(
+  value: string | undefined,
+  maxLength = MAX_ATTENTION_DETAIL_LENGTH
+): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength).trimEnd()}…（長文のため省略）`;
+}
 
 export function toAttentionNotice(ev: Event): AttentionNotice {
   return {
@@ -20,6 +89,7 @@ export function toAttentionNotice(ev: Event): AttentionNotice {
     eventType: ev.type,
     summary: ev.summary,
     detail: ev.detail,
+    kind: getAttentionKind(ev),
   };
 }
 


### PR DESCRIPTION
## 🧑 HUMAN向け（先に読む）

- やったこと: 要対応バナーを「入力待ち」「実行エラー」「確認要求」に分け、画面の下方を見ていても内容と操作を確認できるようにしました。
- なぜ必要か: エラー時に入力を誤って促したり、長文やページ上部固定のため確認ボタンへ戻れなくなったりする問題を防ぐためです。
- あなたの操作: Draft PRの画面を開き、後述のHUMAN実機確認項目を確認してください。MergeやReady化は不要です。

## 原因

- 要対応バナーがurgentイベントを一律に入力待ちとして案内していた。
- バナーがページ先頭の通常フローにあり、ページ下方から到達するには上へ戻る必要があった。
- 長い原文を含む横並びレイアウトで、内容領域がボタンを押し出す可能性があった。

## 対応内容

- 既存イベントのtypeとsummaryだけで状態を分類。
  - 入力待ち: 「質問への回答を待っている」
  - 実行エラー: event.type === error
  - 確認要求: 「許可を待っている」「コマンド実行の確認待ち」
- 状態ごとに案内文と操作を変更。
  - 入力待ち: Managed Terminalへ移動し、回答とEnterを促す。
  - 実行エラー: 入力待ちではないことを明示し、エラー内容の確認を促す。
  - 確認要求: Managed Terminalで許可・承認を確認するよう案内する。
- 未確認の要対応バナーをposition: stickyでviewport上部に追従させ、現在位置から内容と操作へ到達できるようにした。
- ターミナルへ移動する操作は、現在位置からManaged Terminalへスクロールし、既存ターミナルへfocusする。
- 原文は1200文字を上限に省略し、CSSで折り返す。操作ボタンは独立した操作領域にして、狭幅では縦積みにする。
- 既存の「確認した」状態解除と、PTY再起動時の解除処理は維持した。

## 変更ファイル

- apps/web/src/App.tsx
- apps/web/src/App.css
- apps/web/src/components/Notices.tsx
- apps/web/src/lib/event-notify.ts
- apps/web/src/lib/event-notify.test.ts
- apps/web/src/components/Notices.test.tsx

## 新規・変更テスト

- Web: 14 test files / 116 tests passed
- 状態分類、状態別案内、長文制限のunit testを追加
- Noticesの固定mock DOMテストを追加
  - 入力待ちの案内とターミナル操作
  - 実行エラーで入力操作を出さないこと
  - 確認要求の確認・承認案内と「確認した」
  - 長文でも原文と操作領域がDOMに残ること
  - 確認済み状態で未確認バナーを描画しないこと

## ローカル検証結果

- Web test: PASS（14 files / 116 tests）
- Web lint: PASS
- Web build: PASS
- Server test: PASS（54 suites / 702 tests）
- Server typecheck: PASS
- Server build: PASS
- Local readiness: PASS（7 / 7）
- Local readiness内のserver explicit run: PASS（63 files / 917 tests）
- Desktop sidecar runtime tests: PASS（9 tests）
- docs drift guard tests: PASS（11 tests）
- docs drift guard check: PASS
- actionlint: PASS
- Rust cargo check: PASS
- Rust cargo test: PASS（12 tests）
- Desktop bundle artifact verification: PASS
- Desktop distribution runtime smoke: PASS（health check、mock commentary生成、欠損server entry失敗経路）

## GitHub Actions

- ci: docs_drift_guard、test、desktop_check、desktop_distribution_smoke、test_windows、actionlint、failure_regression — すべてSUCCESS
- CodeQL: Analyze — SUCCESS
- Workflow run: https://github.com/gatyoukatyou/cli-commentator/actions/runs/31446849041
- CodeQL run: https://github.com/gatyoukatyou/cli-commentator/actions/runs/31446849072

## HUMAN実機確認項目

- 入力待ちで「入力待ち」と表示され、Managed Terminalへ移動して回答できる。
- 実行エラーで入力待ちと誤案内されず、エラー確認の操作ができる。
- 確認要求で確認・承認が必要だと分かり、Managed Terminalへ移動できる。
- 長文でも原文が折り返し／省略され、案内と操作ボタンが確認できる。
- 狭い画面でもボタンが画面外へ失われない。
- ページ下方から要対応バナーが見え、上端まで手動で戻らず操作できる。
- 「確認した」または「エラーを確認した」を押すと未確認表示が解除され、再レンダーで重複しない。
- ターミナル入力、通常実況、既存の確認済み管理が壊れていない。

## 非対象

- エラー・入力待ちのServer検出／分類ルール
- Server側commentary判定
- TTS、実況文、通常実況カード
- PR #430の初回実況配送とgeneration制御
- Managed Terminalのプロセス管理、Ctrl+C後のServer維持・CLI再開
- ターミナル全体のサイズ・多重スクロール問題（#407）
- #403、#407、#419、その他別Issue
- release、署名、publish

Closes #404