### PR TITLE
fix(web): 小さいウィンドウでもターミナル入力領域を維持する

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,6 +1,7 @@
 #root {
   max-width: none;
   width: 100%;
+  min-height: 100%;
   margin: 0 auto;
   padding: 0;
   text-align: center;
@@ -89,15 +90,23 @@
 
 .app-shell {
   max-width: 1760px;
+  height: 100vh;
+  min-height: 0;
   margin: 0 auto;
   padding: var(--space-4);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .workspace-layout {
   display: grid;
   grid-template-columns: minmax(720px, 1.2fr) minmax(560px, 1fr);
   gap: var(--space-4);
-  align-items: start;
+  align-items: stretch;
+  flex: 1 1 auto;
+  min-height: 0;
   margin-top: var(--space-3);
 }
 
@@ -105,6 +114,7 @@
   display: grid;
   gap: var(--space-3);
   min-width: 0;
+  min-height: 0;
 }
 
 .workspace-column--left {
@@ -120,9 +130,22 @@
 }
 
 .commentary-panel {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-2);
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.commentary-panel > .log-toolbar {
+  flex: 0 0 auto;
+}
+
+.commentary-panel > .log-container {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
 }
 
 .commentary-panel__header {
@@ -278,12 +301,13 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   min-height: 0;
+  overflow: hidden;
 }
 
 .terminal-panel__screen {
-  min-height: 82vh;
-  height: 82vh;
-  max-height: 82vh;
+  min-height: 0;
+  height: auto;
+  max-height: none;
   overflow: hidden;
   margin: 0;
   padding: 0;
@@ -352,6 +376,9 @@
   font-size: var(--text-sm);
   z-index: var(--z-debug);
   width: min(360px, calc(100vw - 24px));
+  max-height: calc(100vh - 24px);
+  overflow-y: auto;
+  box-sizing: border-box;
   text-align: left;
   box-shadow: var(--shadow-lg);
 }
@@ -458,6 +485,16 @@
   gap: var(--space-1);
   align-items: center;
   flex-wrap: wrap;
+}
+
+.debug-panel__actions--server-control {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  margin-top: var(--space-2);
+  padding: var(--space-2) 0 var(--space-1);
+  border-top: var(--panel-border);
+  background: var(--color-bg-secondary);
 }
 
 .debug-panel__actions--wrap {
@@ -608,7 +645,13 @@
   }
 
   .workspace-layout {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+  }
+
+  .workspace-column--left {
+    flex: 0 0 auto;
   }
 
   .commentary-panel__header {
@@ -616,9 +659,9 @@
   }
 
   .terminal-panel__screen {
-    min-height: 340px;
-    max-height: 50vh;
-    height: 50vh;
+    min-height: 180px;
+    max-height: none;
+    height: clamp(180px, 36vh, 320px);
   }
 
   .debug-panel {
@@ -636,6 +679,10 @@
 }
 
 @media (max-width: 1280px) {
+  .workspace-layout {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  }
+
   .launcher-panel__toolbar {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   }
@@ -688,6 +735,17 @@
   flex: 0 0 180px;
 }
 
+.log-toolbar__latest {
+  flex: 0 0 auto;
+  padding: var(--space-1) var(--space-2);
+  border: var(--btn-border-hover);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-fg-primary);
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
 .log-toolbar__meta {
   margin-top: 6px;
   font-size: var(--text-xs);
@@ -698,10 +756,55 @@
   border: var(--panel-border);
   border-radius: var(--radius-md);
   padding: var(--space-3);
-  min-height: 82vh;
-  max-height: 82vh;
+  min-height: 0;
+  max-height: none;
   overflow: auto;
   text-align: left;
+}
+
+@media (max-width: 768px) and (max-height: 480px) {
+  .terminal-panel__screen {
+    min-height: 120px;
+    height: 120px;
+  }
+
+  .launcher-panel,
+  .workspace-subpanel {
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+  }
+}
+
+@media (max-height: 480px) {
+  .workspace-layout {
+    align-items: start;
+    overflow-y: auto;
+  }
+
+  .workspace-column--left {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    align-self: start;
+  }
+
+  .workspace-column--left .terminal-panel {
+    order: -1;
+    flex: 0 0 auto;
+  }
+
+  .workspace-column--left .launcher-panel {
+    order: 1;
+  }
+
+  .workspace-column--left .workspace-subpanel {
+    order: 2;
+  }
+
+  .terminal-panel__screen {
+    min-height: 120px;
+    height: 120px;
+  }
 }
 
 .log-empty {

--- a/apps/web/src/components/CommentaryLog.tsx
+++ b/apps/web/src/components/CommentaryLog.tsx
@@ -8,6 +8,7 @@ import {
   type CommentaryItem,
   type LogEventTypeFilter,
 } from "../lib/log-filter";
+import { getLatestLogScrollTop, isAtLogLatest } from "../lib/log-scroll";
 import type { CommentaryDisplayMode, EventPriority } from "../types";
 import { normalizeSuggestion } from "../lib/text";
 
@@ -16,7 +17,6 @@ const PRIORITY_BADGES: Partial<Record<EventPriority, { label: string; className:
   notice: { label: "通知", className: "log-item__priority-badge--notice" },
 };
 
-const LOG_AUTO_SCROLL_THRESHOLD_PX = 64;
 const GENERIC_LOG_SUMMARIES = new Set(["ログ更新"]);
 const GROUP_DETAIL_PREVIEW_COUNT = 3;
 
@@ -47,6 +47,7 @@ type CommentaryLogProps = {
 export function CommentaryLog({ items, displayMode }: CommentaryLogProps) {
   const [query, setQuery] = useState("");
   const [eventType, setEventType] = useState<LogEventTypeFilter>("all");
+  const [isAtLatest, setIsAtLatest] = useState(true);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const shouldStickRef = useRef(true);
   const filteredItems = useMemo(
@@ -58,8 +59,17 @@ export function CommentaryLog({ items, displayMode }: CommentaryLogProps) {
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
-    const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    shouldStickRef.current = distanceToBottom <= LOG_AUTO_SCROLL_THRESHOLD_PX;
+    const atLatest = isAtLogLatest(container);
+    shouldStickRef.current = atLatest;
+    setIsAtLatest(atLatest);
+  }, []);
+
+  const handleJumpToLatest = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollTop = getLatestLogScrollTop(container);
+    shouldStickRef.current = true;
+    setIsAtLatest(true);
   }, []);
 
   useEffect(() => {
@@ -95,6 +105,16 @@ export function CommentaryLog({ items, displayMode }: CommentaryLogProps) {
               </option>
             ))}
           </select>
+          {!isAtLatest && (
+            <button
+              type="button"
+              className="log-toolbar__latest"
+              onClick={handleJumpToLatest}
+              aria-label="最新の実況ログへ戻る"
+            >
+              最新へ戻る
+            </button>
+          )}
         </div>
         <div className="log-toolbar__meta">
           {filteredItems.length} / {items.length} 件

--- a/apps/web/src/components/TauriStatusPanel.tsx
+++ b/apps/web/src/components/TauriStatusPanel.tsx
@@ -553,7 +553,7 @@ export default function TauriStatusPanel({ onStatusChange }: TauriStatusPanelPro
         </section>
       )}
 
-      <div className="debug-panel__actions">
+      <div className="debug-panel__actions debug-panel__actions--server-control">
         <button className="debug-panel__btn debug-panel__btn--primary" onClick={handleStart} disabled={startDisabled}>
           {startLabel}
         </button>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -281,10 +281,15 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  display: block;
   min-width: 320px;
   min-height: 100vh;
+}
+
+html,
+body {
+  width: 100%;
+  min-height: 100%;
 }
 
 h1 {

--- a/apps/web/src/lib/log-scroll.test.ts
+++ b/apps/web/src/lib/log-scroll.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDistanceToLogBottom,
+  getLatestLogScrollTop,
+  isAtLogLatest,
+  LOG_AUTO_SCROLL_THRESHOLD_PX,
+} from "./log-scroll";
+
+describe("commentary log scroll follow state", () => {
+  it("treats the bottom as the latest position", () => {
+    expect(isAtLogLatest({ scrollHeight: 1000, scrollTop: 800, clientHeight: 200 })).toBe(true);
+    expect(getDistanceToLogBottom({ scrollHeight: 1000, scrollTop: 800, clientHeight: 200 })).toBe(0);
+  });
+
+  it("keeps following within the small bottom threshold", () => {
+    expect(
+      isAtLogLatest({ scrollHeight: 1000, scrollTop: 800 - LOG_AUTO_SCROLL_THRESHOLD_PX + 1, clientHeight: 200 })
+    ).toBe(true);
+    expect(
+      isAtLogLatest({ scrollHeight: 1000, scrollTop: 800 - LOG_AUTO_SCROLL_THRESHOLD_PX - 1, clientHeight: 200 })
+    ).toBe(false);
+  });
+
+  it("does not treat a past position as latest", () => {
+    expect(isAtLogLatest({ scrollHeight: 1000, scrollTop: 420, clientHeight: 200 })).toBe(false);
+  });
+
+  it("calculates the scroll position used by 最新へ戻る", () => {
+    expect(getLatestLogScrollTop({ scrollHeight: 1000, scrollTop: 0, clientHeight: 200 })).toBe(800);
+    expect(getLatestLogScrollTop({ scrollHeight: 120, scrollTop: 0, clientHeight: 200 })).toBe(0);
+  });
+});

--- a/apps/web/src/lib/log-scroll.ts
+++ b/apps/web/src/lib/log-scroll.ts
@@ -1,0 +1,22 @@
+export const LOG_AUTO_SCROLL_THRESHOLD_PX = 64;
+
+export type LogScrollMetrics = {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+};
+
+export function getDistanceToLogBottom({ scrollHeight, scrollTop, clientHeight }: LogScrollMetrics): number {
+  return Math.max(0, scrollHeight - scrollTop - clientHeight);
+}
+
+export function isAtLogLatest(
+  metrics: LogScrollMetrics,
+  threshold = LOG_AUTO_SCROLL_THRESHOLD_PX
+): boolean {
+  return getDistanceToLogBottom(metrics) <= threshold;
+}
+
+export function getLatestLogScrollTop({ scrollHeight, clientHeight }: LogScrollMetrics): number {
+  return Math.max(0, scrollHeight - clientHeight);
+}


### PR DESCRIPTION
## 結果

Draft PRです。Issue #407の狭い画面・短い画面でManaged Terminalを優先するレイアウト修正を実装しました。

## HUMAN向け解説

小さいウィンドウで補助パネルに押し出されていたターミナル入力欄を、画面内で確認しやすい位置へ戻しました。実況ログを過去位置で見ている間は勝手に末尾へ戻らず、「最新へ戻る」で追従を再開できます。Desktop Serverの長い診断表示でも、Start/Retry StartとStopを操作できるようにしています。

## 原因

- Terminalと実況ログに82vhの固定高があり、ヘッダー・補助パネルと合算すると短い画面で入力欄が下へ押し出されていた。
- 狭幅時のgrid/flex縮小でTerminalPaneの外枠だけが縮み、内部の入力行がクリップされる場合があった。
- 実況ログは末尾追従の内部判定はあったが、過去位置を示す状態と最新位置へ戻る操作がなかった。
- Desktop Serverパネルに高さ上限・内部スクロール・操作部固定がなかった。

## 修正内容

- app shell/workspaceをviewport内のflexレイアウトに変更し、82vh固定高を解除。
- 600x400など短い画面ではManaged Terminalを左列の先頭に置き、端末画面を120px以上確保。
- 1280px以下で2列の最小幅による横溢れを抑制し、狭幅では主要領域を明確化。
- CommentaryLogへ最新追従状態と「最新へ戻る」操作を追加。
- Desktop Serverへmax-height・内部スクロール・Start/Retry Start/Stopのsticky操作部を追加。

## 変更ファイル

- `apps/web/src/App.css`
- `apps/web/src/index.css`
- `apps/web/src/components/CommentaryLog.tsx`
- `apps/web/src/components/TauriStatusPanel.tsx`
- `apps/web/src/lib/log-scroll.ts`
- `apps/web/src/lib/log-scroll.test.ts`

## テスト・検証

- Web Vitest: 15 files / 126 tests passed
- Web lint: passed
- Web build: passed
- Server `vitest --run`: 63 files / 923 tests passed
- Server typecheck/build: passed
- Local readiness `--skip-desktop`: 4/4 passed
- Desktop sidecar runtime tests: 9/9 passed
- docs drift guard tests/check: passed
- actionlint: passed
- Browser layout verification: 600x400, 600x768, 1024x400, 1024x768でTerminal入力行がviewport内にあることを確認
- Rust cargo check/testとdesktop full readiness: Homebrew Node 22が非portableでsidecar準備を拒否し、CI用artifact未生成のためローカル実行不可。#407変更が原因ではありません。

## HUMAN実機確認項目

1. 600x400でManaged Terminalを開き、入力位置と入力中の文字が見えること。
2. 600x768、1024x400、1024x768で通常表示・入力・実況表示を確認すること。
3. 過去の実況ログをスクロールし、新着が来ても位置が維持されること。
4. 「最新へ戻る」で末尾へ移動し、その後の新着へ自動追従すること。
5. 最新位置では「最新へ戻る」が表示されないこと。
6. Desktop Serverの長い失敗・診断表示をスクロールし、Start/Retry StartとStopを操作できること。
7. 通常のターミナル入力、実況一覧、TTS、既存の操作が壊れていないこと。

## 非対象

TTS、実況の生成・判定内容、Ctrl+C終了処理、Server、Issue #403、Issue #424、#402、#406、release/publishは変更していません。

Closes #407