### PR TITLE
fix(commentary): distinguish Codex prose from current errors

### DIFF
--- a/apps/server/src/__tests__/extract.test.ts
+++ b/apps/server/src/__tests__/extract.test.ts
@@ -277,4 +277,40 @@ describe("extractEvents fixtures", () => {
   it("does not treat an empty failed-id field as an error", () => {
     expect(extractEvents("failed_remote_plugin_ids=[]", "codex")).toEqual([]);
   });
+
+  it.each([
+    "The explanation mentions Error: only as an example.",
+    "The previous command failed, so I changed the approach.",
+    "The previous command failed with exit code 1, so I changed the approach.",
+    "UI status: Error: is displayed in the action-required banner.",
+    "> Error: quoted from an earlier command",
+    "> Command failed with exit code 1",
+    "Tests: 0 failed, 7 passed",
+    "Test Files  0 failed (7)",
+    "✖ 3 problems (0 errors, 3 warnings)",
+    "Process exited with code 0",
+    "Please confirm which approach to take before I continue.",
+  ])("does not classify Codex prose or completed status as an error: %s", (line) => {
+    expect(extractEvents(line, "codex")).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "error" })])
+    );
+  });
+
+  it.each([
+    "Error: Cannot find module 'zod'",
+    "TypeError: Cannot read properties of undefined",
+    "Command failed with exit code 1",
+    "Tests: 2 failed, 5 passed",
+    "Test Files  1 failed (1)",
+    "✖ 3 problems (3 errors, 0 warnings)",
+    "Process exited with code 1",
+    "TS2322: Type 'string' is not assignable to type 'number'.",
+    "error TS2322 in src/index.ts during tsc -p tsconfig.json",
+    "ELIFECYCLE Command failed",
+    "2026-07-19T01:00:09.000000Z ERROR codex_core_plugins::remote::remote_installed_plugin_sync: plugin sync failed failed_remote_plugin_ids=[\"plugin-demo\"]",
+  ])("keeps structured current Codex failures as errors: %s", (line) => {
+    expect(extractEvents(line, "codex")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "error" })])
+    );
+  });
 });

--- a/apps/server/src/extract.ts
+++ b/apps/server/src/extract.ts
@@ -2,6 +2,7 @@ import type { Event } from "./types.js";
 import { getAutoDetectedSource, rulesForLine } from "./rulesets/index.js";
 import { isClaudeTuiNoise, isCodexProgressNoise, isCodexTuiAssistantLine, isTerminalRenderingNoise } from "./progress-noise.js";
 import { extractClaudeSupervisionEvents } from "./rulesets/claude-supervision.js";
+import { isCurrentCodexErrorLine } from "./rulesets/codex.js";
 import { extractFileListCommand, isFileListExecution, isSearchExecution } from "./command-analysis.js";
 import { ANSI_ESCAPE_RE } from "./terminal-escapes.js";
 
@@ -544,7 +545,12 @@ function preprocessLine(rawLine: string, sourceEnv?: string): string | null {
     return normalized;
   }
 
-  if (/^>\s/.test(normalized) || /\bapply_patch\b|ELIFECYCLE|exit code|error|failed|exception|TS\d{4,5}/i.test(normalized)) {
+  if (/^>\s/.test(normalized)) return normalized;
+  if (/\bapply_patch\b/i.test(normalized)) return normalized;
+  if (source === "codex") {
+    return isCurrentCodexErrorLine(normalized) ? normalized : null;
+  }
+  if (/\bapply_patch\b|ELIFECYCLE|exit code|error|failed|exception|TS\d{4,5}/i.test(normalized)) {
     return normalized;
   }
 

--- a/apps/server/src/rulesets/codex.ts
+++ b/apps/server/src/rulesets/codex.ts
@@ -2,6 +2,24 @@ import type { RuleSet } from "./types.js";
 import { isSearchExecution, isTestExecution } from "../command-analysis.js";
 import { isCodexTuiAssistantLine } from "../progress-noise.js";
 
+const CODEX_NONZERO_EXIT_RE = /^(?:(?:command|process|build|test)\s+)?(?:failed with exit code|exited with (?:code|status)|exit code)\s+(?!0+\b)\d+\b/i;
+
+export const CODEX_CURRENT_ERROR_RE =
+  /\b(?:execution error|uncaught exception|command not found)\b|^(?:command|process|build|test) failed\b|^(?:error|failed|exception):\s|^\s*(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*(?:Error|Exception):\s|^(?:tests?|test files?|suites?|specs?)\b[^\n]*?\b(?!0+\b)\d+\s+failed\b|\bproblems?\s*\(\s*(?!0+\b)\d+\s+errors?\b|(?:^|-\s*)error\s+TS\d{4,5}\b|\bTS\d{4,5}:\s|\bELIFECYCLE\b|(?:^|\s)ERROR\s+codex_core(?:_[A-Za-z0-9_]+)?::|\bfailed_[A-Za-z0-9_]*=\[(?!\s*\])[^\]]+\]/i;
+
+export function isCurrentCodexErrorLine(line: string): boolean {
+  if (/^>\s/.test(line)) return false;
+  return CODEX_NONZERO_EXIT_RE.test(line) || CODEX_CURRENT_ERROR_RE.test(line);
+}
+
+function isCurrentCodexLifecycleErrorLine(line: string): boolean {
+  return /\bELIFECYCLE\b/i.test(line) && isCurrentCodexErrorLine(line);
+}
+
+function isCurrentCodexExitCodeErrorLine(line: string): boolean {
+  return CODEX_NONZERO_EXIT_RE.test(line) && isCurrentCodexErrorLine(line);
+}
+
 export const codexRuleset: RuleSet = {
   id: "codex",
   label: "Codex",
@@ -30,8 +48,8 @@ export const codexRuleset: RuleSet = {
     { id: "codex.bash", priority: 18, re: /^[⏺•]\s*Bash\(/, type: "stdout", summary: "コマンドを実行している" },
     { id: "codex.toolcall", priority: 17, re: /^ToolCall:\s*[A-Za-z0-9_.:]+/i, type: "stdout", summary: "ツールを呼び出している" },
 
-    { id: "codex.lifecycle", priority: 15, re: /\bELIFECYCLE\b/i, type: "error", summary: "スクリプトが異常終了している" },
-    { id: "codex.exitcode", priority: 12, re: /exited with code|exit code/i, type: "error", summary: "終了コードで失敗している" },
-    { id: "codex.error", priority: 10, re: /execution error|error|failed|exception|TS\d{5}/i, type: "error", summary: "エラーが出ている" }
+    { id: "codex.lifecycle", priority: 15, re: /\bELIFECYCLE\b/i, match: isCurrentCodexLifecycleErrorLine, type: "error", summary: "スクリプトが異常終了している" },
+    { id: "codex.exitcode", priority: 12, re: CODEX_NONZERO_EXIT_RE, match: isCurrentCodexExitCodeErrorLine, type: "error", summary: "終了コードで失敗している" },
+    { id: "codex.error", priority: 10, re: CODEX_CURRENT_ERROR_RE, match: isCurrentCodexErrorLine, type: "error", summary: "エラーが出ている" }
   ]
 };


### PR DESCRIPTION
## 🧑 HUMAN向け（先に読む）
- やったこと: 説明文や過去の引用にあるエラー表現を、実際の失敗と区別する修正を入れました。
- なぜ必要か: 正常な処理まで「要対応」と通知され、状況判断を誤ることがあったためです。
- あなたの操作: Draft PRを開き、説明文・引用・本当のコマンド失敗・HUMAN入力待ちの4場面を実機で確認してください。

## 何を直したか
Codexのエラー判定を、単語の全文一致から現在の失敗を示す形式の判定へ変更しました。

## なぜ必要か
`apps/server/src/rulesets/codex.ts` と `apps/server/src/extract.ts` に、`Error` / `failed` / `exception` などを含む任意の文章をエラー候補として通す判定が残っていました。そのため、説明文、過去ログ、UIステータス、引用文まで現在の失敗として扱われていました。

## 原因
Codex側だけが一般的なエラー語を全文単純一致し、Claude側の #408 相当の「行頭・終了コード・失敗件数・例外名・構造化ログ」中心の判定になっていませんでした。

## 変更内容
- Codexの現在エラー判定を共通の構造化判定へ整理。
- 非ゼロ終了コード、例外名、失敗件数、TypeScriptエラーコード、`ELIFECYCLE`、Codex内部の構造化`ERROR`ログ、空でない`failed_*_ids=[...]`を維持。
- 引用行（`> ...`）と一般説明はエラーにしない。
- `Tests: 0 failed`、`Process exited with code 0`、HUMAN確認待ちをエラーにしない。
- Claude、Generic、実況文言、TTS、要対応バナー、レイアウトは変更していません。

## エラーにしなくなった代表例
- `The explanation mentions Error: only as an example.`
- `The previous command failed with exit code 1, so I changed the approach.`
- `UI status: Error: is displayed in the action-required banner.`
- `> Error: quoted from an earlier command`
- `> Command failed with exit code 1`
- `Tests: 0 failed, 7 passed`
- `Process exited with code 0`
- HUMANへの確認文

## 維持した実エラーの代表例
- `Error: Cannot find module 'zod'`
- `TypeError: Cannot read properties of undefined`
- `Command failed with exit code 1`
- `Tests: 2 failed, 5 passed`
- `Process exited with code 1`
- `TS2322: ...`
- `ELIFECYCLE`
- Codex内部の構造化`ERROR`ログ
- 空でない`failed_remote_plugin_ids=["plugin-demo"]`

## 実行したテストと結果
- 修正前の再現確認: 追加した回帰ケース9件が失敗し、誤判定を再現。
- `pnpm -C apps/server exec vitest run src/__tests__/extract.test.ts src/tests/real-classification-regression.test.ts src/tests/claude.supervision.test.ts`: PASS（3 files / 102 tests）。
- `pnpm -C apps/server test`: PASS（54 files / 727 tests、failure regression summary 2/2 suites・4/4 tests PASS）。
- `pnpm -C apps/server exec tsc --noEmit`: PASS。
- `pnpm -C apps/server build`: PASS。
- `git diff --check`: PASS。
- GitHub Actions: `ci` の `test`、`docs_drift_guard`、`test_windows`、`actionlint`、`desktop_distribution_smoke`、`failure_regression`、`desktop_check` が全て PASS。`CodeQL / Analyze` も PASS。

## 環境依存で未確認の項目
- HUMAN実機での画面表示（要対応バナー、HUMAN入力待ちとの表示差）は未確認です。
- リポジトリにBiome実行ファイルおよびlint scriptがないため、任意のBiomeチェックは実行できませんでした。

Closes #423