### PR TITLE
fix(server): keep screen narration and TTS content aligned

### DIFF
--- a/apps/server/src/commentary/narration-subject.test.ts
+++ b/apps/server/src/commentary/narration-subject.test.ts
@@ -12,9 +12,6 @@ function event(type: EventType, detail?: string): Event {
   return { ts: 0, type, summary: "テスト用", detail };
 }
 
-/** Mirrors MAX_PROGRESS_SPEECH_LENGTH in speech-policy.ts. */
-const MAX_PROGRESS_SPEECH_LENGTH = 30;
-
 describe("describeNarrationSubject", () => {
   it("names the file a read touches", () => {
     const subject = describeNarrationSubject(event("read", "⏺ Read(apps/web/src/App.tsx)"));
@@ -145,27 +142,29 @@ describe("narration with a subject", () => {
     }
   });
 
-  // Speech for progress events is replaced by a generic fallback above this
-  // length, which would undo the point of naming the subject.
-  it.each(cases)("stays within the progress speech budget (%s)", (type, detail) => {
+  it.each(cases)("uses the visible subject narration for speech (%s)", (type, detail) => {
     const ev = event(type, detail);
-    const subject = describeNarrationSubject(ev);
-    for (const comment of [commentStandard, commentKansai, commentZundamon]) {
-      expect(comment(ev, subject).length).toBeLessThanOrEqual(MAX_PROGRESS_SPEECH_LENGTH);
+    const context = createSessionContext();
+    const snapshot = context.observeEvent(ev);
+    for (const style of ["standard", "kansai", "zundamon"] as const) {
+      const payload = commentByRules(ev, style, snapshot);
+      expect(payload.narration).toBeTruthy();
+      expect(applySpeechContract(payload, ev, snapshot).speech?.text).toBe(payload.narration);
     }
   });
 
-  it("keeps a long file name inside the budget by clipping it", () => {
+  it("keeps a clipped long file target identical on screen and in speech", () => {
     const ev = event("write", "⏺ Update(apps/server/src/commentary/an-extremely-long-module-name.ts)");
-    const subject = describeNarrationSubject(ev);
-    expect(subject).toMatchObject({ kind: "file" });
-    expect(commentStandard(ev, subject).length).toBeLessThanOrEqual(MAX_PROGRESS_SPEECH_LENGTH);
+    const context = createSessionContext();
+    const snapshot = context.observeEvent(ev);
+    const payload = commentByRules(ev, "standard", snapshot);
+    expect(payload.narration).toContain("an-extremely-long");
+    expect(applySpeechContract(payload, ev, snapshot).speech?.text).toBe(payload.narration);
   });
 
-  // Regression: the phase-change line carries the full path, overruns the
-  // progress speech budget, and is then replaced by a generic fallback — so the
-  // event that introduces a target used to be the one that failed to name it.
-  it("keeps the subject on a phase change and stays speakable", () => {
+  // Regression: the phase-change line carries the full path. It must remain
+  // the same on screen and in normal speech instead of taking a fallback path.
+  it("keeps the subject on a phase change in both channels", () => {
     const event: Event = {
       ts: 1,
       type: "write",
@@ -180,7 +179,7 @@ describe("narration with a subject", () => {
     expect(payload.narration).toContain("speech-policy.ts");
 
     const spoken = applySpeechContract(payload, event, snapshot).speech?.text;
-    expect(spoken).toContain("speech-policy.ts");
+    expect(spoken).toBe(payload.narration);
   });
 
   it("falls back to the type-level sentence when nothing is identified", () => {

--- a/apps/server/src/commentary/narration-subject.ts
+++ b/apps/server/src/commentary/narration-subject.ts
@@ -31,9 +31,8 @@ export type NarrationSubject =
 export const NONE: NarrationSubject = { kind: "none" };
 
 /**
- * Speech for `progress` events is capped at 30 characters by the speech
- * contract, and anything longer is replaced by a generic fallback. Subjects are
- * clipped here so a long path never costs the sentence its subject entirely.
+ * Subjects are clipped here so a long path remains readable in the shared
+ * narration used by both the commentary card and normal speech.
  */
 const MAX_FILE_NAME_LENGTH = 18;
 const MAX_SEARCH_TERM_LENGTH = 20;

--- a/apps/server/src/commentary/rule-based.ts
+++ b/apps/server/src/commentary/rule-based.ts
@@ -182,10 +182,8 @@ export function commentByRules(
   const subject = describeNarrationSubject(ev);
   const core = codexNarration || COMMENTERS[style](ev, subject);
   const contextual = context ? contextNarration(context, style) : "";
-  // The context line spells out the full path, which overruns the progress
-  // speech budget and gets replaced by a generic fallback — losing the target
-  // entirely. A concrete subject names the same target in a sentence that fits,
-  // so it wins; the phase change is carried by the explanation instead.
+  // A concrete subject names the same target in visible narration and speech;
+  // the phase change is carried by the explanation instead.
   const lead = subject.kind !== "none" ? core : contextual || core;
 
   return withCommentaryMode({

--- a/apps/server/src/commentary/speech-policy.test.ts
+++ b/apps/server/src/commentary/speech-policy.test.ts
@@ -208,6 +208,23 @@ describe("commentary speech policy", () => {
     expect(result.speech).toEqual({ disposition: "display_only", reason: "progress_interval" });
   });
 
+  it("keeps a distinct visible progress narration speakable inside the interval", () => {
+    let now = 0;
+    const context = createSessionContext({ now: () => now });
+    context.observeEvent({ ts: 1, type: "stdout", summary: "最初の進捗", detail: "最初の内容" });
+
+    now = 2_000;
+    const event: Event = { ts: 2, type: "stdout", summary: "Codexが説明している", detail: "次の内容" };
+    const narration = "Codexが作業内容を説明してるで。";
+    const result = applySpeechContract({ narration }, event, context.observeEvent(event));
+
+    expect(result.speech).toEqual({
+      disposition: "speak",
+      reason: "progress_refresh",
+      text: narration,
+    });
+  });
+
   // A file name is the whole point of a detail-aware narration. The raw-command
   // guard used to match `tsx` inside `App.tsx` and replace the sentence with a
   // generic fallback, silently undoing the improvement on the spoken path.

--- a/apps/server/src/commentary/speech-policy.test.ts
+++ b/apps/server/src/commentary/speech-policy.test.ts
@@ -9,7 +9,7 @@ function observed(event: Event) {
 }
 
 describe("commentary speech policy", () => {
-  it("keeps display text but exposes only one sentence for speech", () => {
+  it("uses the complete display narration for speech", () => {
     const event: Event = { ts: 1, type: "read", summary: "読取", detail: "⏺ Read(src/a.ts)" };
     const payload: CommentaryPayload = {
       narration: "対象ファイルを確認しています。 詳しい根拠は画面に表示します。",
@@ -24,11 +24,11 @@ describe("commentary speech policy", () => {
     expect(result.speech).toEqual({
       disposition: "speak",
       reason: "new_task",
-      text: "対象ファイルを確認しています。",
+      text: payload.narration,
     });
   });
 
-  it("uses a complete fallback instead of mechanically truncating long progress speech", () => {
+  it("keeps long progress narration identical on screen and in speech", () => {
     const event: Event = {
       ts: 1,
       type: "read",
@@ -41,9 +41,16 @@ describe("commentary speech policy", () => {
 
     expect(result.narration).toBe(narration);
     expect(result.explanation).toBe(explanation);
-    expect(result.speech?.text?.length).toBeLessThanOrEqual(30);
-    expect(result.speech?.text).toBe("「speech-policy.ts」を確認中です。");
-    expect(result.speech?.text).not.toContain("確認し。");
+    expect(result.speech?.text).toBe(narration);
+    expect(result.speech?.text?.length).toBeGreaterThan(30);
+  });
+
+  it("uses the visible explanation when narration is absent", () => {
+    const event: Event = { ts: 1, type: "read", summary: "読取" };
+    const explanation = "表示される補足説明を読み上げます。";
+    const result = applySpeechContract({ narration: " ", explanation }, event, observed(event));
+
+    expect(result.speech?.text).toBe(explanation);
   });
 
   it("routes urgent speech through the dedicated urgent policy", () => {
@@ -76,7 +83,7 @@ describe("commentary speech policy", () => {
     expect(result.speech?.text?.length).toBeLessThanOrEqual(30);
   });
 
-  it("does not create a broken filename fragment from long quoted progress", () => {
+  it("keeps a long quoted progress narration identical on screen and in speech", () => {
     const event: Event = {
       ts: 1,
       type: "read",
@@ -86,12 +93,12 @@ describe("commentary speech policy", () => {
     const narration = "今の対象は「apps/server/src/commentary/orchestrator.ts」です。";
     const result = applySpeechContract({ narration }, event, observed(event));
 
-    expect(result.speech?.text).toBe("「orchestrator.ts」を確認中です。");
-    expect(result.speech?.text?.length).toBeLessThanOrEqual(30);
+    expect(result.speech?.text).toBe(narration);
+    expect(result.speech?.text?.length).toBeGreaterThan(30);
     expect(result.speech?.text).not.toContain("…chestrator");
   });
 
-  it("uses the observed phase when overlong progress needs the safety valve", () => {
+  it("keeps context-rich overlong progress narration identical on screen and in speech", () => {
     const event: Event = {
       ts: 1,
       type: "test",
@@ -101,7 +108,8 @@ describe("commentary speech policy", () => {
     const narration = "検証段階に入り、「apps/server/package.json」を扱っています。";
     const result = applySpeechContract({ narration }, event, observed(event));
 
-    expect(result.speech?.text).toBe("「package.json」を検証中です。");
+    expect(result.speech?.text).toBe(narration);
+    expect(result.speech?.text?.length).toBeGreaterThan(30);
   });
 
   it("falls back to a safe sentence instead of speaking a raw command", () => {

--- a/apps/server/src/commentary/speech-policy.ts
+++ b/apps/server/src/commentary/speech-policy.ts
@@ -9,16 +9,8 @@ import { standardSubjectLine } from "../styles/standard.js";
 // segment: "App.tsx を確認しています。" is narration, not a raw `tsx` invocation.
 const RAW_COMMAND_RE =
   /(?:^[⏺•]\s*|\b(?:Bash|Read|Grep|Glob|Update|Write)\(|\bapply_patch\b|(?<![-./\w])(?:rg|grep|nl|sed|git|gh|pnpm|npm|yarn|cat|find|ls|cd|pwd|node|tsx|cargo|docker|curl)\b(?:\s+|$)|\|)/iu;
-const MAX_SPEECH_LENGTH = 100;
-const MAX_PROGRESS_SPEECH_LENGTH = 30;
-
 export function hasRawCommandText(text?: string): boolean {
   return Boolean(text && RAW_COMMAND_RE.test(text));
-}
-
-function firstSentence(text: string): string {
-  const compact = text.replace(/\s+/g, " ").trim();
-  return compact.match(/^.+?[。！？!?](?:[」』”"])?/u)?.[0]?.trim() ?? compact;
 }
 
 function safeFallback(
@@ -60,34 +52,6 @@ function safeFallback(
   }
 }
 
-function progressLengthFallback(
-  event: Event,
-  context: SessionContextSnapshot,
-  subject: NarrationSubject
-): string {
-  const target = context.target
-    ?.replace(/\\/gu, "/")
-    .split("/")
-    .at(-1)
-    ?.trim();
-  const action = event.type === "read"
-    ? "確認"
-    : event.type === "search"
-      ? "調査"
-      : event.type === "write"
-        ? "更新"
-        : event.type === "test" || event.type === "lint" || event.type === "build"
-          ? "検証"
-          : null;
-  if (target && action && !hasRawCommandText(target)) {
-    const targetSentence = `「${target}」を${action}中です。`;
-    if (targetSentence.length <= MAX_PROGRESS_SPEECH_LENGTH) {
-      return targetSentence;
-    }
-  }
-  return safeFallback(event, context, subject);
-}
-
 function speechSentence(
   payload: CommentaryPayload,
   event: Event,
@@ -100,19 +64,14 @@ function speechSentence(
   if (event.type === "done") {
     return safeFallback(event, context, subject);
   }
-  const candidate = firstSentence(payload.narration ?? payload.explanation ?? "");
-  if (!candidate || candidate.length > MAX_SPEECH_LENGTH || hasRawCommandText(candidate)) {
+  // Normal narration is already the text shown in the commentary card. Keep
+  // that same text for speech so a long or multi-sentence line is not silently
+  // replaced by a different fallback.
+  const candidate = payload.narration?.trim() || payload.explanation?.trim() || "";
+  // Raw command text remains an intentional safety exception: it may stay on
+  // screen for diagnosis, but is replaced in speech to avoid reading commands.
+  if (!candidate || hasRawCommandText(candidate)) {
     return safeFallback(event, context, subject);
-  }
-  if (
-    getEventPriority(event) === "progress" &&
-    candidate.length > MAX_PROGRESS_SPEECH_LENGTH
-  ) {
-    // A mechanical substring is liable to drop the observed result, break
-    // Japanese grammar, or erase the selected character style. The prompt is
-    // responsible for producing a complete short sentence; this is only the
-    // safety valve for a provider that exceeds that contract.
-    return progressLengthFallback(event, context, subject);
   }
   return candidate;
 }

--- a/apps/server/src/session-context.test.ts
+++ b/apps/server/src/session-context.test.ts
@@ -308,6 +308,19 @@ describe("SessionContext", () => {
     });
   });
 
+  it("does not suppress different normal commentary within the progress interval", () => {
+    let now = 0;
+    const context = createSessionContext({ now: () => now });
+    context.setTaskContext({ objective: "実況を続ける", source: "fixture" });
+
+    expect(context.observeEvent(event("stdout", "最初の内容", "作業内容を説明しています。")).speech)
+      .toMatchObject({ disposition: "speak" });
+
+    now = 2_000;
+    expect(context.observeEvent(event("stdout", "次の内容", "別の作業内容を説明しています。")).speech)
+      .toEqual({ disposition: "speak", reason: "progress_refresh" });
+  });
+
   it("speaks phase changes and new targets even within the progress interval", () => {
     let now = 0;
     const context = createSessionContext({ now: () => now });

--- a/apps/server/src/session-context.ts
+++ b/apps/server/src/session-context.ts
@@ -70,6 +70,7 @@ type MutableState = {
   acceptsHumanInput: boolean;
   lastProgressSpeechAt: number;
   lastProgressKey: string | null;
+  lastProgressEventKey: string | null;
   lastSpokenTarget: string | null;
   seenGlossaryNotes: Set<string>;
 };
@@ -239,6 +240,7 @@ function initialState(): MutableState {
     acceptsHumanInput: false,
     lastProgressSpeechAt: Number.NEGATIVE_INFINITY,
     lastProgressKey: null,
+    lastProgressEventKey: null,
     lastSpokenTarget: null,
     seenGlossaryNotes: new Set(),
   };
@@ -290,6 +292,12 @@ function progressKey(state: MutableState): string {
   return `${taskKey}\u0000${state.phase}`;
 }
 
+function progressEventKey(event: Event): string {
+  const summary = limited(event.summary, MAX_SUMMARY_LENGTH) ?? event.type;
+  const detail = limited(event.detail, MAX_CONTEXT_LENGTH) ?? "";
+  return `${event.type}\u0000${summary}\u0000${detail}`;
+}
+
 function decideSpeech(
   state: MutableState,
   event: Event,
@@ -312,8 +320,11 @@ function decideSpeech(
 
   if (!reason && priority === "progress") {
     const key = progressKey(state);
+    const eventKey = progressEventKey(event);
     const withinInterval =
-      state.lastProgressKey === key && now - state.lastProgressSpeechAt < intervalMs;
+      state.lastProgressKey === key &&
+      state.lastProgressEventKey === eventKey &&
+      now - state.lastProgressSpeechAt < intervalMs;
     if (withinInterval) {
       return { disposition: "display_only", reason: "progress_interval" };
     }
@@ -324,6 +335,7 @@ function decideSpeech(
 
   if (commentaryEligible && priority === "progress") {
     state.lastProgressKey = progressKey(state);
+    state.lastProgressEventKey = progressEventKey(event);
     state.lastProgressSpeechAt = now;
   }
   if (commentaryEligible && (reason === "new_task" || reason === "new_target")) {

--- a/apps/server/src/styles/prompt.ts
+++ b/apps/server/src/styles/prompt.ts
@@ -223,5 +223,8 @@ export function normalizeGeneratedCommentaryText(
     return firstSentence.replace(/^1行メモ:\s*/u, "").trim();
   }
 
-  return firstSentence.trim();
+  // Keep the complete visible narration. The speech contract uses this same
+  // value for normal commentary, so dropping the second sentence here would
+  // make the screen and audio disagree before they reach the client.
+  return stripped;
 }

--- a/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
+++ b/apps/server/src/tests/__snapshots__/phase-b-evaluation.test.ts.snap
@@ -12,7 +12,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "speech": {
           "disposition": "speak",
           "reason": "new_task",
-          "text": "「pnpm-workspace.yaml」を調査中です。",
+          "text": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
         },
       },
       "withoutContext": {
@@ -30,7 +30,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "speech": {
           "disposition": "speak",
           "reason": "new_target",
-          "text": "「orchestrator.ts」を確認中です。",
+          "text": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
         },
       },
       "withoutContext": {
@@ -66,7 +66,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
         "speech": {
           "disposition": "speak",
           "reason": "new_target",
-          "text": "「extract.ts」を確認中です。",
+          "text": "今の対象は「apps/server/src/extract.ts」や。",
         },
       },
       "withoutContext": {
@@ -212,7 +212,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "speech": {
         "disposition": "speak",
         "reason": "new_task",
-        "text": "「pnpm-workspace.yaml」を調査中です。",
+        "text": "調査段階に入って、「pnpm-workspace.yaml」を扱ってるで。",
       },
       "ts": 400,
     },
@@ -246,7 +246,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "speech": {
         "disposition": "speak",
         "reason": "new_target",
-        "text": "「orchestrator.ts」を確認中です。",
+        "text": "今の対象は「apps/server/src/commentary/orchestrator.ts」や。",
       },
       "ts": 3218,
     },
@@ -326,7 +326,7 @@ exports[`Phase B evaluation replay > replays the minimal sanitized session deter
       "speech": {
         "disposition": "speak",
         "reason": "new_target",
-        "text": "「extract.ts」を確認中です。",
+        "text": "今の対象は「apps/server/src/extract.ts」や。",
       },
       "ts": 10573,
     },

--- a/apps/server/src/tests/comment.prompt.test.ts
+++ b/apps/server/src/tests/comment.prompt.test.ts
@@ -192,10 +192,10 @@ describe("session context prompts", () => {
 });
 
 describe("normalizeGeneratedCommentaryText", () => {
-  it("keeps narration to the first sentence and strips labels", () => {
+  it("keeps complete narration and strips labels", () => {
     expect(
       normalizeGeneratedCommentaryText("実況: テストを走らせています。次の行も説明します。", "narration")
-    ).toBe("テストを走らせています。");
+    ).toBe("テストを走らせています。次の行も説明します。");
   });
 
   it("strips memo-like explanation prefixes", () => {

--- a/apps/web/src/hooks/useTTS.ts
+++ b/apps/web/src/hooks/useTTS.ts
@@ -110,7 +110,7 @@ export function useTTS({ commentaryDisplayMode }: UseTTSOptions) {
       pending.latest.speech
     );
     if (!speechText) return;
-    // notice（完了/沈黙）は進行中の発話を止めずキュー末尾、progressは従来のcancel方式
+    // notice（完了/沈黙）は進行中の発話を止めずキュー末尾、progressは再生待ちだけを最新へ置換
     speakWithPriority(speechText, pending.latest.priority ?? "progress", ttsSettingsRef.current);
   }, [commentaryDisplayMode]);
 

--- a/apps/web/src/hooks/useTTS.ts
+++ b/apps/web/src/hooks/useTTS.ts
@@ -110,8 +110,18 @@ export function useTTS({ commentaryDisplayMode }: UseTTSOptions) {
       pending.latest.speech
     );
     if (!speechText) return;
-    // notice（完了/沈黙）は進行中の発話を止めずキュー末尾、progressは再生待ちだけを最新へ置換
-    speakWithPriority(speechText, pending.latest.priority ?? "progress", ttsSettingsRef.current);
+    const queueClass =
+      pending.latest.eventType === "stdout" && pending.latest.summary === "長考・沈黙が続いている"
+        ? "heartbeat"
+        : "normal";
+    // notice（完了）は進行中の発話を止めずキューへ追加し、heartbeatは通常実況の後ろへ送る。
+    speakWithPriority(
+      speechText,
+      pending.latest.priority ?? "progress",
+      ttsSettingsRef.current,
+      "ja-JP",
+      queueClass
+    );
   }, [commentaryDisplayMode]);
 
   const schedulePendingSpeech = useCallback(() => {

--- a/apps/web/src/lib/speech-lifecycle.test.ts
+++ b/apps/web/src/lib/speech-lifecycle.test.ts
@@ -148,6 +148,37 @@ describe("speech lifecycle recorder", () => {
     expect(recorder.export().metrics.speechCompletionRate).toBe(0.7);
   });
 
+  it("records suppressed and replaced outcomes separately from completed speech", () => {
+    const recorder = createSpeechLifecycleRecorder({
+      now: () => 0,
+      wallNow: () => 0,
+      sessionId: () => "s",
+    });
+
+    recorder.record({
+      kind: "suppressed",
+      speechId: "heartbeat-1",
+      priority: "progress",
+      text: "定型の待機実況",
+      reason: "heartbeat_suppressed",
+    });
+    recorder.record({
+      kind: "replaced",
+      speechId: "legacy-progress-1",
+      priority: "progress",
+      text: "置き換え対象",
+      reason: "progress_replace",
+    });
+
+    expect(recorder.export()).toMatchObject({
+      metrics: { suppressed: 1, replaced: 1, dropped: 0, progressDropped: 2 },
+      events: [
+        { kind: "suppressed", reason: "heartbeat_suppressed" },
+        { kind: "replaced", reason: "progress_replace" },
+      ],
+    });
+  });
+
   it("detects style-varied repeated progress within 120 seconds and urgent misses", () => {
     let now = 0;
     const recorder = createSpeechLifecycleRecorder({ now: () => now, wallNow: () => now, sessionId: () => "s" });

--- a/apps/web/src/lib/speech-lifecycle.ts
+++ b/apps/web/src/lib/speech-lifecycle.ts
@@ -4,7 +4,14 @@ import {
   REPEATED_PROGRESS_SPEECH_WINDOW_MS,
 } from "@cli-commentator/shared";
 
-export type SpeechLifecycleKind = "queued" | "started" | "ended" | "cancelled" | "dropped";
+export type SpeechLifecycleKind =
+  | "queued"
+  | "started"
+  | "ended"
+  | "cancelled"
+  | "replaced"
+  | "suppressed"
+  | "dropped";
 
 export type SpeechLifecycleEventInput = {
   kind: SpeechLifecycleKind;
@@ -27,6 +34,8 @@ export type SpeechLifecycleMetrics = {
   started: number;
   ended: number;
   cancelled: number;
+  replaced: number;
+  suppressed: number;
   dropped: number;
   urgentInterruptions: number;
   noticeQueued: number;
@@ -107,6 +116,8 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
     started: 0,
     ended: 0,
     cancelled: 0,
+    replaced: 0,
+    suppressed: 0,
     dropped: 0,
     urgentInterruptions: 0,
     noticeQueued: 0,
@@ -143,6 +154,8 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
       started: 0,
       ended: 0,
       cancelled: 0,
+      replaced: 0,
+      suppressed: 0,
       dropped: 0,
       urgentInterruptions: 0,
       noticeQueued: 0,
@@ -182,6 +195,13 @@ export function createSpeechLifecycleRecorder(options: RecorderOptions = {}) {
         startedAt: null,
         spokenCharacters: 0,
       });
+      return;
+    }
+
+    if (input.kind === "replaced" || input.kind === "suppressed") {
+      if (input.kind === "replaced") metrics.replaced += 1;
+      else metrics.suppressed += 1;
+      if (input.priority === "progress") metrics.progressDropped += 1;
       return;
     }
 

--- a/apps/web/src/lib/speech-scheduler.test.ts
+++ b/apps/web/src/lib/speech-scheduler.test.ts
@@ -85,7 +85,7 @@ describe("createSpeechScheduler", () => {
     ]);
   });
 
-  it("再生待ちの古いprogressだけを最新のprogressへ置き換える", () => {
+  it("再生待ちの通常progressを置き換えず、画面に出た順で保持する", () => {
     const fake = createFakeSink();
     const dropped: Array<{ text: string; reason: string }> = [];
     const scheduler = createSpeechScheduler(fake.sink, {
@@ -98,13 +98,51 @@ describe("createSpeechScheduler", () => {
 
     expect(fake.calls).toEqual([{ kind: "speak", text: "再生中" }]);
     expect(fake.cancelReasons).not.toContain("progress_replace");
-    expect(dropped).toEqual([{ text: "待機中の古い実況", reason: "progress_replace" }]);
+    expect(dropped).toEqual([]);
 
     fake.settle(0);
     expect(fake.calls).toEqual([
       { kind: "speak", text: "再生中" },
+      { kind: "speak", text: "待機中の古い実況" },
+    ]);
+    fake.settle(1);
+    expect(fake.calls).toEqual([
+      { kind: "speak", text: "再生中" },
+      { kind: "speak", text: "待機中の古い実況" },
       { kind: "speak", text: "最新の実況" },
     ]);
+  });
+
+  it("heartbeatは通常progressの後ろへ送り、後から来た通常progressを先に読む", () => {
+    const fake = createFakeSink();
+    const scheduler = createSpeechScheduler(fake.sink);
+
+    scheduler.speak("progress", "再生中の通常実況", undefined);
+    scheduler.speak("progress", "待機中のheartbeat", undefined, "heartbeat");
+    scheduler.speak("progress", "後続の通常実況", undefined);
+
+    fake.settle(0);
+    fake.settle(1);
+    fake.settle(2);
+
+    expect(fake.calls.map((call) => call.kind === "speak" ? call.text : "cancel")).toEqual([
+      "再生中の通常実況",
+      "後続の通常実況",
+      "待機中のheartbeat",
+    ]);
+  });
+
+  it("通常progressが待機中ならheartbeatを抑止する", () => {
+    const fake = createFakeSink();
+    const dropped: Array<{ text: string; reason: string }> = [];
+    const scheduler = createSpeechScheduler(fake.sink, {
+      onDropped: (request, reason) => dropped.push({ text: request.text, reason }),
+    });
+
+    scheduler.speak("progress", "再生中", undefined);
+    scheduler.speak("progress", "未再生の通常実況", undefined);
+    expect(scheduler.speak("progress", "定型heartbeat", undefined, "heartbeat")).toBe(false);
+    expect(dropped).toEqual([{ text: "定型heartbeat", reason: "heartbeat_suppressed" }]);
   });
 
   it("120秒以内の同じprogressはスタイル違いでも間引く", () => {
@@ -136,31 +174,39 @@ describe("createSpeechScheduler", () => {
     expect(scheduler.speak("progress", "状況を確認しています。", undefined)).toBe(true);
   });
 
-  it("urgent/notice が未消化の間、progress は間引かれる", () => {
+  it("urgent/notice が未消化でも通常progressを捨てず、後ろで待機させる", () => {
     const fake = createFakeSink();
     const scheduler = createSpeechScheduler(fake.sink);
 
     scheduler.speak("urgent", "許可待ち", undefined);
     expect(scheduler.hasPendingHighPriority()).toBe(true);
-    expect(scheduler.speak("progress", "実況", undefined)).toBe(false);
+    expect(scheduler.speak("progress", "実況", undefined)).toBe(true);
     expect(fake.calls.filter((call) => call.kind === "speak")).toHaveLength(1);
 
-    // urgent の発話が終了したら progress を再開できる
+    // urgent の発話が終了したら待機中のprogressを再開できる
     fake.settle(0);
     expect(scheduler.hasPendingHighPriority()).toBe(false);
-    expect(scheduler.speak("progress", "実況", undefined)).toBe(true);
+    expect(fake.calls).toEqual([
+      { kind: "cancel" },
+      { kind: "speak", text: "許可待ち" },
+      { kind: "speak", text: "実況" },
+    ]);
   });
 
-  it("notice が複数積まれた場合は全件消化まで progress を間引く", () => {
+  it("notice が複数積まれても通常progressを後続に保持する", () => {
     const fake = createFakeSink();
     const scheduler = createSpeechScheduler(fake.sink);
 
     scheduler.speak("notice", "完了1", undefined);
     scheduler.speak("notice", "完了2", undefined);
     fake.settle(0);
-    expect(scheduler.speak("progress", "実況", undefined)).toBe(false);
-    fake.settle(1);
     expect(scheduler.speak("progress", "実況", undefined)).toBe(true);
+    fake.settle(1);
+    expect(fake.calls).toEqual([
+      { kind: "speak", text: "完了1" },
+      { kind: "speak", text: "完了2" },
+      { kind: "speak", text: "実況" },
+    ]);
   });
 
   it("cancel() は内部状態をリセットし、古い発話の終了通知を無視する", () => {
@@ -191,7 +237,7 @@ describe("createSpeechScheduler", () => {
     expect(scheduler.speak("progress", "実況", undefined)).toBe(true);
   });
 
-  it("assigns stable IDs and records urgent interruption, notice append, and progress thinning", () => {
+  it("assigns stable IDs and records urgent interruption without dropping normal progress", () => {
     const fake = createFakeSink();
     const dropped: Array<{ id: string; reason: string }> = [];
     let id = 0;
@@ -201,14 +247,14 @@ describe("createSpeechScheduler", () => {
     });
 
     expect(scheduler.speak("notice", "完了を追記", undefined)).toBe(true);
-    expect(scheduler.speak("progress", "間引かれる進捗", undefined)).toBe(false);
+    expect(scheduler.speak("progress", "待機する進捗", undefined)).toBe(true);
     expect(scheduler.speak("urgent", "割り込み", undefined)).toBe(true);
 
     expect(fake.requests.map(({ id, priority, queueDepth, queueReason }) => ({ id, priority, queueDepth, queueReason }))).toEqual([
       { id: "speech-1", priority: "notice", queueDepth: 1, queueReason: "notice_append" },
       { id: "speech-3", priority: "urgent", queueDepth: 1, queueReason: "urgent_interrupt" },
     ]);
-    expect(dropped).toEqual([{ id: "speech-2", reason: "high_priority_pending" }]);
+    expect(dropped).toEqual([]);
     expect(fake.cancelReasons).toContain("urgent_interrupt");
   });
 });

--- a/apps/web/src/lib/speech-scheduler.test.ts
+++ b/apps/web/src/lib/speech-scheduler.test.ts
@@ -45,7 +45,6 @@ describe("createSpeechScheduler", () => {
     expect(scheduler.speak("urgent", "許可待ち", undefined)).toBe(true);
 
     expect(fake.calls).toEqual([
-      { kind: "cancel" },
       { kind: "speak", text: "実況中" },
       { kind: "cancel" },
       { kind: "speak", text: "許可待ち" },
@@ -59,25 +58,52 @@ describe("createSpeechScheduler", () => {
     scheduler.speak("progress", "実況中", undefined);
     expect(scheduler.speak("notice", "完了しました", undefined)).toBe(true);
 
+    expect(fake.calls).toEqual([{ kind: "speak", text: "実況中" }]);
+    fake.settle(0);
+
     expect(fake.calls).toEqual([
-      { kind: "cancel" },
       { kind: "speak", text: "実況中" },
       { kind: "speak", text: "完了しました" },
     ]);
   });
 
-  it("progress は従来どおり前の発話をキャンセルして最新のみ読み上げる", () => {
+  it("progress は再生中の発話をキャンセルせず、終了後に次の発話を読む", () => {
     const fake = createFakeSink();
     const scheduler = createSpeechScheduler(fake.sink);
 
-    scheduler.speak("progress", "1件目", undefined);
-    scheduler.speak("progress", "2件目", undefined);
+    expect(scheduler.speak("progress", "1件目", undefined)).toBe(true);
+    expect(scheduler.speak("progress", "2件目", undefined)).toBe(true);
+
+    expect(fake.calls).toEqual([{ kind: "speak", text: "1件目" }]);
+    expect(fake.cancelReasons).not.toContain("progress_replace");
+
+    fake.settle(0);
 
     expect(fake.calls).toEqual([
-      { kind: "cancel" },
       { kind: "speak", text: "1件目" },
-      { kind: "cancel" },
       { kind: "speak", text: "2件目" },
+    ]);
+  });
+
+  it("再生待ちの古いprogressだけを最新のprogressへ置き換える", () => {
+    const fake = createFakeSink();
+    const dropped: Array<{ text: string; reason: string }> = [];
+    const scheduler = createSpeechScheduler(fake.sink, {
+      onDropped: (request, reason) => dropped.push({ text: request.text, reason }),
+    });
+
+    scheduler.speak("progress", "再生中", undefined);
+    scheduler.speak("progress", "待機中の古い実況", undefined);
+    scheduler.speak("progress", "最新の実況", undefined);
+
+    expect(fake.calls).toEqual([{ kind: "speak", text: "再生中" }]);
+    expect(fake.cancelReasons).not.toContain("progress_replace");
+    expect(dropped).toEqual([{ text: "待機中の古い実況", reason: "progress_replace" }]);
+
+    fake.settle(0);
+    expect(fake.calls).toEqual([
+      { kind: "speak", text: "再生中" },
+      { kind: "speak", text: "最新の実況" },
     ]);
   });
 
@@ -160,7 +186,7 @@ describe("createSpeechScheduler", () => {
     scheduler.speak("urgent", "エラー発生", undefined);
 
     // urgent 1件のみが残っている状態
-    fake.settle(2);
+    fake.settle(1);
     expect(scheduler.hasPendingHighPriority()).toBe(false);
     expect(scheduler.speak("progress", "実況", undefined)).toBe(true);
   });

--- a/apps/web/src/lib/speech-scheduler.ts
+++ b/apps/web/src/lib/speech-scheduler.ts
@@ -8,8 +8,8 @@ import {
  * 優先度つき読み上げスケジューラ
  * - urgent: 進行中・待機中の発話をすべてキャンセルして即時読み上げ（割り込み）
  * - notice: 進行中の発話を止めず、キュー末尾に追加
- * - progress: 再生中の発話は止めず、再生待ちのprogressだけを最新へ置換する。
- *   ただしurgent/noticeの発話が残っている間は間引き（読み上げない）
+ * - progress: 再生中の発話は止めず、通常実況をFIFOで保持する。
+ * - heartbeat: 待機・沈黙の定型実況。通常実況の後ろへ送り、通常実況が待機中なら間引く。
  *
  * Web Speech API へは直接依存せず、SpeechSink 経由で発話する（テスト容易性のため）。
  */
@@ -22,8 +22,13 @@ export type SpeechSink<Opts> = {
 };
 
 export type SpeechCancellationReason = "urgent_interrupt" | "progress_replace" | "manual_stop";
-export type SpeechDropReason = "high_priority_pending" | "repeated_progress" | "progress_replace";
-export type SpeechQueueReason = "urgent_interrupt" | "notice_append" | "progress_latest";
+export type SpeechQueueClass = "normal" | "heartbeat";
+export type SpeechDropReason =
+  | "high_priority_pending"
+  | "repeated_progress"
+  | "heartbeat_suppressed"
+  | "progress_replace";
+export type SpeechQueueReason = "urgent_interrupt" | "notice_append" | "progress_fifo" | "heartbeat_low_priority";
 
 export type ScheduledSpeech<Opts> = {
   id: string;
@@ -32,6 +37,7 @@ export type ScheduledSpeech<Opts> = {
   opts: Opts;
   queueDepth: number;
   queueReason: SpeechQueueReason;
+  queueClass: SpeechQueueClass;
 };
 
 type SpeechSchedulerOptions<Opts> = {
@@ -42,7 +48,7 @@ type SpeechSchedulerOptions<Opts> = {
 
 export type SpeechScheduler<Opts> = {
   /** @returns 発話をキューに積んだら true、間引いた場合は false */
-  speak(priority: EventPriority, text: string, opts: Opts): boolean;
+  speak(priority: EventPriority, text: string, opts: Opts, queueClass?: SpeechQueueClass): boolean;
   /** すべての発話を破棄し、内部状態をリセットする */
   cancel(): void;
   /** urgent/notice の発話が未消化で残っているか */
@@ -95,7 +101,14 @@ export function createSpeechScheduler<Opts>(
     isHighPriority: boolean,
     queueReason: SpeechQueueReason
   ): void => {
-    queued.push({ request, isHighPriority, queueReason });
+    const entry = { request, isHighPriority, queueReason };
+    // heartbeat is always the lowest queued priority. New normal progress and
+    // notices go in front of any heartbeat that has not started yet.
+    const insertAt = request.queueClass === "heartbeat"
+      ? queued.length
+      : queued.findIndex(({ request: queuedRequest }) => queuedRequest.queueClass === "heartbeat");
+    if (insertAt < 0) queued.push(entry);
+    else queued.splice(insertAt, 0, entry);
     if (isHighPriority) pendingHighCount += 1;
     pendingTotalCount += 1;
     pump();
@@ -116,34 +129,19 @@ export function createSpeechScheduler<Opts>(
     options.onDropped?.({
       ...request,
       queueDepth: pendingTotalCount,
-      queueReason: "progress_latest",
+      queueReason: request.queueClass === "heartbeat" ? "heartbeat_low_priority" : "progress_fifo",
     }, reason);
     return false;
   };
 
-  const replaceQueuedProgress = (
-    request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">
-  ): boolean => {
-    const index = queued.findIndex(({ request: queuedRequest }) => queuedRequest.priority === "progress");
-    if (index < 0) return false;
-
-    const previous = queued[index];
-    options.onDropped?.(toScheduledSpeech(previous), "progress_replace");
-    queued[index] = {
-      request,
-      isHighPriority: false,
-      queueReason: "progress_latest",
-    };
-    return true;
-  };
-
   return {
-    speak(priority, text, opts) {
+    speak(priority, text, opts, queueClass = "normal") {
       const request = {
         id: options.nextId?.() ?? `speech-${Date.now()}-${++fallbackId}`,
         priority,
         text,
         opts,
+        queueClass,
       };
       if (priority === "urgent") {
         sink.cancel("urgent_interrupt", request.id);
@@ -157,11 +155,6 @@ export function createSpeechScheduler<Opts>(
         return true;
       }
 
-      // progress: 高優先の発話が残っている間は間引く
-      if (pendingHighCount > 0) {
-        return drop(request, "high_priority_pending");
-      }
-
       const repetitionKey = normalizeSpeechRepetitionKey(text);
       const current = now();
       const lastProgressAt = lastProgressAtByKey.get(repetitionKey);
@@ -173,9 +166,17 @@ export function createSpeechScheduler<Opts>(
         return drop(request, "repeated_progress");
       }
       lastProgressAtByKey.set(repetitionKey, current);
-      if (!replaceQueuedProgress(request)) {
-        enqueue(request, false, "progress_latest");
+      if (
+        queueClass === "heartbeat" &&
+        queued.some(({ request: queuedRequest }) => queuedRequest.priority === "progress" && queuedRequest.queueClass === "normal")
+      ) {
+        return drop(request, "heartbeat_suppressed");
       }
+      enqueue(
+        request,
+        false,
+        queueClass === "heartbeat" ? "heartbeat_low_priority" : "progress_fifo"
+      );
       return true;
     },
     cancel() {

--- a/apps/web/src/lib/speech-scheduler.ts
+++ b/apps/web/src/lib/speech-scheduler.ts
@@ -8,8 +8,8 @@ import {
  * 優先度つき読み上げスケジューラ
  * - urgent: 進行中・待機中の発話をすべてキャンセルして即時読み上げ（割り込み）
  * - notice: 進行中の発話を止めず、キュー末尾に追加
- * - progress: 従来のcancel方式（最新のみ）。ただしurgent/noticeの発話が
- *   残っている間は間引き（読み上げない）
+ * - progress: 再生中の発話は止めず、再生待ちのprogressだけを最新へ置換する。
+ *   ただしurgent/noticeの発話が残っている間は間引き（読み上げない）
  *
  * Web Speech API へは直接依存せず、SpeechSink 経由で発話する（テスト容易性のため）。
  */
@@ -22,7 +22,7 @@ export type SpeechSink<Opts> = {
 };
 
 export type SpeechCancellationReason = "urgent_interrupt" | "progress_replace" | "manual_stop";
-export type SpeechDropReason = "high_priority_pending" | "repeated_progress";
+export type SpeechDropReason = "high_priority_pending" | "repeated_progress" | "progress_replace";
 export type SpeechQueueReason = "urgent_interrupt" | "notice_append" | "progress_latest";
 
 export type ScheduledSpeech<Opts> = {
@@ -55,29 +55,56 @@ export function createSpeechScheduler<Opts>(
 ): SpeechScheduler<Opts> {
   // cancel()後に届く古いonSettledを無視するための世代番号
   let generation = 0;
+  type QueueEntry = {
+    request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">;
+    isHighPriority: boolean;
+    queueReason: SpeechQueueReason;
+  };
+  let active: QueueEntry | null = null;
+  const queued: QueueEntry[] = [];
   let pendingHighCount = 0;
   let pendingTotalCount = 0;
   let fallbackId = 0;
   let lastProgressAtByKey = new Map<string, number>();
   const now = options.now ?? Date.now;
 
-  const submit = (
+  const toScheduledSpeech = (entry: QueueEntry): ScheduledSpeech<Opts> => ({
+    ...entry.request,
+    queueDepth: pendingTotalCount,
+    queueReason: entry.queueReason,
+  });
+
+  const pump = (): void => {
+    if (active || queued.length === 0) return;
+
+    const next = queued.shift();
+    if (!next) return;
+    active = next;
+    const submittedGeneration = generation;
+    sink.speak(toScheduledSpeech(next), () => {
+      if (submittedGeneration !== generation || active?.request.id !== next.request.id) return;
+      active = null;
+      if (next.isHighPriority) pendingHighCount = Math.max(0, pendingHighCount - 1);
+      pendingTotalCount = Math.max(0, pendingTotalCount - 1);
+      pump();
+    });
+  };
+
+  const enqueue = (
     request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">,
     isHighPriority: boolean,
     queueReason: SpeechQueueReason
   ): void => {
-    const submittedGeneration = generation;
+    queued.push({ request, isHighPriority, queueReason });
     if (isHighPriority) pendingHighCount += 1;
     pendingTotalCount += 1;
-    sink.speak({ ...request, queueDepth: pendingTotalCount, queueReason }, () => {
-      if (submittedGeneration !== generation) return;
-      if (isHighPriority) pendingHighCount = Math.max(0, pendingHighCount - 1);
-      pendingTotalCount = Math.max(0, pendingTotalCount - 1);
-    });
+    pump();
   };
 
   const reset = (): void => {
     generation += 1;
+    active = null;
+    queued.length = 0;
     pendingHighCount = 0;
     pendingTotalCount = 0;
   };
@@ -94,6 +121,22 @@ export function createSpeechScheduler<Opts>(
     return false;
   };
 
+  const replaceQueuedProgress = (
+    request: Omit<ScheduledSpeech<Opts>, "queueDepth" | "queueReason">
+  ): boolean => {
+    const index = queued.findIndex(({ request: queuedRequest }) => queuedRequest.priority === "progress");
+    if (index < 0) return false;
+
+    const previous = queued[index];
+    options.onDropped?.(toScheduledSpeech(previous), "progress_replace");
+    queued[index] = {
+      request,
+      isHighPriority: false,
+      queueReason: "progress_latest",
+    };
+    return true;
+  };
+
   return {
     speak(priority, text, opts) {
       const request = {
@@ -105,12 +148,12 @@ export function createSpeechScheduler<Opts>(
       if (priority === "urgent") {
         sink.cancel("urgent_interrupt", request.id);
         reset();
-        submit(request, true, "urgent_interrupt");
+        enqueue(request, true, "urgent_interrupt");
         return true;
       }
 
       if (priority === "notice") {
-        submit(request, true, "notice_append");
+        enqueue(request, true, "notice_append");
         return true;
       }
 
@@ -130,9 +173,9 @@ export function createSpeechScheduler<Opts>(
         return drop(request, "repeated_progress");
       }
       lastProgressAtByKey.set(repetitionKey, current);
-      sink.cancel("progress_replace", request.id);
-      reset();
-      submit(request, false, "progress_latest");
+      if (!replaceQueuedProgress(request)) {
+        enqueue(request, false, "progress_latest");
+      }
       return true;
     },
     cancel() {

--- a/apps/web/src/lib/tts.test.ts
+++ b/apps/web/src/lib/tts.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_TTS_SETTINGS,
   TTS_PRESETS,
   applyTTSPreset,
   detectTTSPreset,
+  getTTSLifecycleLog,
   normalizeForSpeech,
+  resetTTSLifecycleLog,
+  speakWithPriority,
+  splitForSpeech,
   type TTSSettings,
 } from "./tts";
 
@@ -65,5 +69,90 @@ describe("normalizeForSpeech", () => {
       "ようかくにんです。ようたいおうです：設定を見直します。"
     );
     expect(displayText).toBe("要確認です。要対応です：設定を見直します。");
+  });
+
+  it("長文を切り捨てず、安全なチャンクへ分割して全文を復元できる", () => {
+    const input = Array.from({ length: 18 }, (_, index) =>
+      `実況${index}: 次の出力を確認しながら処理を続けています。`
+    ).join("");
+    const normalized = normalizeForSpeech(input);
+    const chunks = splitForSpeech(input, 48);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => Array.from(chunk).length <= 48)).toBe(true);
+    expect(chunks.join("")).toBe(normalized);
+  });
+
+  it("長文の各チャンクを順番にTTSへ渡し、最後のendedまで全文を保持する", () => {
+    type FakeUtterance = {
+      text: string;
+      onstart: (() => void) | null;
+      onboundary: ((event: { charIndex: number }) => void) | null;
+      onend: (() => void) | null;
+      onerror: ((event: { error: string }) => void) | null;
+    };
+    class FakeSpeechSynthesisUtterance implements FakeUtterance {
+      text: string;
+      onstart: (() => void) | null = null;
+      onboundary: ((event: { charIndex: number }) => void) | null = null;
+      onend: (() => void) | null = null;
+      onerror: ((event: { error: string }) => void) | null = null;
+      lang = "";
+      rate = 1;
+      pitch = 1;
+      volume = 1;
+
+      constructor(text: string) {
+        this.text = text;
+      }
+    }
+
+    const utterances: FakeUtterance[] = [];
+    const fakeSpeechSynthesis = {
+      getVoices: () => [],
+      speak: (utterance: FakeUtterance) => utterances.push(utterance),
+      cancel: vi.fn(),
+    };
+    vi.stubGlobal("window", { speechSynthesis: fakeSpeechSynthesis });
+    vi.stubGlobal("speechSynthesis", fakeSpeechSynthesis);
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeSpeechSynthesisUtterance);
+    resetTTSLifecycleLog("long_text_test");
+    fakeSpeechSynthesis.cancel.mockClear();
+
+    const input = Array.from({ length: 24 }, (_, index) =>
+      `長文実況${index}: 画面に表示した内容を最後まで順番に読み上げます。`
+    ).join("");
+    const normalized = normalizeForSpeech(input);
+    const firstChunkCount = splitForSpeech(input).length;
+    expect(speakWithPriority(input, "progress")).toBe(true);
+    expect(speakWithPriority("次の通常実況も待機させます。", "progress")).toBe(true);
+    expect(utterances).toHaveLength(1);
+
+    for (let index = 0; index < firstChunkCount; index += 1) {
+      const utterance = utterances[index];
+      utterance.onstart?.();
+      utterance.onboundary?.({ charIndex: utterance.text.length });
+      utterance.onend?.();
+    }
+
+    expect(utterances.length).toBe(firstChunkCount + 1);
+    expect(utterances.slice(0, firstChunkCount).map(({ text }) => text).join("")).toBe(normalized);
+    expect(utterances[firstChunkCount]?.text).toBe("次の通常実況も待機させます。");
+    expect(fakeSpeechSynthesis.cancel).not.toHaveBeenCalled();
+
+    utterances[firstChunkCount]?.onstart?.();
+    utterances[firstChunkCount]?.onend?.();
+
+    expect(getTTSLifecycleLog().events.map(({ kind }) => kind)).toEqual([
+      "queued",
+      "started",
+      "ended",
+      "queued",
+      "started",
+      "ended",
+    ]);
+
+    resetTTSLifecycleLog("long_text_test_cleanup");
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -1,9 +1,9 @@
 /**
  * TTS (Text-to-Speech) utilities using Web Speech API
- * Sprint 24: cancel方式（最新のみ読み上げ）
+ * Sprint 24: cancel方式（当時の最新のみ読み上げ）
  * Sprint 25: TTS設定（voice/rate/pitch/volume）
  * Sprint 26: 読み上げプリセット
- * #309: 優先度つき読み上げ（urgent割り込み / noticeキュー / progress従来）
+ * #309: 優先度つき読み上げ（urgent割り込み / noticeキュー / progress待機置換）
  */
 
 import {
@@ -177,9 +177,10 @@ export function waitForVoices(timeoutMs = 3000): Promise<SpeechSynthesisVoice[]>
 }
 
 /**
- * テキスト正規化（ログ記号除去、長さ制限）
+ * テキスト正規化（ログ記号除去）。
+ * 長さで切り捨てず、必要な場合の分割は splitForSpeech で行う。
  */
-export function normalizeForSpeech(text: string, maxLength = 500): string {
+export function normalizeForSpeech(text: string): string {
   const cleaned = TTS_PRONUNCIATION_REPLACEMENTS.reduce(
     (value, [pattern, replacement]) => value.replace(pattern, replacement),
     stripControlChars(text)
@@ -190,7 +191,44 @@ export function normalizeForSpeech(text: string, maxLength = 500): string {
       .trim()
   );
 
-  return cleaned.length > maxLength ? cleaned.slice(0, maxLength) + "..." : cleaned;
+  return cleaned;
+}
+
+/**
+ * Web Speech APIへ渡す安全な長さの発話単位へ分割する。
+ * 分割位置は句読点・空白を優先するが、チャンク連結で正規化後の全文を
+ * 完全に復元できるよう、文字を黙って削除しない。
+ */
+export function splitForSpeech(text: string, maxLength = 500): string[] {
+  const normalized = normalizeForSpeech(text);
+  if (!normalized) return [];
+
+  const limit = Number.isFinite(maxLength) ? Math.max(1, Math.floor(maxLength)) : 500;
+  const characters = Array.from(normalized);
+  const chunks: string[] = [];
+  let offset = 0;
+
+  while (offset < characters.length) {
+    const remaining = characters.length - offset;
+    if (remaining <= limit) {
+      chunks.push(characters.slice(offset).join(""));
+      break;
+    }
+
+    let chunkLength = limit;
+    const preferredMinimum = Math.max(1, Math.floor(limit * 0.6));
+    for (let index = limit; index >= preferredMinimum; index -= 1) {
+      if (/[\s。！？!?、,，；;：:]/u.test(characters[offset + index - 1] ?? "")) {
+        chunkLength = index;
+        break;
+      }
+    }
+
+    chunks.push(characters.slice(offset, offset + chunkLength).join(""));
+    offset += chunkLength;
+  }
+
+  return chunks;
 }
 
 type SpeakOptions = {
@@ -199,7 +237,14 @@ type SpeakOptions = {
 };
 
 const lifecycleRecorder = createSpeechLifecycleRecorder();
-const activeSpeech = new Map<string, ScheduledSpeech<SpeakOptions>>();
+type ActiveSpeech = {
+  request: ScheduledSpeech<SpeakOptions>;
+  chunks: string[];
+  chunkIndex: number;
+  spokenOffset: number;
+  started: boolean;
+};
+const activeSpeech = new Map<string, ActiveSpeech>();
 let speechId = 0;
 
 const scheduler = createSpeechScheduler<SpeakOptions>({
@@ -207,9 +252,9 @@ const scheduler = createSpeechScheduler<SpeakOptions>({
     for (const request of activeSpeech.values()) {
       lifecycleRecorder.record({
         kind: "cancelled",
-        speechId: request.id,
-        priority: request.priority,
-        text: request.text,
+        speechId: request.request.id,
+        priority: request.request.priority,
+        text: request.request.text,
         reason,
         causeSpeechId,
       });
@@ -220,23 +265,20 @@ const scheduler = createSpeechScheduler<SpeakOptions>({
   speak(request, onSettled) {
     const { settings: options, lang } = request.opts;
     const settings = { ...DEFAULT_TTS_SETTINGS, ...options };
-
-    const utterance = new SpeechSynthesisUtterance(request.text);
-    utterance.lang = lang;
-    utterance.rate = settings.rate;
-    utterance.pitch = settings.pitch;
-    utterance.volume = settings.volume;
-
-    // 指定された音声を設定
-    if (settings.voiceURI) {
-      const voices = speechSynthesis.getVoices();
-      const voice = voices.find((v) => v.voiceURI === settings.voiceURI);
-      if (voice) {
-        utterance.voice = voice;
-      }
+    const chunks = splitForSpeech(request.text);
+    if (chunks.length === 0) {
+      onSettled();
+      return;
     }
 
-    activeSpeech.set(request.id, request);
+    const active: ActiveSpeech = {
+      request,
+      chunks,
+      chunkIndex: 0,
+      spokenOffset: 0,
+      started: false,
+    };
+    activeSpeech.set(request.id, active);
     lifecycleRecorder.record({
       kind: "queued",
       speechId: request.id,
@@ -245,41 +287,78 @@ const scheduler = createSpeechScheduler<SpeakOptions>({
       reason: request.queueReason,
       queueDepth: request.queueDepth,
     });
-    utterance.onstart = () => {
-      if (!activeSpeech.has(request.id)) return;
-      lifecycleRecorder.record({
-        kind: "started",
-        speechId: request.id,
-        priority: request.priority,
-        text: request.text,
-      });
+
+    const speakChunk = (): void => {
+      const current = activeSpeech.get(request.id);
+      if (!current) return;
+
+      const chunk = current.chunks[current.chunkIndex];
+      if (!chunk) return;
+      const utterance = new SpeechSynthesisUtterance(chunk);
+      utterance.lang = lang;
+      utterance.rate = settings.rate;
+      utterance.pitch = settings.pitch;
+      utterance.volume = settings.volume;
+
+      // 指定された音声を設定
+      if (settings.voiceURI) {
+        const voices = speechSynthesis.getVoices();
+        const voice = voices.find((v) => v.voiceURI === settings.voiceURI);
+        if (voice) {
+          utterance.voice = voice;
+        }
+      }
+
+      utterance.onstart = () => {
+        const startedSpeech = activeSpeech.get(request.id);
+        if (!startedSpeech || startedSpeech.started) return;
+        startedSpeech.started = true;
+        lifecycleRecorder.record({
+          kind: "started",
+          speechId: request.id,
+          priority: request.priority,
+          text: request.text,
+        });
+      };
+      utterance.onboundary = (event) => {
+        const speaking = activeSpeech.get(request.id);
+        if (!speaking) return;
+        lifecycleRecorder.updateProgress(request.id, speaking.spokenOffset + event.charIndex);
+      };
+      utterance.onend = () => {
+        const finished = activeSpeech.get(request.id);
+        if (!finished) return;
+        finished.spokenOffset += chunk.length;
+        if (finished.chunkIndex + 1 < finished.chunks.length) {
+          finished.chunkIndex += 1;
+          speakChunk();
+          return;
+        }
+
+        activeSpeech.delete(request.id);
+        lifecycleRecorder.record({
+          kind: "ended",
+          speechId: request.id,
+          priority: request.priority,
+          text: request.text,
+        });
+        onSettled();
+      };
+      utterance.onerror = (event) => {
+        if (!activeSpeech.delete(request.id)) return;
+        lifecycleRecorder.record({
+          kind: "cancelled",
+          speechId: request.id,
+          priority: request.priority,
+          text: request.text,
+          reason: `speech_error:${event.error}`,
+        });
+        onSettled();
+      };
+      speechSynthesis.speak(utterance);
     };
-    utterance.onboundary = (event) => {
-      if (!activeSpeech.has(request.id)) return;
-      lifecycleRecorder.updateProgress(request.id, event.charIndex);
-    };
-    utterance.onend = () => {
-      if (!activeSpeech.delete(request.id)) return;
-      lifecycleRecorder.record({
-        kind: "ended",
-        speechId: request.id,
-        priority: request.priority,
-        text: request.text,
-      });
-      onSettled();
-    };
-    utterance.onerror = (event) => {
-      if (!activeSpeech.delete(request.id)) return;
-      lifecycleRecorder.record({
-        kind: "cancelled",
-        speechId: request.id,
-        priority: request.priority,
-        text: request.text,
-        reason: `speech_error:${event.error}`,
-      });
-      onSettled();
-    };
-    speechSynthesis.speak(utterance);
+
+    speakChunk();
   },
 }, {
   nextId: () => `speech-${Date.now()}-${++speechId}`,
@@ -338,7 +417,7 @@ export function stopSpeech(): void {
  * 優先度つき読み上げ
  * - urgent: 進行中の発話に割り込む（従来のcancel方式と同じ即時性）
  * - notice: 進行中の発話を止めずキュー末尾に追加
- * - progress: 従来のcancel方式。ただしurgent/notice消化中は間引く
+ * - progress: 再生中は止めず、再生待ちだけ最新へ置換する。urgent/notice消化中は間引く
  * @returns 読み上げをキューに積んだら true、間引いた場合は false
  */
 export function speakWithPriority(
@@ -356,7 +435,7 @@ export function speakWithPriority(
 }
 
 /**
- * 読み上げ実行（cancel方式：前の発話をキャンセルして最新のみ）
+ * 読み上げ実行（urgent扱い：前の発話へ割り込む）
  * ユーザー操作起点（開始アナウンス・テスト読み上げ）用。urgent扱いで割り込む。
  * @param text 読み上げるテキスト
  * @param options TTS設定（省略時はデフォルト）

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -10,6 +10,7 @@ import {
   createSpeechScheduler,
   type ScheduledSpeech,
   type SpeechCancellationReason,
+  type SpeechQueueClass,
 } from "./speech-scheduler";
 import { createSpeechLifecycleRecorder, type SpeechLifecycleExport } from "./speech-lifecycle";
 import type { EventPriority } from "../types";
@@ -364,7 +365,7 @@ const scheduler = createSpeechScheduler<SpeakOptions>({
   nextId: () => `speech-${Date.now()}-${++speechId}`,
   onDropped(request, reason) {
     lifecycleRecorder.record({
-      kind: "dropped",
+      kind: reason === "progress_replace" ? "replaced" : "suppressed",
       speechId: request.id,
       priority: request.priority,
       text: request.text,
@@ -417,21 +418,22 @@ export function stopSpeech(): void {
  * 優先度つき読み上げ
  * - urgent: 進行中の発話に割り込む（従来のcancel方式と同じ即時性）
  * - notice: 進行中の発話を止めずキュー末尾に追加
- * - progress: 再生中は止めず、再生待ちだけ最新へ置換する。urgent/notice消化中は間引く
+ * - progress: 再生中は止めず、通常実況をFIFOで保持する。heartbeatは通常実況の後ろへ送る
  * @returns 読み上げをキューに積んだら true、間引いた場合は false
  */
 export function speakWithPriority(
   text: string,
   priority: EventPriority,
   options: Partial<TTSSettings> = {},
-  lang = "ja-JP"
+  lang = "ja-JP",
+  queueClass: SpeechQueueClass = "normal"
 ): boolean {
   if (!isTTSSupported()) return false;
 
   const normalized = normalizeForSpeech(text);
   if (!normalized) return false;
 
-  return scheduler.speak(priority, normalized, { settings: options, lang });
+  return scheduler.speak(priority, normalized, { settings: options, lang }, queueClass);
 }
 
 /**


### PR DESCRIPTION
## 結果

- HUMAN再確認で見つかった「画面には出た通常実況が、次の実況到着前に読まれず消える」問題をPR #432内で修正しました。
- 修正commit: b8a3b21512acd72712e4466c9475dcf132d2203d
- HUMAN実機再確認：合格
- PR #432：Ready for review・OPEN、未マージです。
- `Closes #403`

## HUMAN向け解説

画面に表示された通常実況を、音声が勝手に省略したり後続通知で捨てたりしないようにしました。内容のある通常実況は到着順に残し、定型的な待機通知は通常実況の後ろへ回すか、通常実況が待機中なら抑止します。自動テストとGitHub Actionsは成功しています。HUMAN実機再確認も合格し、PRはReady for reviewへ変更済みです。次はマージ指示待ちです。

## 確定した原因

1. Serverの進捗音声判定が、同じタスク・同じphaseにいる異なる通常実況まで30秒間 `display_only` にしていました。Webはこの状態を読み上げ対象外としていたため、画面には出ても `speech.text` が生成されない経路がありました。
2. Webの待機progress置換が、まだ開始していない通常実況を最新通知へ置き換えていました。画面に出た内容を発話開始前に捨てるため、後続の一般的なheartbeatだけが読まれる可能性がありました。

## 修正内容

- Serverは同一タスク・同一phaseでも、イベント内容が異なる通常実況を抑止しないようにしました。
- 同一イベントの重複抑止は維持し、画面表示用の全文を音声へ渡す契約も維持しました。
- Webの通常実況は、再生中・待機中ともFIFOで保持します。通常実況同士で `progress_replace` やcancelは発生しません。
- heartbeat（沈黙・待機の定型通知）は最低優先度として通常実況の後ろへ送り、通常実況が待機中なら `suppressed` として記録します。
- urgentの即時割り込み、長文の安全な分割、生コマンド非読み上げ、完了/noticeの既存扱いは維持しました。
- TTSライフサイクルログで `queued / started / ended / replaced / suppressed / cancelled` を識別できるようにしました。

## 変更ファイル

PR全体で17ファイルです。

- Server: `apps/server/src/commentary/narration-subject.*`, `speech-policy.*`, `rule-based.ts`, `session-context.*`, `styles/prompt.ts`, `tests/comment.prompt.test.ts`, phase-b snapshot
- Web: `apps/web/src/hooks/useTTS.ts`, `apps/web/src/lib/speech-lifecycle.*`, `speech-scheduler.*`, `tts.*`

## 新規・変更テスト

- Server: 異なる通常実況をprogress interval内で読み上げる回帰、speech.textまで確認する回帰
- Web: 待機中通常実況のFIFO保持、heartbeatの後回し/抑止、urgent維持、ライフサイクルの `replaced / suppressed` 記録
- Server全体: 63 files / 922 tests PASS
- Web全体: 14 files / 122 tests PASS
- 長文分割、startedからendedまでの継続、重複抑止、生コマンド非読み上げ、urgent割り込みの既存回帰 PASS

## ローカル検証

- Server typecheck / build: PASS
- Web lint / build: PASS
- `pnpm check:local-readiness --skip-desktop`: PASS（4/4）
- Server全体テスト、Server typecheck: PASS
- Desktop sidecar runtime: PASS（9 tests）
- docs drift guard: PASS（11 tests + guard）
- actionlint: PASS
- Rust `cargo check`: PASS
- Rust `cargo test`: PASS（12 tests）
- Desktop bundle artifact verification: PASS（既存prepared bundle）
- distribution smoke: PASS（health、mock commentary、server entry欠損経路）

full readinessではsidecar準備のみFAILしました。これは今回の変更ではなく、ローカルのHomebrew Node 22が同梱用のself-contained Nodeではないため `sidecar_node_not_portable` になったものです。CIのDesktop検証は成功しています。秘密鍵、APIキー、実会話は使用していません。

## GitHub Actions

今回のcommitに対する全9チェックが成功しました。

- Analyze / CodeQL
- actionlint
- docs_drift_guard
- failure_regression
- test
- test_windows
- desktop_check
- desktop_distribution_smoke

## HUMAN実機確認項目

- 長めの通常実況が画面と同じ全文で最後まで読み上げられる
- 通常実況の読み上げ開始前に次の通常実況が来ても、先の実況が消えず到着順に読まれる
- 「Codexが作業内容を説明してるで。」のような内容のある実況が、後続heartbeatに置き換わらず読まれる
- heartbeatは通常実況を飛ばさず、後回しまたは抑止される
- urgent通知の割り込みは従来どおり動作する
- 生コマンドは読み上げない
- 同じ実況が重複して読み上げられない
- 通常の実況表示、TTS設定、ターミナル入力が壊れていない

## 非対象

- 要対応バナーUI（#404）
- エラー・入力待ち・確認要求の検出/分類
- 実況文の品質、TTSエンジン、音声契約wire形式
- Managed Terminal、ターミナル全体レイアウト（#407）
- release、署名、publish
- PR #432のmerge、Issue #403の手動close

HUMAN実機再確認とReady化を完了しました。PRは未マージのまま、次のHUMAN指示を待ちます。